### PR TITLE
Retry on Unavailable and ResourceExhausted

### DIFF
--- a/client.go
+++ b/client.go
@@ -254,5 +254,11 @@ func (node *node) invoke(method string, in interface{}, out interface{}) error {
 		node.conn = conn
 	}
 
-	return node.conn.Invoke(context.TODO(), method, in, out)
+	err := node.conn.Invoke(context.TODO(), method, in, out)
+
+	if err != nil {
+		return newErrHederaNetwork(err)
+	}
+
+	return nil
 }

--- a/crypto.go
+++ b/crypto.go
@@ -238,25 +238,18 @@ func Ed25519PrivateKeyReadPem(source io.Reader, passphrase string) (Ed25519Priva
 
 // Ed25519PublicKeyFromString recovers an Ed25519PublicKey from its text-encoded representation.
 func Ed25519PublicKeyFromString(s string) (Ed25519PublicKey, error) {
-	switch len(s) {
-	case 64: // raw public key
-		bytes, err := hex.DecodeString(s)
-		if err != nil {
-			return Ed25519PublicKey{}, err
-		}
-
-		return Ed25519PublicKey{bytes}, nil
-
-	case 88: // DER encoded public key
-		if strings.HasPrefix(strings.ToLower(s), ed25519PubKeyPrefix) {
-			pk, err := Ed25519PublicKeyFromString(s[24:])
-			if err != nil {
-				return Ed25519PublicKey{}, err
-			}
-			return pk, nil
-		}
+	sLen := len(s)
+	if sLen != 64 && sLen != 88 {
+		return Ed25519PublicKey{}, newErrBadKeyf("invalid public key '%v' string with length %v", s, sLen)
 	}
-	return Ed25519PublicKey{}, newErrBadKeyf("invalid public key '%v' string with length %v", s, len(s))
+
+	keyStr := strings.TrimPrefix(strings.ToLower(s), ed25519PubKeyPrefix)
+	bytes, err := hex.DecodeString(keyStr)
+	if err != nil {
+		return Ed25519PublicKey{}, err
+	}
+
+	return Ed25519PublicKey{bytes}, nil
 }
 
 // Ed25519PublicKeyFromBytes constructs a known Ed25519PublicKey from its text-encoded representation.

--- a/crypto.go
+++ b/crypto.go
@@ -142,22 +142,17 @@ func Ed25519PrivateKeyFromMnemonic(mnemonic Mnemonic, passPhrase string) (Ed2551
 
 // Ed25519PrivateKeyFromString recovers an Ed25519PrivateKey from its text-encoded representation.
 func Ed25519PrivateKeyFromString(s string) (Ed25519PrivateKey, error) {
-	switch len(s) {
-	case 64, 128: // private key : public key
-		bytes, err := hex.DecodeString(s)
-		if err != nil {
-			return Ed25519PrivateKey{}, err
-		}
-
-		return Ed25519PrivateKeyFromBytes(bytes)
-
-	case 96: // prefix-encoded private key
-		if strings.HasPrefix(strings.ToLower(s), ed25519PrivateKeyPrefix) {
-			return Ed25519PrivateKeyFromString(s[32:])
-		}
+	sLen := len(s)
+	if sLen != 64 && sLen != 96 && sLen != 128 {
+		return Ed25519PrivateKey{}, newErrBadKeyf("invalid private key string with length %v", len(s))
 	}
 
-	return Ed25519PrivateKey{}, newErrBadKeyf("invalid private key string with length %v", len(s))
+	bytes, err := hex.DecodeString(strings.TrimPrefix(strings.ToLower(s), ed25519PrivateKeyPrefix))
+	if err != nil {
+		return Ed25519PrivateKey{}, err
+	}
+
+	return Ed25519PrivateKeyFromBytes(bytes)
 }
 
 // Ed25519PrivateKeyFromKeystore recovers an Ed25519PrivateKey from an encrypted keystore encoded as a byte slice.

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,8 @@ package hedera
 
 import (
 	"fmt"
+	"google.golang.org/grpc/codes"
+	status2 "google.golang.org/grpc/status"
 	"reflect"
 )
 
@@ -50,9 +52,15 @@ func (e ErrBadKey) Error() string {
 // ErrHederaNetwork is returned in cases where the Hedera network cannot be reached or a network-side error occurs.
 type ErrHederaNetwork struct {
 	error error
+	// GRPC Status Code
+	StatusCode *codes.Code
 }
 
 func newErrHederaNetwork(e error) ErrHederaNetwork {
+	if status, ok := status2.FromError(e); ok == true {
+		statusCode := status.Code()
+		return ErrHederaNetwork{error: e, StatusCode: &statusCode}
+	}
 	return ErrHederaNetwork{error: e}
 }
 

--- a/query_builder.go
+++ b/query_builder.go
@@ -2,6 +2,7 @@ package hedera
 
 import (
 	"fmt"
+	"google.golang.org/grpc/codes"
 	"math"
 	"math/rand"
 	"time"
@@ -356,6 +357,13 @@ func execute(node *node, paymentID *TransactionID, pb *proto.Query, deadline tim
 
 		err := node.invoke(methodName, pb, resp)
 		if err != nil {
+			statusCode := err.(ErrHederaNetwork).StatusCode
+
+			if *statusCode == codes.Unavailable || *statusCode == codes.ResourceExhausted {
+				// try again on unavailable or ResourceExhausted
+				continue
+			}
+
 			return nil, err
 		}
 


### PR DESCRIPTION
As a side effect, grpc status code is now exposed in `ErrHederaNetwork`

also simplifies the `___KeyFromString` functions