### PR TITLE
Implement 8 bit variants for int and uint and bytes32 in function result/params/selector

### DIFF
--- a/contract_function_params.go
+++ b/contract_function_params.go
@@ -68,7 +68,18 @@ func (contract *ContractFunctionParams) AddFunction(address string, selector Con
 	return contract, nil
 }
 
-func (contract *ContractFunctionParams) AddInt32(value int32) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddInt8(value int8) *ContractFunctionParams {
+	argument := NewArgument()
+
+	argument.value[31] = uint8(value)
+
+	contract.function.AddInt8()
+	contract.arguments = append(contract.arguments, argument)
+
+	return contract
+}
+
+func (contract *ContractFunctionParams) AddInt32(value int32) *ContractFunctionParams {
 	argument := NewArgument()
 
 	binary.BigEndian.PutUint32(argument.value[28:32], uint32(value))
@@ -76,10 +87,10 @@ func (contract *ContractFunctionParams) AddInt32(value int32) (*ContractFunction
 	contract.function.AddInt32()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
-func (contract *ContractFunctionParams) AddInt64(value int64) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddInt64(value int64) *ContractFunctionParams {
 	argument := NewArgument()
 
 	binary.BigEndian.PutUint64(argument.value[24:32], uint64(value))
@@ -87,10 +98,10 @@ func (contract *ContractFunctionParams) AddInt64(value int64) (*ContractFunction
 	contract.function.AddInt64()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
-func (contract *ContractFunctionParams) AddInt256(value []byte) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddInt256(value []byte) *ContractFunctionParams {
 	argument := NewArgument()
 
 	argument.value = value
@@ -98,10 +109,21 @@ func (contract *ContractFunctionParams) AddInt256(value []byte) (*ContractFuncti
 	contract.function.AddInt256()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
-func (contract *ContractFunctionParams) AddUint32(value uint32) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddUint8(value uint8) *ContractFunctionParams {
+	argument := NewArgument()
+
+	argument.value[31] = value
+
+	contract.function.AddUint8()
+	contract.arguments = append(contract.arguments, argument)
+
+	return contract
+}
+
+func (contract *ContractFunctionParams) AddUint32(value uint32) *ContractFunctionParams {
 	argument := NewArgument()
 
 	binary.BigEndian.PutUint32(argument.value[28:32], value)
@@ -109,10 +131,10 @@ func (contract *ContractFunctionParams) AddUint32(value uint32) (*ContractFuncti
 	contract.function.AddUint32()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
-func (contract *ContractFunctionParams) AddUint64(value uint64) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddUint64(value uint64) *ContractFunctionParams {
 	argument := NewArgument()
 
 	binary.BigEndian.PutUint64(argument.value[24:32], value)
@@ -120,10 +142,10 @@ func (contract *ContractFunctionParams) AddUint64(value uint64) (*ContractFuncti
 	contract.function.AddUint64()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
-func (contract *ContractFunctionParams) AddUint256(value []byte) (*ContractFunctionParams, error) {
+func (contract *ContractFunctionParams) AddUint256(value []byte) *ContractFunctionParams {
 	argument := NewArgument()
 
 	argument.value = value
@@ -131,7 +153,7 @@ func (contract *ContractFunctionParams) AddUint256(value []byte) (*ContractFunct
 	contract.function.AddUint256()
 	contract.arguments = append(contract.arguments, argument)
 
-	return contract, nil
+	return contract
 }
 
 func (contract *ContractFunctionParams) AddInt32Array(value []int32) *ContractFunctionParams {
@@ -303,6 +325,17 @@ func (contract *ContractFunctionParams) AddBytes(value []byte) *ContractFunction
 	return contract
 }
 
+func (contract *ContractFunctionParams) AddBytes32(value []byte) *ContractFunctionParams {
+	argument := NewArgument()
+
+	argument.value = value[:]
+
+	contract.function.AddBytes32()
+	contract.arguments = append(contract.arguments, argument)
+
+	return contract
+}
+
 func (contract *ContractFunctionParams) AddAddress(value string) (*ContractFunctionParams, error) {
 	if len(value) != 40 {
 		return contract, errors.Unwrap(fmt.Errorf("Address is required to be 40 characters"))
@@ -333,6 +366,25 @@ func (contract *ContractFunctionParams) AddBytesArray(value [][]byte) *ContractF
 	argument.value = bytesArray(value)
 
 	contract.function.AddBytesArray()
+	contract.arguments = append(contract.arguments, argument)
+	return contract
+}
+
+func (contract *ContractFunctionParams) AddByte32sArray(value [][]byte) *ContractFunctionParams {
+	argument := NewArgument()
+	argument.dynamic = true
+
+	result := make([]byte, len(value)+32)
+
+	binary.BigEndian.PutUint64(result[24:32], uint64(len(value)))
+
+	for i, v := range value {
+		copy(result[i*32+32:i*32+32+32], v[0:32])
+	}
+
+	argument.value = result
+
+	contract.function.AddBytes32Array()
 	contract.arguments = append(contract.arguments, argument)
 	return contract
 }

--- a/contract_function_result.go
+++ b/contract_function_result.go
@@ -22,6 +22,10 @@ func (result ContractFunctionResult) GetAddress(index uint64) []byte {
 	return result.ContractCallResult[(index*32)+12 : (index*32)+32]
 }
 
+func (result ContractFunctionResult) GetInt8(index uint64) int8 {
+	return int8(result.ContractCallResult[index*32+31])
+}
+
 func (result ContractFunctionResult) GetInt32(index uint64) int32 {
 	return int32(binary.BigEndian.Uint32(result.ContractCallResult[index*32+28 : (index+1)*32]))
 }
@@ -34,6 +38,10 @@ func (result ContractFunctionResult) GetInt256(index uint64) []byte {
 	return result.ContractCallResult[index*32 : index*32+32]
 }
 
+func (result ContractFunctionResult) GetUint8(index uint64) uint8 {
+	return result.ContractCallResult[index*32+31]
+}
+
 func (result ContractFunctionResult) GetUint32(index uint64) uint32 {
 	return binary.BigEndian.Uint32(result.ContractCallResult[index*32+28 : (index+1)*32])
 }
@@ -43,6 +51,10 @@ func (result ContractFunctionResult) GetUint64(index uint64) uint64 {
 }
 
 func (result ContractFunctionResult) GetUint256(index uint64) []byte {
+	return result.ContractCallResult[index*32 : index*32+32]
+}
+
+func (result ContractFunctionResult) GetBytes32(index uint64) []byte {
 	return result.ContractCallResult[index*32 : index*32+32]
 }
 

--- a/contract_function_selector.go
+++ b/contract_function_selector.go
@@ -22,13 +22,16 @@ type argument string
 const (
 	aBool     argument = "bool"
 	aString   argument = "string"
+	aInt8     argument = "int8"
 	aInt32    argument = "int32"
 	aInt64    argument = "int64"
 	aInt256   argument = "int256"
+	aUint8    argument = "uint8"
 	aUint32   argument = "uint32"
 	aUint64   argument = "uint64"
 	aUint256  argument = "uint256"
 	aBytes    argument = "bytes"
+	aBytes32  argument = "bytes32"
 	aFunction argument = "function"
 	aAddress  argument = "address"
 )
@@ -91,6 +94,13 @@ func (selector *ContractFunctionSelector) AddString() *ContractFunctionSelector 
 	})
 }
 
+func (selector *ContractFunctionSelector) AddInt8() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aInt8,
+		array: false,
+	})
+}
+
 func (selector *ContractFunctionSelector) AddInt32() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aInt32,
@@ -108,6 +118,13 @@ func (selector *ContractFunctionSelector) AddInt64() *ContractFunctionSelector {
 func (selector *ContractFunctionSelector) AddInt256() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aInt256,
+		array: false,
+	})
+}
+
+func (selector *ContractFunctionSelector) AddUint8() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aUint8,
 		array: false,
 	})
 }
@@ -140,6 +157,13 @@ func (selector *ContractFunctionSelector) AddBytes() *ContractFunctionSelector {
 	})
 }
 
+func (selector *ContractFunctionSelector) AddBytes32() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aBytes32,
+		array: false,
+	})
+}
+
 func (selector *ContractFunctionSelector) AddAddressArray() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aAddress,
@@ -161,6 +185,13 @@ func (selector *ContractFunctionSelector) AddStringArray() *ContractFunctionSele
 	})
 }
 
+func (selector *ContractFunctionSelector) AddInt8Array() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aInt8,
+		array: true,
+	})
+}
+
 func (selector *ContractFunctionSelector) AddInt32Array() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aInt32,
@@ -178,6 +209,13 @@ func (selector *ContractFunctionSelector) AddInt64Array() *ContractFunctionSelec
 func (selector *ContractFunctionSelector) AddInt256Array() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aInt256,
+		array: true,
+	})
+}
+
+func (selector *ContractFunctionSelector) AddUint8Array() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aUint8,
 		array: true,
 	})
 }
@@ -206,6 +244,13 @@ func (selector *ContractFunctionSelector) AddUint256Array() *ContractFunctionSel
 func (selector *ContractFunctionSelector) AddBytesArray() *ContractFunctionSelector {
 	return selector.addParam(solidity{
 		ty:    aBytes,
+		array: true,
+	})
+}
+
+func (selector *ContractFunctionSelector) AddBytes32Array() *ContractFunctionSelector {
+	return selector.addParam(solidity{
+		ty:    aBytes32,
 		array: true,
 	})
 }


### PR DESCRIPTION
- Implement `ContractFunction*.[Int|Uint]8[Array]()`    
- Implement `ContractFunction*.[Get|Add]Bytes32[Array]()`

Signed-off-by: Daniel Akhterov <akhterovd@gmail.com>