### PR TITLE
Feature(transaction): Get Signature Pairs, Get Body and Body Bytes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -156,3 +156,18 @@ func newErrPingStatus(e error) ErrPingStatus {
 func (e ErrPingStatus) Error() string {
 	return fmt.Sprintf("error occured during ping")
 }
+
+// ErrSignatureVerification is returned by Transaction.AppendSignature(Ed25519PublicKey, []byte)
+// if signature verification fails.
+type ErrSignatureVerification struct {
+	message string
+}
+
+func newErrSignatureVerification(format string, a ...interface{}) ErrSignatureVerification {
+	return ErrSignatureVerification{fmt.Sprintf(format, a...)}
+}
+
+// Error() implements the Error interface
+func (e ErrSignatureVerification) Error() string {
+	return e.message
+}

--- a/errors.go
+++ b/errors.go
@@ -156,18 +156,3 @@ func newErrPingStatus(e error) ErrPingStatus {
 func (e ErrPingStatus) Error() string {
 	return fmt.Sprintf("error occured during ping")
 }
-
-// ErrSignatureVerification is returned by Transaction.AppendSignature(Ed25519PublicKey, []byte)
-// if signature verification fails.
-type ErrSignatureVerification struct {
-	message string
-}
-
-func newErrSignatureVerification(format string, a ...interface{}) ErrSignatureVerification {
-	return ErrSignatureVerification{fmt.Sprintf(format, a...)}
-}
-
-// Error() implements the Error interface
-func (e ErrSignatureVerification) Error() string {
-	return e.message
-}

--- a/transaction.go
+++ b/transaction.go
@@ -78,16 +78,10 @@ func (transaction Transaction) SignWith(publicKey Ed25519PublicKey, signer Trans
 	return transaction
 }
 
-// AppendSignature verifies provided signature and public key for corresponding transaction and adds them
+// AppendSignature verifies provided signature and public key for corresponding transaction body and adds them
 // to the Transaction's signature map
 func (transaction Transaction) AppendSignature(publicKey Ed25519PublicKey, signature []byte) (*Transaction, error) {
-	txBytes, err := transaction.MarshalBinary()
-
-	if err != nil {
-		return nil, err
-	}
-
-	verifiedSignature := ed25519.Verify(publicKey.Bytes(), txBytes, signature)
+	verifiedSignature := ed25519.Verify(publicKey.Bytes(), transaction.BodyBytes(), signature)
 
 	if verifiedSignature != true {
 		return nil, newErrSignatureVerification("invalid public key or signature provided")

--- a/transaction.go
+++ b/transaction.go
@@ -202,6 +202,11 @@ func (transaction Transaction) ID() TransactionID {
 	return transaction.id
 }
 
+// BodyBytes returns the transaction body as raw bytes
+func (transaction Transaction) BodyBytes() []byte {
+	return transaction.pb.GetBodyBytes()
+}
+
 // The protobuf stores the transaction body as raw bytes so we need to first
 // decode what we have to inspect the Kind, TransactionID, and the NodeAccountID so we know how to
 // properly execute it

--- a/transaction.go
+++ b/transaction.go
@@ -100,7 +100,7 @@ func (transaction Transaction) executeForResponse(client *Client) (TransactionID
 		transaction.signWithOperator(*client.operator)
 	}
 
-	transactionBody := transaction.body()
+	transactionBody := transaction.Body()
 	id := transactionIDFromProto(transactionBody.TransactionID)
 
 	nodeAccountID := accountIDFromProto(transactionBody.NodeAccountID)
@@ -110,7 +110,7 @@ func (transaction Transaction) executeForResponse(client *Client) (TransactionID
 		return id, nil, newErrLocalValidationf("NodeAccountID %v not found on Client", nodeAccountID)
 	}
 
-	methodName, err := getMethodName(transaction.body())
+	methodName, err := getMethodName(transaction.Body())
 
 	if err != nil {
 		return id, nil, err
@@ -181,7 +181,7 @@ func (transaction Transaction) Execute(client *Client) (TransactionID, error) {
 
 func (transaction Transaction) String() string {
 	return protobuf.MarshalTextString(transaction.pb) +
-		protobuf.MarshalTextString(transaction.body())
+		protobuf.MarshalTextString(transaction.Body())
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
@@ -201,10 +201,15 @@ func (transaction Transaction) BodyBytes() []byte {
 	return transaction.pb.GetBodyBytes()
 }
 
+// SignaturePairs returns the transaction signature pairs
+func (transaction Transaction) SignaturePairs() []*proto.SignaturePair {
+	return transaction.pb.GetSigMap().SigPair
+}
+
 // The protobuf stores the transaction body as raw bytes so we need to first
 // decode what we have to inspect the Kind, TransactionID, and the NodeAccountID so we know how to
 // properly execute it
-func (transaction Transaction) body() *proto.TransactionBody {
+func (transaction Transaction) Body() *proto.TransactionBody {
 	transactionBody := new(proto.TransactionBody)
 	err := protobuf.Unmarshal(transaction.pb.GetBodyBytes(), transactionBody)
 	if err != nil {

--- a/transaction.go
+++ b/transaction.go
@@ -2,7 +2,6 @@ package hedera
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"google.golang.org/grpc/codes"
 	"math"
 	"math/rand"
@@ -76,23 +75,6 @@ func (transaction Transaction) SignWith(publicKey Ed25519PublicKey, signer Trans
 	})
 
 	return transaction
-}
-
-// AppendSignature verifies provided signature and public key for corresponding transaction body and adds them
-// to the Transaction's signature map
-func (transaction Transaction) AppendSignature(publicKey Ed25519PublicKey, signature []byte) (*Transaction, error) {
-	verifiedSignature := ed25519.Verify(publicKey.Bytes(), transaction.BodyBytes(), signature)
-
-	if verifiedSignature != true {
-		return nil, newErrSignatureVerification("invalid public key or signature provided")
-	}
-
-	transaction.pb.SigMap.SigPair = append(transaction.pb.SigMap.SigPair, &proto.SignaturePair{
-		PubKeyPrefix: publicKey.keyData,
-		Signature:    &proto.SignaturePair_Ed25519{Ed25519: signature},
-	})
-
-	return &transaction, nil
 }
 
 func (transaction Transaction) executeForResponse(client *Client) (TransactionID, *proto.TransactionResponse, error) {


### PR DESCRIPTION
**Detailed description**:
- Add tx `SignaturePairs` method
- Add tx `BodyBytes` method
- Update tx `Body` method to be accessible outside package

**Which issue(s) this PR fixes**:
Fixes #85
