### PR TITLE
Fix TestAccountUpdateTransaction_Execute so it always waits for the update

### DIFF
--- a/account_update_transaction_test.go
+++ b/account_update_transaction_test.go
@@ -70,7 +70,7 @@ func TestAccountUpdateTransaction_Execute(t *testing.T) {
 	tx.Sign(newKey)
 	tx.Sign(newKey2)
 
-	_, err = tx.Execute(client)
+	txID, err = tx.Execute(client)
 	assert.NoError(t, err)
 
 	_, err = txID.GetReceipt(client)


### PR DESCRIPTION
Before it was querying for the receipt of the original account create transaction instead of the account update transaction and then immediately requesting the account info -- if it did it fast enough it would get the original key instead of the updated key because consensus had not been reached on the network, resulting in the test failing occasionally.