### PR TITLE
Parity

### DIFF
--- a/account_delete_transaction.go
+++ b/account_delete_transaction.go
@@ -21,6 +21,9 @@ func NewAccountDeleteTransaction() AccountDeleteTransaction {
 	return builder
 }
 
+// Sets the account to delete. Note: To successfully delete an account
+// one must also manually set the `TransactionID` to a `TransactionID`
+// constructed from the same `AccountID`
 func (builder AccountDeleteTransaction) SetDeleteAccountId(id AccountID) AccountDeleteTransaction {
 	builder.pb.DeleteAccountID = id.toProto()
 	return builder

--- a/account_id.go
+++ b/account_id.go
@@ -1,8 +1,6 @@
 package hedera
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/proto"
 )
@@ -27,18 +25,10 @@ func AccountIDFromString(s string) (AccountID, error) {
 }
 
 func AccountIDFromSolidityAddress(s string) (AccountID, error) {
-	bytes, err := hex.DecodeString(s)
+	shard, realm, account, err := idFromSolidityAddress(s)
 	if err != nil {
 		return AccountID{}, err
 	}
-
-	if len(bytes) != 20 {
-		return AccountID{}, fmt.Errorf("Solidity address must be 20 bytes")
-	}
-
-	shard := uint64(binary.BigEndian.Uint32(bytes[0:4]))
-	realm := binary.BigEndian.Uint64(bytes[4:12])
-	account := binary.BigEndian.Uint64(bytes[12:20])
 
 	return AccountID{
 		Shard:   shard,
@@ -52,11 +42,7 @@ func (id AccountID) String() string {
 }
 
 func (id AccountID) ToSolidityAddress() string {
-	bytes := make([]byte, 20)
-	binary.BigEndian.PutUint32(bytes[0:4], uint32(id.Shard))
-	binary.BigEndian.PutUint64(bytes[4:12], id.Realm)
-	binary.BigEndian.PutUint64(bytes[12:20], id.Account)
-	return hex.EncodeToString(bytes)
+	return idToSolidityAddress(id.Shard, id.Realm, id.Account)
 }
 
 func (id AccountID) toProto() *proto.AccountID {

--- a/account_id.go
+++ b/account_id.go
@@ -1,6 +1,8 @@
 package hedera
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/proto"
 )
@@ -24,8 +26,37 @@ func AccountIDFromString(s string) (AccountID, error) {
 	}, nil
 }
 
+func AccountIDFromSolidityAddress(s string) (AccountID, error) {
+	bytes, err := hex.DecodeString(s)
+	if err != nil {
+		return AccountID{}, err
+	}
+
+	if len(bytes) != 20 {
+		return AccountID{}, fmt.Errorf("Solidity address must be 20 bytes")
+	}
+
+	shard := uint64(binary.BigEndian.Uint32(bytes[0:4]))
+	realm := binary.BigEndian.Uint64(bytes[4:12])
+	account := binary.BigEndian.Uint64(bytes[12:20])
+
+	return AccountID{
+		Shard:   shard,
+		Realm:   realm,
+		Account: account,
+	}, nil
+}
+
 func (id AccountID) String() string {
 	return fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.Account)
+}
+
+func (id AccountID) ToSolidityAddress() string {
+	bytes := make([]byte, 20)
+	binary.BigEndian.PutUint32(bytes[0:4], uint32(id.Shard))
+	binary.BigEndian.PutUint64(bytes[4:12], id.Realm)
+	binary.BigEndian.PutUint64(bytes[12:20], id.Account)
+	return hex.EncodeToString(bytes)
 }
 
 func (id AccountID) toProto() *proto.AccountID {

--- a/account_info_query.go
+++ b/account_info_query.go
@@ -59,3 +59,21 @@ func (builder *AccountInfoQuery) Execute(client *Client) (AccountInfo, error) {
 		ExpirationTime:                 timeFromProto(resp.GetCryptoGetInfo().AccountInfo.ExpirationTime),
 	}, nil
 }
+
+func (builder *AccountInfoQuery) Cost(client *Client) (uint64, error) {
+	// deleted files return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+	// if you set that as the query payment; 25 tinybar seems to be enough to get
+	// `ACCOUNT_DELETED` back instead.
+	cost, err := builder.QueryBuilder.Cost(client)
+	if err != nil {
+		return 0, err
+	}
+
+	// math.Min requires float64 and returns float64
+	if cost > 25 {
+		return cost, nil
+	} else {
+		return 25, nil
+	}
+
+}

--- a/contract_execute_transaction.go
+++ b/contract_execute_transaction.go
@@ -31,8 +31,8 @@ func (builder ContractExecuteTransaction) SetGas(gas uint64) ContractExecuteTran
 	return builder
 }
 
-func (builder ContractExecuteTransaction) SetAmount(amount uint64) ContractExecuteTransaction {
-	builder.pb.Amount = int64(amount)
+func (builder ContractExecuteTransaction) SetPayableAmount(amount Hbar) ContractExecuteTransaction {
+	builder.pb.Amount = int64(amount.AsTinybar())
 	return builder
 }
 

--- a/contract_execute_transaction_test.go
+++ b/contract_execute_transaction_test.go
@@ -13,11 +13,11 @@ func TestSerializeContractExecuteTransaction(t *testing.T) {
 	assert.NoError(t, err)
 
 	tx := NewContractExecuteTransaction().
-		SetContractID(ContractID{ Contract: 5 }).
+		SetContractID(ContractID{Contract: 5}).
 		SetGas(141).
-		SetAmount(10000).
+		SetPayableAmount(HbarFromTinybar(10000)).
 		// this was pulled from the Java test
-		SetFunctionParameters([]byte{ 24, 43, 11 }).
+		SetFunctionParameters([]byte{24, 43, 11}).
 		SetMaxTransactionFee(1e6).
 		SetTransactionID(testTransactionId).
 		Build(mockClient).

--- a/contract_id.go
+++ b/contract_id.go
@@ -1,8 +1,6 @@
 package hedera
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/proto"
 )
@@ -27,18 +25,10 @@ func ContractIDFromString(s string) (ContractID, error) {
 }
 
 func ContractIDFromSolidityAddress(s string) (ContractID, error) {
-	bytes, err := hex.DecodeString(s)
+	shard, realm, contract, err := idFromSolidityAddress(s)
 	if err != nil {
 		return ContractID{}, err
 	}
-
-	if len(bytes) != 20 {
-		return ContractID{}, fmt.Errorf("Solidity address must be 20 bytes")
-	}
-
-	shard := uint64(binary.BigEndian.Uint32(bytes[0:4]))
-	realm := binary.BigEndian.Uint64(bytes[4:12])
-	contract := binary.BigEndian.Uint64(bytes[12:20])
 
 	return ContractID{
 		Shard:    shard,
@@ -52,11 +42,7 @@ func (id ContractID) String() string {
 }
 
 func (id ContractID) ToSolidityAddress() string {
-	bytes := make([]byte, 20)
-	binary.BigEndian.PutUint32(bytes[0:4], uint32(id.Shard))
-	binary.BigEndian.PutUint64(bytes[4:12], id.Realm)
-	binary.BigEndian.PutUint64(bytes[12:20], id.Contract)
-	return hex.EncodeToString(bytes)
+	return idToSolidityAddress(id.Shard, id.Realm, id.Contract)
 }
 
 func (id ContractID) toProto() *proto.ContractID {

--- a/contract_info_query.go
+++ b/contract_info_query.go
@@ -52,3 +52,21 @@ func (builder *ContractInfoQuery) Execute(client *Client) (ContractInfo, error) 
 		ContractMemo:      resp.GetContractGetInfo().ContractInfo.Memo,
 	}, nil
 }
+
+func (builder *ContractInfoQuery) Cost(client *Client) (uint64, error) {
+	// deleted files return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+	// if you set that as the query payment; 25 tinybar seems to be enough to get
+	// `FILE_DELETED` back instead.
+	cost, err := builder.QueryBuilder.Cost(client)
+	if err != nil {
+		return 0, err
+	}
+
+	// math.Min requires float64 and returns float64
+	if cost > 25 {
+		return cost, nil
+	} else {
+		return 25, nil
+	}
+
+}

--- a/file_id.go
+++ b/file_id.go
@@ -1,8 +1,6 @@
 package hedera
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/proto"
 )
@@ -27,18 +25,10 @@ func FileIDFromString(s string) (FileID, error) {
 }
 
 func FileIDFromSolidityAddress(s string) (FileID, error) {
-	bytes, err := hex.DecodeString(s)
+	shard, realm, file, err := idFromSolidityAddress(s)
 	if err != nil {
 		return FileID{}, err
 	}
-
-	if len(bytes) != 20 {
-		return FileID{}, fmt.Errorf("Solidity address must be 20 bytes")
-	}
-
-	shard := uint64(binary.BigEndian.Uint32(bytes[0:4]))
-	realm := binary.BigEndian.Uint64(bytes[4:12])
-	file := binary.BigEndian.Uint64(bytes[12:20])
 
 	return FileID{
 		Shard: shard,
@@ -52,11 +42,7 @@ func (id FileID) String() string {
 }
 
 func (id FileID) ToSolidityAddress() string {
-	bytes := make([]byte, 20)
-	binary.BigEndian.PutUint32(bytes[0:4], uint32(id.Shard))
-	binary.BigEndian.PutUint64(bytes[4:12], id.Realm)
-	binary.BigEndian.PutUint64(bytes[12:20], id.File)
-	return hex.EncodeToString(bytes)
+	return idToSolidityAddress(id.Shard, id.Realm, id.File)
 }
 
 func (id FileID) toProto() *proto.FileID {

--- a/file_id.go
+++ b/file_id.go
@@ -1,6 +1,8 @@
 package hedera
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/proto"
 )
@@ -24,8 +26,37 @@ func FileIDFromString(s string) (FileID, error) {
 	}, nil
 }
 
+func FileIDFromSolidityAddress(s string) (FileID, error) {
+	bytes, err := hex.DecodeString(s)
+	if err != nil {
+		return FileID{}, err
+	}
+
+	if len(bytes) != 20 {
+		return FileID{}, fmt.Errorf("Solidity address must be 20 bytes")
+	}
+
+	shard := uint64(binary.BigEndian.Uint32(bytes[0:4]))
+	realm := binary.BigEndian.Uint64(bytes[4:12])
+	file := binary.BigEndian.Uint64(bytes[12:20])
+
+	return FileID{
+		Shard: shard,
+		Realm: realm,
+		File:  file,
+	}, nil
+}
+
 func (id FileID) String() string {
 	return fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.File)
+}
+
+func (id FileID) ToSolidityAddress() string {
+	bytes := make([]byte, 20)
+	binary.BigEndian.PutUint32(bytes[0:4], uint32(id.Shard))
+	binary.BigEndian.PutUint64(bytes[4:12], id.Realm)
+	binary.BigEndian.PutUint64(bytes[12:20], id.File)
+	return hex.EncodeToString(bytes)
 }
 
 func (id FileID) toProto() *proto.FileID {

--- a/file_info_query.go
+++ b/file_info_query.go
@@ -46,3 +46,21 @@ func (builder *FileInfoQuery) Execute(client *Client) (FileInfo, error) {
 		Deleted:        resp.GetFileGetInfo().FileInfo.Deleted,
 	}, nil
 }
+
+func (builder *FileInfoQuery) Cost(client *Client) (uint64, error) {
+	// deleted files return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+	// if you set that as the query payment; 25 tinybar seems to be enough to get
+	// `FILE_DELETED` back instead.
+	cost, err := builder.QueryBuilder.Cost(client)
+	if err != nil {
+		return 0, err
+	}
+
+	// math.Min requires float64 and returns float64
+	if cost > 25 {
+		return cost, nil
+	} else {
+		return 25, nil
+	}
+
+}

--- a/id.go
+++ b/id.go
@@ -1,6 +1,8 @@
 package hedera
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -29,4 +31,25 @@ func idFromString(s string) (shard int, realm int, num int, err error) {
 	}
 
 	return
+}
+
+func idFromSolidityAddress(s string) (uint64, uint64, uint64, error) {
+	bytes, err := hex.DecodeString(s)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	if len(bytes) != 20 {
+		return 0, 0, 0, fmt.Errorf("Solidity address must be 20 bytes")
+	}
+
+	return uint64(binary.BigEndian.Uint32(bytes[0:4])), binary.BigEndian.Uint64(bytes[4:12]), binary.BigEndian.Uint64(bytes[12:20]), nil
+}
+
+func idToSolidityAddress(shard uint64, realm uint64, num uint64) string {
+	bytes := make([]byte, 20)
+	binary.BigEndian.PutUint32(bytes[0:4], uint32(shard))
+	binary.BigEndian.PutUint64(bytes[4:12], realm)
+	binary.BigEndian.PutUint64(bytes[12:20], num)
+	return hex.EncodeToString(bytes)
 }

--- a/transaction_record.go
+++ b/transaction_record.go
@@ -14,7 +14,7 @@ type TransactionRecord struct {
 	TransactionID      TransactionID
 	TransactionMemo    string
 	TransactionFee     uint64
-	TransferList       []Transfer
+	Transfers          []Transfer
 	callResult         *ContractFunctionResult
 	callResultIsCreate bool
 }
@@ -60,7 +60,7 @@ func transactionRecordFromProto(pb *proto.TransactionRecord) TransactionRecord {
 		TransactionID:      transactionIDFromProto(pb.TransactionID),
 		TransactionMemo:    pb.Memo,
 		TransactionFee:     pb.TransactionFee,
-		TransferList:       transferList,
+		Transfers:          transferList,
 		callResultIsCreate: callResultIsCreate,
 		callResult:         callResult,
 	}

--- a/transfer.go
+++ b/transfer.go
@@ -4,12 +4,12 @@ import "github.com/hashgraph/hedera-sdk-go/proto"
 
 type Transfer struct {
 	AccountID AccountID
-	Amount    int64
+	Amount    Hbar
 }
 
 func transferFromProto(pb *proto.AccountAmount) Transfer {
 	return Transfer{
 		AccountID: accountIDFromProto(pb.AccountID),
-		Amount:    pb.Amount,
+		Amount:    HbarFromTinybar(pb.Amount),
 	}
 }


### PR DESCRIPTION
Rebased onto #2 so that needs to be merged first.

    - Implement `*IDFromSolidityAddress()`
    - Implement `*ID.ToSolidityAddress()`
    - Implement `*InfoQuery.Cost()`
    - Implement `*InfoQuery.Cost()`
    - Add comment to `AccountDeleteTransaction.SetDeleteAccountID()`
    - Rename `ContractExecuteTransaction.SetAmount()` to
      `ContractExecuteTransaction.SetPayableAmount()`

Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>