### PR TITLE
fix: checksums are now fixed for similar ledgerIDs, ex: 0x01 and 0x10

### DIFF
--- a/account_balance_query_unit_test.go
+++ b/account_balance_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitAccountBalanceQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	balanceQuery := NewAccountBalanceQuery().
@@ -36,6 +36,6 @@ func TestUnitAccountBalanceQueryValidateWrong(t *testing.T) {
 	err = balanceQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/account_create_transaction_unit_test.go
+++ b/account_create_transaction_unit_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnitAccountCreateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	createAccount := NewAccountCreateTransaction().
@@ -40,7 +40,7 @@ func TestUnitAccountCreateTransactionValidateWrong(t *testing.T) {
 	err = createAccount._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/account_delete_transaction_unit_test.go
+++ b/account_delete_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitAccountDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	deleteAccount := NewAccountDeleteTransaction().
@@ -38,6 +38,6 @@ func TestUnitAccountDeleteTransactionValidateWrong(t *testing.T) {
 	err = deleteAccount._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/account_id_unit_test.go
+++ b/account_id_unit_test.go
@@ -35,3 +35,12 @@ func TestUnitAccountIDFromStringAlias(t *testing.T) {
 
 	assert.Equal(t, id.String(), id2.String())
 }
+
+func TestUnitChecksum(t *testing.T) {
+	ad1, err := _ChecksumParseAddress("01", "0.0.3")
+	require.NoError(t, err)
+	ad2, err := _ChecksumParseAddress("10", "0.0.3")
+	require.NoError(t, err)
+
+	require.NotEqual(t, ad1.correctChecksum, ad2.correctChecksum)
+}

--- a/account_info_query_unit_test.go
+++ b/account_info_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitAccountInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	infoQuery := NewAccountInfoQuery().
@@ -36,6 +36,6 @@ func TestUnitAccountInfoQueryValidateWrong(t *testing.T) {
 	err = infoQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/account_records_query_unit_test.go
+++ b/account_records_query_unit_test.go
@@ -16,7 +16,7 @@ import (
 func TestUnitAccountRecordQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	recordQuery := NewAccountRecordsQuery().
@@ -38,7 +38,7 @@ func TestUnitAccountRecordQueryValidateWrong(t *testing.T) {
 	err = recordQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/account_stakers_query_unit_test.go
+++ b/account_stakers_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitAccountStakersQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	stackersQuery := NewAccountStakersQuery().
@@ -36,6 +36,6 @@ func TestUnitAccountStakersQueryValidateWrong(t *testing.T) {
 	err = stackersQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/account_update_transaction_unit_test.go
+++ b/account_update_transaction_unit_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnitAccountUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	accountUpdate := NewAccountUpdateTransaction().
@@ -39,7 +39,7 @@ func TestUnitAccountUpdateTransactionValidateWrong(t *testing.T) {
 	err = accountUpdate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_bytecode_query_unit_test.go
+++ b/contract_bytecode_query_unit_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnitContractBytecodeQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractBytecode := NewContractBytecodeQuery().
@@ -39,7 +39,7 @@ func TestUnitContractBytecodeQueryValidateWrong(t *testing.T) {
 	err = contractBytecode._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_call_query_unit_test.go
+++ b/contract_call_query_unit_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnitContractCallQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractCall := NewContractCallQuery().
@@ -39,7 +39,7 @@ func TestUnitContractCallQueryValidateWrong(t *testing.T) {
 	err = contractCall._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_create_transaction_unit_test.go
+++ b/contract_create_transaction_unit_test.go
@@ -19,9 +19,9 @@ import (
 func TestUnitContractCreateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractCreate := NewContractCreateTransaction().
@@ -47,7 +47,7 @@ func TestUnitContractCreateTransactionValidateWrong(t *testing.T) {
 	err = contractCreate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_delete_transaction_unit_test.go
+++ b/contract_delete_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitContractDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractDelete := NewContractDeleteTransaction().
@@ -44,6 +44,6 @@ func TestUnitContractDeleteTransactionValidateWrong(t *testing.T) {
 	err = contractDelete._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/contract_execute_transaction_unit_test.go
+++ b/contract_execute_transaction_unit_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnitContractExecuteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractExecute := NewContractExecuteTransaction().
@@ -40,7 +40,7 @@ func TestUnitContractExecuteTransactionValidateWrong(t *testing.T) {
 	err = contractExecute._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_info_query_unit_test.go
+++ b/contract_info_query_unit_test.go
@@ -4,8 +4,9 @@
 package hedera
 
 import (
-	protobuf "google.golang.org/protobuf/proto"
 	"testing"
+
+	protobuf "google.golang.org/protobuf/proto"
 
 	"github.com/hashgraph/hedera-protobufs-go/services"
 
@@ -17,7 +18,7 @@ import (
 func TestUnitContractInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractInfoQuery := NewContractInfoQuery().
@@ -39,7 +40,7 @@ func TestUnitContractInfoQueryValidateWrong(t *testing.T) {
 	err = contractInfoQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/contract_update_transaction_unit_test.go
+++ b/contract_update_transaction_unit_test.go
@@ -18,11 +18,11 @@ import (
 func TestUnitContractUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	contractID, err := ContractIDFromString("0.0.123-rmkyk")
+	contractID, err := ContractIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	contractInfoQuery := NewContractUpdateTransaction().
@@ -52,7 +52,7 @@ func TestUnitContractUpdateTransactionValidateWrong(t *testing.T) {
 	err = contractInfoQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/file_append_transaction_unit_test.go
+++ b/file_append_transaction_unit_test.go
@@ -18,7 +18,7 @@ import (
 func TestUnitFileAppendTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	fileAppend := NewFileAppendTransaction().
@@ -40,7 +40,7 @@ func TestUnitFileAppendTransactionValidateWrong(t *testing.T) {
 	err = fileAppend._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/file_contents_query_unit_test.go
+++ b/file_contents_query_unit_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnitFileContentsQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	fileContents := NewFileContentsQuery().
@@ -39,7 +39,7 @@ func TestUnitFileContentsQueryValidateWrong(t *testing.T) {
 	err = fileContents._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/file_delete_transaction_unit_test.go
+++ b/file_delete_transaction_unit_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnitFileDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	fileDelete := NewFileDeleteTransaction().
@@ -39,7 +39,7 @@ func TestUnitFileDeleteTransactionValidateWrong(t *testing.T) {
 	err = fileDelete._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/file_info_query_unit_test.go
+++ b/file_info_query_unit_test.go
@@ -16,7 +16,7 @@ import (
 func TestUnitFileInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	fileInfo := NewFileInfoQuery().
@@ -38,7 +38,7 @@ func TestUnitFileInfoQueryValidateWrong(t *testing.T) {
 	err = fileInfo._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/file_update_transaction_unit_test.go
+++ b/file_update_transaction_unit_test.go
@@ -19,7 +19,7 @@ import (
 func TestUnitFileUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	fileID, err := FileIDFromString("0.0.123-rmkyk")
+	fileID, err := FileIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	fileUpdate := NewFileUpdateTransaction().
@@ -41,7 +41,7 @@ func TestUnitFileUpdateTransactionValidateWrong(t *testing.T) {
 	err = fileUpdate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/live_hash_add_transaction_unit_test.go
+++ b/live_hash_add_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitLiveHashAddTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	addLiveHash := NewLiveHashAddTransaction().
@@ -36,6 +36,6 @@ func TestUnitLiveHashAddTransactionValidateWrong(t *testing.T) {
 	err = addLiveHash._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/live_hash_query_unit_test.go
+++ b/live_hash_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitLiveHashQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	liveHashQuery := NewLiveHashQuery().
@@ -36,6 +36,6 @@ func TestUnitLiveHashQueryValidateWrong(t *testing.T) {
 	err = liveHashQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/schedule_create_transaction_unit_test.go
+++ b/schedule_create_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitScheduleCreateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	scheduleCreate := NewScheduleCreateTransaction().
@@ -36,14 +36,14 @@ func TestUnitScheduleCreateTransactionValidateWrong(t *testing.T) {
 	err = scheduleCreate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 
 func TestUnitScheduleInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	scheduleID, err := ScheduleIDFromString("0.0.123-rmkyk")
+	scheduleID, err := ScheduleIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	scheduleInfo := NewScheduleInfoQuery().
@@ -65,14 +65,14 @@ func TestUnitScheduleInfoQueryValidateWrong(t *testing.T) {
 	err = scheduleInfo._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 
 func TestUnitScheduleSignTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	scheduleID, err := ScheduleIDFromString("0.0.123-rmkyk")
+	scheduleID, err := ScheduleIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	scheduleSign := NewScheduleSignTransaction().
@@ -94,14 +94,14 @@ func TestUnitScheduleSignTransactionValidateWrong(t *testing.T) {
 	err = scheduleSign._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 
 func TestUnitScheduleDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	scheduleID, err := ScheduleIDFromString("0.0.123-rmkyk")
+	scheduleID, err := ScheduleIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	scheduleDelete := NewScheduleDeleteTransaction().
@@ -123,6 +123,6 @@ func TestUnitScheduleDeleteTransactionValidateWrong(t *testing.T) {
 	err = scheduleDelete._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_associate_transaction_unit_test.go
+++ b/token_associate_transaction_unit_test.go
@@ -18,9 +18,9 @@ import (
 func TestUnitTokenAssociateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenAssociate := NewTokenAssociateTransaction().
@@ -46,7 +46,7 @@ func TestUnitTokenAssociateTransactionValidateWrong(t *testing.T) {
 	err = tokenAssociate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/token_burn_transaction_unit_test.go
+++ b/token_burn_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTokenBurnTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenBurn := NewTokenBurnTransaction().
@@ -36,6 +36,6 @@ func TestUnitTokenBurnTransactionValidateWrong(t *testing.T) {
 	err = tokenBurn._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_create_transaction_unit_test.go
+++ b/token_create_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTokenCreateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenCreate := NewTokenCreateTransaction().
@@ -38,6 +38,6 @@ func TestUnitTokenCreateTransactionValidateWrong(t *testing.T) {
 	err = tokenCreate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_delete_transaction_unit_test.go
+++ b/token_delete_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTokenDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenDelete := NewTokenDeleteTransaction().
@@ -36,6 +36,6 @@ func TestUnitTokenDeleteTransactionValidateWrong(t *testing.T) {
 	err = tokenDelete._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_dissociate_transaction_unit_test.go
+++ b/token_dissociate_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenDissociateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenDissociate := NewTokenDissociateTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenDissociateTransactionValidateWrong(t *testing.T) {
 	err = tokenDissociate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_fee_schedule_update_transaction_unit_test.go
+++ b/token_fee_schedule_update_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenFeeScheduleUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	fee := NewCustomFixedFee().SetDenominatingTokenID(tokenID).SetFeeCollectorAccountID(accountID)
 	require.NoError(t, err)
 
@@ -44,6 +44,6 @@ func TestUnitTokenFeeScheduleUpdateTransactionValidateWrong(t *testing.T) {
 	err = tokenFeeUpdate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_freeze_transaction_unit_test.go
+++ b/token_freeze_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenFreezeTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenFreeze := NewTokenFreezeTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenFreezeTransactionValidateWrong(t *testing.T) {
 	err = tokenFreeze._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_grant_kyc_transaction_unit_test.go
+++ b/token_grant_kyc_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenGrantKycTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenGrantKyc := NewTokenGrantKycTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenGrantKycTransactionValidateWrong(t *testing.T) {
 	err = tokenGrantKyc._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_info_query_unit_test.go
+++ b/token_info_query_unit_test.go
@@ -15,7 +15,7 @@ import (
 func TestUnitTokenInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenInfo := NewTokenInfoQuery().
@@ -37,7 +37,7 @@ func TestUnitTokenInfoQueryValidateWrong(t *testing.T) {
 	err = tokenInfo._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 

--- a/token_mint_transaction_unit_test.go
+++ b/token_mint_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTokenMintTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenMint := NewTokenGrantKycTransaction().
@@ -36,6 +36,6 @@ func TestUnitTokenMintTransactionValidateWrong(t *testing.T) {
 	err = tokenMint._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_nft_info_query_unit_test.go
+++ b/token_nft_info_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTokenNftGetInfoByNftIDValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	nftID, err := NftIDFromString("2@0.0.123-rmkyk")
+	nftID, err := NftIDFromString("2@0.0.123-esxsf")
 	require.NoError(t, err)
 
 	nftInfo := NewTokenNftInfoQuery().
@@ -36,6 +36,6 @@ func TestUnitTokenNftGetInfoByNftIDValidateWrong(t *testing.T) {
 	err = nftInfo._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_revoke_kys_transaction_unit_test.go
+++ b/token_revoke_kys_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenRevokeKycTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenRevokeKyc := NewTokenRevokeKycTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenRevokeKycTransactionValidateWrong(t *testing.T) {
 	err = tokenRevokeKyc._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_transfer_transaction_unit_test.go
+++ b/token_transfer_transaction_unit_test.go
@@ -101,11 +101,11 @@ func TestUnitTokenTransferTransactionTransfers(t *testing.T) {
 func TestUnitTokenTransferTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	nftID, err := NftIDFromString("2@0.0.123-rmkyk")
+	nftID, err := NftIDFromString("2@0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenTransfer := NewTransferTransaction().
@@ -133,6 +133,6 @@ func TestUnitTokenTransferTransactionValidateWrong(t *testing.T) {
 	err = tokenTransfer._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_unfreeze_transaction_unit_test.go
+++ b/token_unfreeze_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenUnfreezeTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenUnfreeze := NewTokenUnfreezeTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenUnfreezeTransactionValidateWrong(t *testing.T) {
 	err = tokenUnfreeze._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_update_transaction_unit_test.go
+++ b/token_update_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenUpdate := NewTokenUpdateTransaction().
@@ -44,6 +44,6 @@ func TestUnitTokenUpdateTransactionValidateWrong(t *testing.T) {
 	err = tokenUpdate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/token_wipe_transaction_unit_test.go
+++ b/token_wipe_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTokenWipeTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	tokenID, err := TokenIDFromString("0.0.123-rmkyk")
+	tokenID, err := TokenIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	tokenWipe := NewTokenWipeTransaction().
@@ -42,6 +42,6 @@ func TestUnitTokenWipeTransactionValidateWrong(t *testing.T) {
 	err = tokenWipe._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/topic_create_transaction_unit_test.go
+++ b/topic_create_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTopicCreateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	topicCreate := NewTopicCreateTransaction().
@@ -36,6 +36,6 @@ func TestUnitTopicCreateTransactionValidateWrong(t *testing.T) {
 	err = topicCreate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/topic_delete_transaction_unit_test.go
+++ b/topic_delete_transaction_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTopicDeleteTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	topicID, err := TopicIDFromString("0.0.123-rmkyk")
+	topicID, err := TopicIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	topicDelete := NewTopicDeleteTransaction().
@@ -36,6 +36,6 @@ func TestUnitTopicDeleteTransactionValidateWrong(t *testing.T) {
 	err = topicDelete._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/topic_info_query_unit_test.go
+++ b/topic_info_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTopicInfoQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	topicID, err := TopicIDFromString("0.0.123-rmkyk")
+	topicID, err := TopicIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	topicInfo := NewTopicInfoQuery().
@@ -36,6 +36,6 @@ func TestUnitTopicInfoQueryValidateWrong(t *testing.T) {
 	err = topicInfo._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/topic_update_transaction_unit_test.go
+++ b/topic_update_transaction_unit_test.go
@@ -14,9 +14,9 @@ import (
 func TestUnitTopicUpdateTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-	topicID, err := TopicIDFromString("0.0.123-rmkyk")
+	topicID, err := TopicIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	topicUpdate := NewTopicUpdateTransaction().
@@ -42,6 +42,6 @@ func TestUnitTopicUpdateTransactionValidateWrong(t *testing.T) {
 	err = topicUpdate._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/transaction_receipt_query_unit_test.go
+++ b/transaction_receipt_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTransactionReceiptQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	transactionID := TransactionIDGenerate(accountID)
 	require.NoError(t, err)
 
@@ -38,6 +38,6 @@ func TestUnitTransactionReceiptQueryValidateWrong(t *testing.T) {
 	err = receiptQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/transaction_record_query_unit_test.go
+++ b/transaction_record_query_unit_test.go
@@ -14,7 +14,7 @@ import (
 func TestUnitTransactionRecordQueryValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	transactionID := TransactionIDGenerate(accountID)
 	require.NoError(t, err)
 
@@ -38,6 +38,6 @@ func TestUnitTransactionRecordQueryValidateWrong(t *testing.T) {
 	err = recordQuery._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }

--- a/transfer_transaction_unit_test.go
+++ b/transfer_transaction_unit_test.go
@@ -28,7 +28,7 @@ func TestUnitTransferTransactionSetTokenTransferWithDecimals(t *testing.T) {
 func TestUnitTransferTransactionValidate(t *testing.T) {
 	client := ClientForTestnet()
 	client.SetAutoValidateChecksums(true)
-	accountID, err := AccountIDFromString("0.0.123-rmkyk")
+	accountID, err := AccountIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
 
 	transfer := NewTransferTransaction().
@@ -50,7 +50,7 @@ func TestUnitTransferTransactionValidateWrong(t *testing.T) {
 	err = transfer._ValidateNetworkOnIDs(client)
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum rmkyk, network: testnet", err.Error())
+		assert.Equal(t, "network mismatch or wrong checksum given, given checksum: rmkykd, correct checksum esxsf, network: testnet", err.Error())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Andrei Kuzmiankov <andrei@launchbadge.com>

closes: #417 