### PR TITLE
Update transaction_id.go to resolve overflow error

### DIFF
--- a/transaction_id.go
+++ b/transaction_id.go
@@ -18,7 +18,7 @@ type TransactionID struct {
 // NewTransactionID constructs a new Transaction id struct with the provided AccountID and the valid start time set
 // to the current time - 10 seconds.
 func TransactionIDGenerate(accountID AccountID) TransactionID {
-	allowance := -(time.Duration(rand.Intn(5*int(time.Second))) + (8 * time.Second))
+	allowance := -(time.Duration(rand.Int63n(5*int64(time.Second))) + (8 * time.Second))
 	validStart := time.Now().UTC().Add(allowance)
 
 	return TransactionID{accountID, validStart}


### PR DESCRIPTION
I got the following error when using gomobile bind:
transaction_id.go:21:42: constant 5000000000 overflows int

I changed the types to int64 and that seems to resolve the issue.