### PR TITLE
add basic validation to the transaction builder

### DIFF
--- a/account_create_transaction_test.go
+++ b/account_create_transaction_test.go
@@ -14,7 +14,7 @@ func TestSerializeAccountCreateTransaction(t *testing.T) {
 	key, err := Ed25519PrivateKeyFromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962")
 	assert.NoError(t, err)
 
-	tx := NewAccountCreateTransaction().
+	tx, err := NewAccountCreateTransaction().
 		SetKey(key.PublicKey()).
 		SetInitialBalance(HbarFromTinybar(450)).
 		SetProxyAccountID(AccountID{Account: 1020}).
@@ -25,8 +25,11 @@ func TestSerializeAccountCreateTransaction(t *testing.T) {
 			ValidStart: date,
 		}).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
-		Build(nil).
-		Sign(key)
+		Build(nil)
+
+	assert.NoError(t, err)
+
+	tx.Sign(key)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/account_delete_transaction_test.go
+++ b/account_delete_transaction_test.go
@@ -13,13 +13,16 @@ func TestSerializeAccountDeleteTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewAccountDeleteTransaction().
+	tx, err := NewAccountDeleteTransaction().
 		SetDeleteAccountID(AccountID{Account: 3}).
 		SetTransferAccountID(AccountID{Account: 2}).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/account_update_transaction_test.go
+++ b/account_update_transaction_test.go
@@ -13,13 +13,16 @@ func TestSerializeAccountUpdateTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewAccountUpdateTransaction().
+	tx, err := NewAccountUpdateTransaction().
 		SetTransactionID(testTransactionID).
 		SetAccountID(AccountID{Account: 3}).
 		SetKey(privateKey.PublicKey()).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/contract_create_transaction_test.go
+++ b/contract_create_transaction_test.go
@@ -14,7 +14,7 @@ func TestSerializeContractCreateTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewContractCreateTransaction().
+	tx, err := NewContractCreateTransaction().
 		SetAdminKey(privateKey.PublicKey()).
 		SetInitialBalance(HbarFromTinybar(1e3)).
 		SetBytecodeFileID(FileID{File: 4}).
@@ -23,8 +23,11 @@ func TestSerializeContractCreateTransaction(t *testing.T) {
 		SetAutoRenewPeriod(60 * 60 * 24 * 14 * time.Second).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/contract_delete_transaction_test.go
+++ b/contract_delete_transaction_test.go
@@ -13,12 +13,15 @@ func TestSerializeContractDeleteTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewContractDeleteTransaction().
+	tx, err := NewContractDeleteTransaction().
 		SetContractID(ContractID{Contract: 5}).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/contract_execute_transaction_test.go
+++ b/contract_execute_transaction_test.go
@@ -16,15 +16,18 @@ func TestSerializeContractExecuteTransaction(t *testing.T) {
 	parameters := NewContractFunctionParams().
 		AddBytes([]byte{24, 43, 11})
 
-	tx := NewContractExecuteTransaction().
+	tx, err := NewContractExecuteTransaction().
 		SetContractID(ContractID{Contract: 5}).
 		SetGas(141).
 		SetPayableAmount(HbarFromTinybar(10000)).
 		SetFunction("someFunction", *parameters).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/contract_update_transaction_test.go
+++ b/contract_update_transaction_test.go
@@ -14,7 +14,7 @@ func TestSerializeContractUpdateTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewContractUpdateTransaction().
+	tx, err := NewContractUpdateTransaction().
 		SetContractID(ContractID{Contract: 3}).
 		SetAdminKey(privateKey.PublicKey()).
 		SetBytecodeFileID(FileID{File: 5}).
@@ -23,8 +23,11 @@ func TestSerializeContractUpdateTransaction(t *testing.T) {
 		SetAutoRenewPeriod(60 * 60 * 24 * 14 * time.Second).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/file_append_transaction_test.go
+++ b/file_append_transaction_test.go
@@ -13,13 +13,16 @@ func TestSerializeFileAppendTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewFileAppendTransaction().
+	tx, err := NewFileAppendTransaction().
 		SetFileID(FileID{File: 5}).
 		SetContents([]byte("This is some random data")).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/file_create_transaction_test.go
+++ b/file_create_transaction_test.go
@@ -14,7 +14,7 @@ func TestSerializeFileCreateTransaction(t *testing.T) {
 	key, err := Ed25519PrivateKeyFromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962")
 	assert.NoError(t, err)
 
-	tx := NewFileCreateTransaction().
+	tx, err := NewFileCreateTransaction().
 		AddKey(key.PublicKey()).
 		SetContents([]byte{1, 2, 3, 4}).
 		SetExpirationTime(date).
@@ -24,8 +24,11 @@ func TestSerializeFileCreateTransaction(t *testing.T) {
 			ValidStart: date,
 		}).
 		SetMaxTransactionFee(HbarFromTinybar(100_000)).
-		Build(nil).
-		Sign(key)
+		Build(nil)
+
+	assert.NoError(t, err)
+
+	tx.Sign(key)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/file_delete_transaction.go
+++ b/file_delete_transaction.go
@@ -26,7 +26,7 @@ func (builder FileDeleteTransaction) SetFileID(id FileID) FileDeleteTransaction 
 	return builder
 }
 
-func (builder FileDeleteTransaction) Build(client *Client) Transaction {
+func (builder FileDeleteTransaction) Build(client *Client) (Transaction, error) {
 	return builder.TransactionBuilder.Build(client)
 }
 

--- a/file_delete_transaction_test.go
+++ b/file_delete_transaction_test.go
@@ -13,12 +13,15 @@ func TestSerializeFileDeleteTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewFileDeleteTransaction().
+	tx, err := NewFileDeleteTransaction().
 		SetFileID(FileID{File: 5}).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/file_update_transaction_test.go
+++ b/file_update_transaction_test.go
@@ -14,15 +14,17 @@ func TestSerializeFileUpdateTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewFileUpdateTransaction().
+	tx, err := NewFileUpdateTransaction().
 		SetFileID(FileID{File: 5}).
 		SetContents([]byte("there was a hole here")).
 		SetExpirationTime(time.Unix(15415151511, 0)).
 		AddKey(privateKey.PublicKey()).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/freeze_transaction_test.go
+++ b/freeze_transaction_test.go
@@ -14,14 +14,17 @@ func TestSerializeFreezeTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewFreezeTransaction().
+	tx, err := NewFreezeTransaction().
 		SetTransactionID(testTransactionID).
 		SetStartTime(time.Unix(600, 100)).
 		SetEndTime(time.Unix(800, 100)).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/system_delete_transaction_test.go
+++ b/system_delete_transaction_test.go
@@ -14,13 +14,16 @@ func TestSerializeSystemDeleteFileIDTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewSystemDeleteTransaction().
+	tx, err := NewSystemDeleteTransaction().
 		SetFileID(FileID{File: 3}).
 		SetExpirationTime(time.Unix(15415151511, 0)).
 		SetMaxTransactionFee(HbarFromTinybar(100_000)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }
@@ -32,13 +35,15 @@ func TestSerializeSystemDeleteContractIDTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewSystemDeleteTransaction().
-		SetContractID(ContractID{Contract: 3}).
+	tx, err := NewSystemDeleteTransaction().
+	 	SetContractID(ContractID{Contract: 3}).
 		SetExpirationTime(time.Unix(15415151511, 0)).
 		SetMaxTransactionFee(HbarFromTinybar(100_000)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/system_undelete_transaction_test.go
+++ b/system_undelete_transaction_test.go
@@ -13,12 +13,15 @@ func TestSerializeSystemUndeleteFileIDTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewSystemUndeleteTransaction().
+	tx, err := NewSystemUndeleteTransaction().
 		SetFileID(FileID{File: 3}).
 		SetMaxTransactionFee(HbarFromTinybar(100_000)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }
@@ -30,12 +33,15 @@ func TestSerializeSystemUndeleteContractIDTransaction(t *testing.T) {
 	privateKey, err := Ed25519PrivateKeyFromString(mockPrivateKey)
 	assert.NoError(t, err)
 
-	tx := NewSystemUndeleteTransaction().
+	tx, err := NewSystemUndeleteTransaction().
 		SetContractID(ContractID{Contract: 3}).
 		SetMaxTransactionFee(HbarFromTinybar(100_000)).
 		SetTransactionID(testTransactionID).
-		Build(mockClient).
-		Sign(privateKey)
+		Build(mockClient)
+
+	assert.NoError(t, err)
+
+	tx.Sign(privateKey)
 
 	cupaloy.SnapshotT(t, tx.String())
 }

--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -44,13 +44,18 @@ func newMockTransaction() (Transaction, error) {
 		return Transaction{}, err
 	}
 
-	tx := NewCryptoTransferTransaction().
+	tx, err := NewCryptoTransferTransaction().
 		AddSender(AccountID{Account: 2}, HbarFromTinybar(100)).
 		AddRecipient(AccountID{Account: 3}, HbarFromTinybar(100)).
 		SetMaxTransactionFee(HbarFrom(1, HbarUnits.Hbar)).
 		SetTransactionID(testTransactionID).
-		Build(client).
-		Sign(privateKey)
+		Build(client)
+
+	if err != nil {
+		return Transaction{}, err
+	}
+
+	tx.Sign(privateKey)
 
 	return tx, nil
 }


### PR DESCRIPTION
This adds basic validation to the transaction builder, making it where a `.Build()` call also returns an LocalValidationError if validation fails. The logic in the transaction builder is also improved to prevent nil pointer access errors at run-time.