### PR TITLE
Polish

### DIFF
--- a/contract_execute_transaction_test.go
+++ b/contract_execute_transaction_test.go
@@ -20,7 +20,7 @@ func TestSerializeContractExecuteTransaction(t *testing.T) {
 		SetContractID(ContractID{Contract: 5}).
 		SetGas(141).
 		SetPayableAmount(HbarFromTinybar(10000)).
-		SetFunction("someFunction", *parameters).
+		SetFunction("someFunction", parameters).
 		SetMaxTransactionFee(HbarFromTinybar(1e6)).
 		SetTransactionID(testTransactionID).
 		Build(mockClient)

--- a/examples/create_account_with_threshold_keys/main.go
+++ b/examples/create_account_with_threshold_keys/main.go
@@ -38,9 +38,7 @@ func main() {
 		pubKeys[i] = newKey.PublicKey()
 	}
 
-	client := hedera.ClientForTestnet().
-		SetMaxTransactionFee(hedera.HbarFrom(3, hedera.HbarUnits.Hbar)).
-		SetMaxQueryPayment(hedera.HbarFrom(3, hedera.HbarUnits.Hbar))
+	client := hedera.ClientForTestnet()
 
 	// A threshold key with a threshold of 2 and length of 3 requires
 	// at least 2 of the 3 keys to sign anything modifying the account
@@ -51,7 +49,7 @@ func main() {
 
 	transaction, err := hedera.NewAccountCreateTransaction().
 		SetKey(thresholdKey).
-		SetInitialBalance(hedera.HbarFrom(20, hedera.HbarUnits.Hbar)).
+		SetInitialBalance(hedera.NewHbar(6)).
 		SetTransactionID(hedera.NewTransactionID(operatorAccountID)).
 		SetTransactionMemo("sdk example create_account_with_threshold_keys/main.go").
 		Build(client)
@@ -103,11 +101,18 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("Status of transfer transaction: %v\n", receipt.Status)
+	fmt.Printf("status of transfer transaction: %v\n", receipt.Status)
+
+	// Operator must be set
+	client.SetOperator(operatorAccountID, operatorPrivateKey)
 
 	balance, err := hedera.NewAccountBalanceQuery().
 		SetAccountID(newAccountID).
 		Execute(client)
+
+	if err != nil {
+		panic(err)
+	}
 
 	fmt.Printf("account balance after transfer: %v\n", balance)
 }

--- a/hbar.go
+++ b/hbar.go
@@ -37,9 +37,13 @@ func (hbar Hbar) As(unit HbarUnit) int64 {
 	return hbar.tinybar * unit.numberOfTinybar()
 }
 
-// todo: format in hbar if over 0.00001 hbar
 func (hbar Hbar) String() string {
-	return fmt.Sprintf("%v tħ", hbar.tinybar)
+	// Format the string as tinybar if the value is 1000 tinybar or less
+	if hbar.tinybar <= 1000 {
+		return fmt.Sprintf("%v tħ", hbar.tinybar)
+	}
+
+	return fmt.Sprintf("%v ℏ", float64(hbar.tinybar)/float64(HbarUnits.Hbar.numberOfTinybar()))
 }
 
 func (hbar Hbar) negated() Hbar {

--- a/query_builder.go
+++ b/query_builder.go
@@ -39,6 +39,11 @@ func (builder *QueryBuilder) SetQueryPaymentTransaction(tx Transaction) *QueryBu
 }
 
 func (builder *QueryBuilder) Cost(client *Client) (Hbar, error) {
+	// An operator must be set on the client
+	if client == nil || client.operator == nil {
+		return ZeroHbar, newErrLocalValidationf("calling .Cost() requires client.SetOperator")
+	}
+
 	// Store the current response type and payment from the
 	// query header
 	currentResponseType := builder.pbHeader.ResponseType
@@ -68,9 +73,7 @@ func (builder *QueryBuilder) Cost(client *Client) (Hbar, error) {
 		return ZeroHbar, err
 	}
 
-	if client.operator != nil {
-		tx = tx.signWithOperator(*client.operator)
-	}
+	tx = tx.signWithOperator(*client.operator)
 
 	builder.pbHeader.Payment = tx.pb
 


### PR DESCRIPTION
 - fails and returns an error on `.Cost` for queries if the operator is not set
 - formats hbar string as hbar if value < 1000 tinybar
 - tests work again