### PR TITLE
added abi support for uint256

### DIFF
--- a/abi/Readme.md
+++ b/abi/Readme.md
@@ -1,0 +1,13 @@
+# ABI package for using uint256
+
+> Regarding this [Issue]: hedera-sdk do not support uint256 conversion from big.Int.
+> Solution is usage of go-ethereum abi library.
+
+[Issue]: https://github.com/hashgraph/hedera-sdk-go/issues/534
+
+
+## Example
+
+```
+AddUint256(abi.U256(big.NewInt(some number)))
+```

--- a/abi/abi.go
+++ b/abi/abi.go
@@ -1,0 +1,146 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// The ABI holds information about a contract's context and available
+// invokable methods. It will allow you to type check function calls and
+// packs data accordingly.
+type ABI struct {
+	Constructor Method
+	Methods     map[string]Method
+	Events      map[string]Event
+}
+
+// JSON returns a parsed ABI interface and error if it failed.
+func JSON(reader io.Reader) (ABI, error) {
+	dec := json.NewDecoder(reader)
+
+	var abi ABI
+	if err := dec.Decode(&abi); err != nil {
+		return ABI{}, err
+	}
+
+	return abi, nil
+}
+
+// Pack the given method name to conform the ABI. Method call's data
+// will consist of method_id, args0, arg1, ... argN. Method id consists
+// of 4 bytes and arguments are all 32 bytes.
+// Method ids are created from the first 4 bytes of the hash of the
+// methods string signature. (signature = baz(uint32,string32))
+func (abi ABI) Pack(name string, args ...interface{}) ([]byte, error) {
+	// Fetch the ABI of the requested method
+	if name == "" {
+		// constructor
+		arguments, err := abi.Constructor.Inputs.Pack(args...)
+		if err != nil {
+			return nil, err
+		}
+		return arguments, nil
+
+	}
+	method, exist := abi.Methods[name]
+	if !exist {
+		return nil, fmt.Errorf("method '%s' not found", name)
+	}
+
+	arguments, err := method.Inputs.Pack(args...)
+	if err != nil {
+		return nil, err
+	}
+	// Pack up the method ID too if not a constructor and return
+	return append(method.Id(), arguments...), nil
+}
+
+// Unpack output in v according to the abi specification
+func (abi ABI) Unpack(v interface{}, name string, output []byte) (err error) {
+	if len(output) == 0 {
+		return fmt.Errorf("abi: unmarshalling empty output")
+	}
+	// since there can't be naming collisions with contracts and events,
+	// we need to decide whether we're calling a method or an event
+	if method, ok := abi.Methods[name]; ok {
+		if len(output)%32 != 0 {
+			return fmt.Errorf("abi: improperly formatted output")
+		}
+		return method.Outputs.Unpack(v, output)
+	} else if event, ok := abi.Events[name]; ok {
+		return event.Inputs.Unpack(v, output)
+	}
+	return fmt.Errorf("abi: could not locate named method or event")
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (abi *ABI) UnmarshalJSON(data []byte) error {
+	var fields []struct {
+		Type      string
+		Name      string
+		Constant  bool
+		Anonymous bool
+		Inputs    []Argument
+		Outputs   []Argument
+	}
+
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	abi.Methods = make(map[string]Method)
+	abi.Events = make(map[string]Event)
+	for _, field := range fields {
+		switch field.Type {
+		case "constructor":
+			abi.Constructor = Method{
+				Inputs: field.Inputs,
+			}
+		// empty defaults to function according to the abi spec
+		case "function", "":
+			abi.Methods[field.Name] = Method{
+				Name:    field.Name,
+				Const:   field.Constant,
+				Inputs:  field.Inputs,
+				Outputs: field.Outputs,
+			}
+		case "event":
+			abi.Events[field.Name] = Event{
+				Name:      field.Name,
+				Anonymous: field.Anonymous,
+				Inputs:    field.Inputs,
+			}
+		}
+	}
+
+	return nil
+}
+
+// MethodById looks up a method by the 4-byte id
+// returns nil if none found
+func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
+	for _, method := range abi.Methods {
+		if bytes.Equal(method.Id(), sigdata[:4]) {
+			return &method, nil
+		}
+	}
+	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
+}

--- a/abi/argument.go
+++ b/abi/argument.go
@@ -1,0 +1,290 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Argument holds the name of the argument and the corresponding type.
+// Types are used when packing and testing arguments.
+type Argument struct {
+	Name    string
+	Type    Type
+	Indexed bool // indexed is only used by events
+}
+
+type Arguments []Argument
+
+// UnmarshalJSON implements json.Unmarshaler interface
+func (argument *Argument) UnmarshalJSON(data []byte) error {
+	var extarg struct {
+		Name    string
+		Type    string
+		Indexed bool
+	}
+	err := json.Unmarshal(data, &extarg)
+	if err != nil {
+		return fmt.Errorf("argument json err: %v", err)
+	}
+
+	argument.Type, err = NewType(extarg.Type)
+	if err != nil {
+		return err
+	}
+	argument.Name = extarg.Name
+	argument.Indexed = extarg.Indexed
+
+	return nil
+}
+
+// LengthNonIndexed returns the number of arguments when not counting 'indexed' ones. Only events
+// can ever have 'indexed' arguments, it should always be false on arguments for method input/output
+func (arguments Arguments) LengthNonIndexed() int {
+	out := 0
+	for _, arg := range arguments {
+		if !arg.Indexed {
+			out++
+		}
+	}
+	return out
+}
+
+// NonIndexed returns the arguments with indexed arguments filtered out
+func (arguments Arguments) NonIndexed() Arguments {
+	var ret []Argument
+	for _, arg := range arguments {
+		if !arg.Indexed {
+			ret = append(ret, arg)
+		}
+	}
+	return ret
+}
+
+// isTuple returns true for non-atomic constructs, like (uint,uint) or uint[]
+func (arguments Arguments) isTuple() bool {
+	return len(arguments) > 1
+}
+
+// Unpack performs the operation hexdata -> Go format
+func (arguments Arguments) Unpack(v interface{}, data []byte) error {
+
+	// make sure the passed value is arguments pointer
+	if reflect.Ptr != reflect.ValueOf(v).Kind() {
+		return fmt.Errorf("abi: Unpack(non-pointer %T)", v)
+	}
+	marshalledValues, err := arguments.UnpackValues(data)
+	if err != nil {
+		return err
+	}
+	if arguments.isTuple() {
+		return arguments.unpackTuple(v, marshalledValues)
+	}
+	return arguments.unpackAtomic(v, marshalledValues)
+}
+
+func (arguments Arguments) unpackTuple(v interface{}, marshalledValues []interface{}) error {
+
+	var (
+		value = reflect.ValueOf(v).Elem()
+		typ   = value.Type()
+		kind  = value.Kind()
+	)
+
+	if err := requireUnpackKind(value, typ, kind, arguments); err != nil {
+		return err
+	}
+
+	// If the interface is a struct, get of abi->struct_field mapping
+
+	var abi2struct map[string]string
+	if kind == reflect.Struct {
+		var err error
+		abi2struct, err = mapAbiToStructFields(arguments, value)
+		if err != nil {
+			return err
+		}
+	}
+	for i, arg := range arguments.NonIndexed() {
+
+		reflectValue := reflect.ValueOf(marshalledValues[i])
+
+		switch kind {
+		case reflect.Struct:
+			if structField, ok := abi2struct[arg.Name]; ok {
+				if err := set(value.FieldByName(structField), reflectValue, arg); err != nil {
+					return err
+				}
+			}
+		case reflect.Slice, reflect.Array:
+			if value.Len() < i {
+				return fmt.Errorf("abi: insufficient number of arguments for unpack, want %d, got %d", len(arguments), value.Len())
+			}
+			v := value.Index(i)
+			if err := requireAssignable(v, reflectValue); err != nil {
+				return err
+			}
+
+			if err := set(v.Elem(), reflectValue, arg); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("abi:[2] cannot unmarshal tuple in to %v", typ)
+		}
+	}
+	return nil
+}
+
+// unpackAtomic unpacks ( hexdata -> go ) a single value
+func (arguments Arguments) unpackAtomic(v interface{}, marshalledValues []interface{}) error {
+	if len(marshalledValues) != 1 {
+		return fmt.Errorf("abi: wrong length, expected single value, got %d", len(marshalledValues))
+	}
+
+	elem := reflect.ValueOf(v).Elem()
+	kind := elem.Kind()
+	reflectValue := reflect.ValueOf(marshalledValues[0])
+
+	var abi2struct map[string]string
+	if kind == reflect.Struct {
+		var err error
+		if abi2struct, err = mapAbiToStructFields(arguments, elem); err != nil {
+			return err
+		}
+		arg := arguments.NonIndexed()[0]
+		if structField, ok := abi2struct[arg.Name]; ok {
+			return set(elem.FieldByName(structField), reflectValue, arg)
+		}
+		return nil
+	}
+
+	return set(elem, reflectValue, arguments.NonIndexed()[0])
+
+}
+
+// Computes the full size of an array;
+// i.e. counting nested arrays, which count towards size for unpacking.
+func getArraySize(arr *Type) int {
+	size := arr.Size
+	// Arrays can be nested, with each element being the same size
+	arr = arr.Elem
+	for arr.T == ArrayTy {
+		// Keep multiplying by elem.Size while the elem is an array.
+		size *= arr.Size
+		arr = arr.Elem
+	}
+	// Now we have the full array size, including its children.
+	return size
+}
+
+// UnpackValues can be used to unpack ABI-encoded hexdata according to the ABI-specification,
+// without supplying a struct to unpack into. Instead, this method returns a list containing the
+// values. An atomic argument will be a list with one element.
+func (arguments Arguments) UnpackValues(data []byte) ([]interface{}, error) {
+	retval := make([]interface{}, 0, arguments.LengthNonIndexed())
+	virtualArgs := 0
+	for index, arg := range arguments.NonIndexed() {
+		marshalledValue, err := toGoType((index+virtualArgs)*32, arg.Type, data)
+		if arg.Type.T == ArrayTy {
+			// If we have a static array, like [3]uint256, these are coded as
+			// just like uint256,uint256,uint256.
+			// This means that we need to add two 'virtual' arguments when
+			// we count the index from now on.
+			//
+			// Array values nested multiple levels deep are also encoded inline:
+			// [2][3]uint256: uint256,uint256,uint256,uint256,uint256,uint256
+			//
+			// Calculate the full array size to get the correct offset for the next argument.
+			// Decrement it by 1, as the normal index increment is still applied.
+			virtualArgs += getArraySize(&arg.Type) - 1
+		}
+		if err != nil {
+			return nil, err
+		}
+		retval = append(retval, marshalledValue)
+	}
+	return retval, nil
+}
+
+// PackValues performs the operation Go format -> Hexdata
+// It is the semantic opposite of UnpackValues
+func (arguments Arguments) PackValues(args []interface{}) ([]byte, error) {
+	return arguments.Pack(args...)
+}
+
+// Pack performs the operation Go format -> Hexdata
+func (arguments Arguments) Pack(args ...interface{}) ([]byte, error) {
+	// Make sure arguments match up and pack them
+	abiArgs := arguments
+	if len(args) != len(abiArgs) {
+		return nil, fmt.Errorf("argument count mismatch: %d for %d", len(args), len(abiArgs))
+	}
+	// variable input is the output appended at the end of packed
+	// output. This is used for strings and bytes types input.
+	var variableInput []byte
+
+	// input offset is the bytes offset for packed output
+	inputOffset := 0
+	for _, abiArg := range abiArgs {
+		if abiArg.Type.T == ArrayTy {
+			inputOffset += 32 * abiArg.Type.Size
+		} else {
+			inputOffset += 32
+		}
+	}
+	var ret []byte
+	for i, a := range args {
+		input := abiArgs[i]
+		// pack the input
+		packed, err := input.Type.pack(reflect.ValueOf(a))
+		if err != nil {
+			return nil, err
+		}
+		// check for a slice type (string, bytes, slice)
+		if input.Type.requiresLengthPrefix() {
+			// calculate the offset
+			offset := inputOffset + len(variableInput)
+			// set the offset
+			ret = append(ret, packNum(reflect.ValueOf(offset))...)
+			// Append the packed output to the variable input. The variable input
+			// will be appended at the end of the input.
+			variableInput = append(variableInput, packed...)
+		} else {
+			// append the packed value to the input
+			ret = append(ret, packed...)
+		}
+	}
+	// append the variable input at the end of the packed input
+	ret = append(ret, variableInput...)
+
+	return ret, nil
+}
+
+// capitalise makes the first character of a string upper case, also removing any
+// prefixing underscores from the variable names.
+func capitalise(input string) string {
+	for len(input) > 0 && input[0] == '_' {
+		input = input[1:]
+	}
+	if len(input) == 0 {
+		return ""
+	}
+	return strings.ToUpper(input[:1]) + input[1:]
+}

--- a/abi/doc.go
+++ b/abi/doc.go
@@ -1,0 +1,26 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package abi implements the Ethereum ABI (Application Binary
+// Interface).
+//
+// The Ethereum ABI is strongly typed, known at compile time
+// and static. This ABI will handle basic type casting; unsigned
+// to signed and visa versa. It does not handle slice casting such
+// as unsigned slice to signed slice. Bit size type casting is also
+// handled. ints with a bit size of 32 will be properly cast to int256,
+// etc.
+package abi

--- a/abi/error.go
+++ b/abi/error.go
@@ -1,0 +1,84 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var (
+	errBadBool = errors.New("abi: improperly encoded boolean value")
+)
+
+// formatSliceString formats the reflection kind with the given slice size
+// and returns a formatted string representation.
+func formatSliceString(kind reflect.Kind, sliceSize int) string {
+	if sliceSize == -1 {
+		return fmt.Sprintf("[]%v", kind)
+	}
+	return fmt.Sprintf("[%d]%v", sliceSize, kind)
+}
+
+// sliceTypeCheck checks that the given slice can by assigned to the reflection
+// type in t.
+func sliceTypeCheck(t Type, val reflect.Value) error {
+	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
+		return typeErr(formatSliceString(t.Kind, t.Size), val.Type())
+	}
+
+	if t.T == ArrayTy && val.Len() != t.Size {
+		return typeErr(formatSliceString(t.Elem.Kind, t.Size), formatSliceString(val.Type().Elem().Kind(), val.Len()))
+	}
+
+	if t.Elem.T == SliceTy {
+		if val.Len() > 0 {
+			return sliceTypeCheck(*t.Elem, val.Index(0))
+		}
+	} else if t.Elem.T == ArrayTy {
+		return sliceTypeCheck(*t.Elem, val.Index(0))
+	}
+
+	if elemKind := val.Type().Elem().Kind(); elemKind != t.Elem.Kind {
+		return typeErr(formatSliceString(t.Elem.Kind, t.Size), val.Type())
+	}
+	return nil
+}
+
+// typeCheck checks that the given reflection value can be assigned to the reflection
+// type in t.
+func typeCheck(t Type, value reflect.Value) error {
+	if t.T == SliceTy || t.T == ArrayTy {
+		return sliceTypeCheck(t, value)
+	}
+
+	// Check base type validity. Element types will be checked later on.
+	if t.Kind != value.Kind() {
+		return typeErr(t.Kind, value.Kind())
+	} else if t.T == FixedBytesTy && t.Size != value.Len() {
+		return typeErr(t.Type, value.Type())
+	} else {
+		return nil
+	}
+
+}
+
+// typeErr returns a formatted type casting error.
+func typeErr(expected, got interface{}) error {
+	return fmt.Errorf("abi: cannot use %v as type %v as argument", got, expected)
+}

--- a/abi/event.go
+++ b/abi/event.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Event is an event potentially triggered by the EVM's LOG mechanism. The Event
+// holds type information (inputs) about the yielded output. Anonymous events
+// don't get the signature canonical representation as the first LOG topic.
+type Event struct {
+	Name      string
+	Anonymous bool
+	Inputs    Arguments
+}
+
+func (e Event) String() string {
+	inputs := make([]string, len(e.Inputs))
+	for i, input := range e.Inputs {
+		inputs[i] = fmt.Sprintf("%v %v", input.Name, input.Type)
+		if input.Indexed {
+			inputs[i] = fmt.Sprintf("%v indexed %v", input.Name, input.Type)
+		}
+	}
+	return fmt.Sprintf("e %v(%v)", e.Name, strings.Join(inputs, ", "))
+}
+
+// Id returns the canonical representation of the event's signature used by the
+// abi definition to identify event names and types.
+func (e Event) Id() common.Hash {
+	types := make([]string, len(e.Inputs))
+	i := 0
+	for _, input := range e.Inputs {
+		types[i] = input.Type.String()
+		i++
+	}
+	return common.BytesToHash(crypto.Keccak256([]byte(fmt.Sprintf("%v(%v)", e.Name, strings.Join(types, ",")))))
+}

--- a/abi/method.go
+++ b/abi/method.go
@@ -1,0 +1,79 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Method represents a callable given a `Name` and whether the method is a constant.
+// If the method is `Const` no transaction needs to be created for this
+// particular Method call. It can easily be simulated using a local VM.
+// For example a `Balance()` method only needs to retrieve something
+// from the storage and therefor requires no Tx to be send to the
+// network. A method such as `Transact` does require a Tx and thus will
+// be flagged `true`.
+// Input specifies the required input parameters for this gives method.
+type Method struct {
+	Name    string
+	Const   bool
+	Inputs  Arguments
+	Outputs Arguments
+}
+
+// Sig returns the methods string signature according to the ABI spec.
+//
+// Example
+//
+//     function foo(uint32 a, int b)    =    "foo(uint32,int256)"
+//
+// Please note that "int" is substitute for its canonical representation "int256"
+func (method Method) Sig() string {
+	types := make([]string, len(method.Inputs))
+	i := 0
+	for _, input := range method.Inputs {
+		types[i] = input.Type.String()
+		i++
+	}
+	return fmt.Sprintf("%v(%v)", method.Name, strings.Join(types, ","))
+}
+
+func (method Method) String() string {
+	inputs := make([]string, len(method.Inputs))
+	for i, input := range method.Inputs {
+		inputs[i] = fmt.Sprintf("%v %v", input.Name, input.Type)
+	}
+	outputs := make([]string, len(method.Outputs))
+	for i, output := range method.Outputs {
+		if len(output.Name) > 0 {
+			outputs[i] = fmt.Sprintf("%v ", output.Name)
+		}
+		outputs[i] += output.Type.String()
+	}
+	constant := ""
+	if method.Const {
+		constant = "constant "
+	}
+	return fmt.Sprintf("function %v(%v) %sreturns(%v)", method.Name, strings.Join(inputs, ", "), constant, strings.Join(outputs, ", "))
+}
+
+func (method Method) Id() []byte {
+	return crypto.Keccak256([]byte(method.Sig()))[:4]
+}

--- a/abi/numbers.go
+++ b/abi/numbers.go
@@ -1,0 +1,59 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+var (
+	bigT      = reflect.TypeOf(&big.Int{})
+	derefbigT = reflect.TypeOf(big.Int{})
+	uint8T    = reflect.TypeOf(uint8(0))
+	uint16T   = reflect.TypeOf(uint16(0))
+	uint32T   = reflect.TypeOf(uint32(0))
+	uint64T   = reflect.TypeOf(uint64(0))
+	intT      = reflect.TypeOf(int(0))
+	int8T     = reflect.TypeOf(int8(0))
+	int16T    = reflect.TypeOf(int16(0))
+	int32T    = reflect.TypeOf(int32(0))
+	int64T    = reflect.TypeOf(int64(0))
+	addressT  = reflect.TypeOf(common.Address{})
+	intTS     = reflect.TypeOf([]int(nil))
+	int8TS    = reflect.TypeOf([]int8(nil))
+	int16TS   = reflect.TypeOf([]int16(nil))
+	int32TS   = reflect.TypeOf([]int32(nil))
+	int64TS   = reflect.TypeOf([]int64(nil))
+)
+
+// U256 converts a big Int into a 256bit EVM number.
+func U256(n *big.Int) []byte {
+	return math.PaddedBigBytes(math.U256(n), 32)
+}
+
+// checks whether the given reflect value is signed. This also works for slices with a number type
+func isSigned(v reflect.Value) bool {
+	switch v.Type() {
+	case intTS, int8TS, int16TS, int32TS, int64TS, intT, int8T, int16T, int32T, int64T:
+		return true
+	}
+	return false
+}

--- a/abi/pack.go
+++ b/abi/pack.go
@@ -1,0 +1,81 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+// packBytesSlice packs the given bytes as [L, V] as the canonical representation
+// bytes slice
+func packBytesSlice(bytes []byte, l int) []byte {
+	len := packNum(reflect.ValueOf(l))
+	return append(len, common.RightPadBytes(bytes, (l+31)/32*32)...)
+}
+
+// packElement packs the given reflect value according to the abi specification in
+// t.
+func packElement(t Type, reflectValue reflect.Value) []byte {
+	switch t.T {
+	case IntTy, UintTy:
+		return packNum(reflectValue)
+	case StringTy:
+		return packBytesSlice([]byte(reflectValue.String()), reflectValue.Len())
+	case AddressTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+
+		return common.LeftPadBytes(reflectValue.Bytes(), 32)
+	case BoolTy:
+		if reflectValue.Bool() {
+			return math.PaddedBigBytes(common.Big1, 32)
+		}
+		return math.PaddedBigBytes(common.Big0, 32)
+	case BytesTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+		return packBytesSlice(reflectValue.Bytes(), reflectValue.Len())
+	case FixedBytesTy, FunctionTy:
+		if reflectValue.Kind() == reflect.Array {
+			reflectValue = mustArrayToByteSlice(reflectValue)
+		}
+		return common.RightPadBytes(reflectValue.Bytes(), 32)
+	default:
+		panic("abi: fatal error")
+	}
+}
+
+// packNum packs the given number (using the reflect value) and will cast it to appropriate number representation
+func packNum(value reflect.Value) []byte {
+	switch kind := value.Kind(); kind {
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return U256(new(big.Int).SetUint64(value.Uint()))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return U256(big.NewInt(value.Int()))
+	case reflect.Ptr:
+		return U256(value.Interface().(*big.Int))
+	default:
+		panic("abi: fatal error")
+	}
+
+}

--- a/abi/reflect.go
+++ b/abi/reflect.go
@@ -1,0 +1,212 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// indirect recursively dereferences the value until it either gets the value
+// or finds a big.Int
+func indirect(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Ptr && v.Elem().Type() != derefbigT {
+		return indirect(v.Elem())
+	}
+	return v
+}
+
+// reflectIntKind returns the reflect using the given size and
+// unsignedness.
+func reflectIntKindAndType(unsigned bool, size int) (reflect.Kind, reflect.Type) {
+	switch size {
+	case 8:
+		if unsigned {
+			return reflect.Uint8, uint8T
+		}
+		return reflect.Int8, int8T
+	case 16:
+		if unsigned {
+			return reflect.Uint16, uint16T
+		}
+		return reflect.Int16, int16T
+	case 32:
+		if unsigned {
+			return reflect.Uint32, uint32T
+		}
+		return reflect.Int32, int32T
+	case 64:
+		if unsigned {
+			return reflect.Uint64, uint64T
+		}
+		return reflect.Int64, int64T
+	}
+	return reflect.Ptr, bigT
+}
+
+// mustArrayToBytesSlice creates a new byte slice with the exact same size as value
+// and copies the bytes in value to the new slice.
+func mustArrayToByteSlice(value reflect.Value) reflect.Value {
+	slice := reflect.MakeSlice(reflect.TypeOf([]byte{}), value.Len(), value.Len())
+	reflect.Copy(slice, value)
+	return slice
+}
+
+// set attempts to assign src to dst by either setting, copying or otherwise.
+//
+// set is a bit more lenient when it comes to assignment and doesn't force an as
+// strict ruleset as bare `reflect` does.
+func set(dst, src reflect.Value, output Argument) error {
+	dstType := dst.Type()
+	srcType := src.Type()
+	switch {
+	case dstType.AssignableTo(srcType):
+		dst.Set(src)
+	case dstType.Kind() == reflect.Interface:
+		dst.Set(src)
+	case dstType.Kind() == reflect.Ptr:
+		return set(dst.Elem(), src, output)
+	default:
+		return fmt.Errorf("abi: cannot unmarshal %v in to %v", src.Type(), dst.Type())
+	}
+	return nil
+}
+
+// requireAssignable assures that `dest` is a pointer and it's not an interface.
+func requireAssignable(dst, src reflect.Value) error {
+	if dst.Kind() != reflect.Ptr && dst.Kind() != reflect.Interface {
+		return fmt.Errorf("abi: cannot unmarshal %v into %v", src.Type(), dst.Type())
+	}
+	return nil
+}
+
+// requireUnpackKind verifies preconditions for unpacking `args` into `kind`
+func requireUnpackKind(v reflect.Value, t reflect.Type, k reflect.Kind,
+	args Arguments) error {
+
+	switch k {
+	case reflect.Struct:
+	case reflect.Slice, reflect.Array:
+		if minLen := args.LengthNonIndexed(); v.Len() < minLen {
+			return fmt.Errorf("abi: insufficient number of elements in the list/array for unpack, want %d, got %d",
+				minLen, v.Len())
+		}
+	default:
+		return fmt.Errorf("abi: cannot unmarshal tuple into %v", t)
+	}
+	return nil
+}
+
+// mapAbiToStringField maps abi to struct fields.
+// first round: for each Exportable field that contains a `abi:""` tag
+//   and this field name exists in the arguments, pair them together.
+// second round: for each argument field that has not been already linked,
+//   find what variable is expected to be mapped into, if it exists and has not been
+//   used, pair them.
+func mapAbiToStructFields(args Arguments, value reflect.Value) (map[string]string, error) {
+
+	typ := value.Type()
+
+	abi2struct := make(map[string]string)
+	struct2abi := make(map[string]string)
+
+	// first round ~~~
+	for i := 0; i < typ.NumField(); i++ {
+		structFieldName := typ.Field(i).Name
+
+		// skip private struct fields.
+		if structFieldName[:1] != strings.ToUpper(structFieldName[:1]) {
+			continue
+		}
+
+		// skip fields that have no abi:"" tag.
+		var ok bool
+		var tagName string
+		if tagName, ok = typ.Field(i).Tag.Lookup("abi"); !ok {
+			continue
+		}
+
+		// check if tag is empty.
+		if tagName == "" {
+			return nil, fmt.Errorf("struct: abi tag in '%s' is empty", structFieldName)
+		}
+
+		// check which argument field matches with the abi tag.
+		found := false
+		for _, abiField := range args.NonIndexed() {
+			if abiField.Name == tagName {
+				if abi2struct[abiField.Name] != "" {
+					return nil, fmt.Errorf("struct: abi tag in '%s' already mapped", structFieldName)
+				}
+				// pair them
+				abi2struct[abiField.Name] = structFieldName
+				struct2abi[structFieldName] = abiField.Name
+				found = true
+			}
+		}
+
+		// check if this tag has been mapped.
+		if !found {
+			return nil, fmt.Errorf("struct: abi tag '%s' defined but not found in abi", tagName)
+		}
+
+	}
+
+	// second round ~~~
+	for _, arg := range args {
+
+		abiFieldName := arg.Name
+		structFieldName := capitalise(abiFieldName)
+
+		if structFieldName == "" {
+			return nil, fmt.Errorf("abi: purely underscored output cannot unpack to struct")
+		}
+
+		// this abi has already been paired, skip it... unless there exists another, yet unassigned
+		// struct field with the same field name. If so, raise an error:
+		//    abi: [ { "name": "value" } ]
+		//    struct { Value  *big.Int , Value1 *big.Int `abi:"value"`}
+		if abi2struct[abiFieldName] != "" {
+			if abi2struct[abiFieldName] != structFieldName &&
+				struct2abi[structFieldName] == "" &&
+				value.FieldByName(structFieldName).IsValid() {
+				return nil, fmt.Errorf("abi: multiple variables maps to the same abi field '%s'", abiFieldName)
+			}
+			continue
+		}
+
+		// return an error if this struct field has already been paired.
+		if struct2abi[structFieldName] != "" {
+			return nil, fmt.Errorf("abi: multiple outputs mapping to the same struct field '%s'", structFieldName)
+		}
+
+		if value.FieldByName(structFieldName).IsValid() {
+			// pair them
+			abi2struct[abiFieldName] = structFieldName
+			struct2abi[structFieldName] = abiFieldName
+		} else {
+			// not paired, but annotate as used, to detect cases like
+			//   abi : [ { "name": "value" }, { "name": "_value" } ]
+			//   struct { Value *big.Int }
+			struct2abi[structFieldName] = abiFieldName
+		}
+
+	}
+
+	return abi2struct, nil
+}

--- a/abi/type.go
+++ b/abi/type.go
@@ -1,0 +1,204 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Type enumerator
+const (
+	IntTy byte = iota
+	UintTy
+	BoolTy
+	StringTy
+	SliceTy
+	ArrayTy
+	AddressTy
+	FixedBytesTy
+	BytesTy
+	HashTy
+	FixedPointTy
+	FunctionTy
+)
+
+// Type is the reflection of the supported argument type
+type Type struct {
+	Elem *Type
+
+	Kind reflect.Kind
+	Type reflect.Type
+	Size int
+	T    byte // Our own type checking
+
+	stringKind string // holds the unparsed string for deriving signatures
+}
+
+var (
+	// typeRegex parses the abi sub types
+	typeRegex = regexp.MustCompile("([a-zA-Z]+)(([0-9]+)(x([0-9]+))?)?")
+)
+
+// NewType creates a new reflection type of abi type given in t.
+func NewType(t string) (typ Type, err error) {
+	// check that array brackets are equal if they exist
+	if strings.Count(t, "[") != strings.Count(t, "]") {
+		return Type{}, fmt.Errorf("invalid arg type in abi")
+	}
+
+	typ.stringKind = t
+
+	// if there are brackets, get ready to go into slice/array mode and
+	// recursively create the type
+	if strings.Count(t, "[") != 0 {
+		i := strings.LastIndex(t, "[")
+		// recursively embed the type
+		embeddedType, err := NewType(t[:i])
+		if err != nil {
+			return Type{}, err
+		}
+		// grab the last cell and create a type from there
+		sliced := t[i:]
+		// grab the slice size with regexp
+		re := regexp.MustCompile("[0-9]+")
+		intz := re.FindAllString(sliced, -1)
+
+		if len(intz) == 0 {
+			// is a slice
+			typ.T = SliceTy
+			typ.Kind = reflect.Slice
+			typ.Elem = &embeddedType
+			typ.Type = reflect.SliceOf(embeddedType.Type)
+		} else if len(intz) == 1 {
+			// is a array
+			typ.T = ArrayTy
+			typ.Kind = reflect.Array
+			typ.Elem = &embeddedType
+			typ.Size, err = strconv.Atoi(intz[0])
+			if err != nil {
+				return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
+			}
+			typ.Type = reflect.ArrayOf(typ.Size, embeddedType.Type)
+		} else {
+			return Type{}, fmt.Errorf("invalid formatting of array type")
+		}
+		return typ, err
+	}
+	// parse the type and size of the abi-type.
+	parsedType := typeRegex.FindAllStringSubmatch(t, -1)[0]
+	// varSize is the size of the variable
+	var varSize int
+	if len(parsedType[3]) > 0 {
+		var err error
+		varSize, err = strconv.Atoi(parsedType[2])
+		if err != nil {
+			return Type{}, fmt.Errorf("abi: error parsing variable size: %v", err)
+		}
+	} else {
+		if parsedType[0] == "uint" || parsedType[0] == "int" {
+			// this should fail because it means that there's something wrong with
+			// the abi type (the compiler should always format it to the size...always)
+			return Type{}, fmt.Errorf("unsupported arg type: %s", t)
+		}
+	}
+	// varType is the parsed abi type
+	switch varType := parsedType[1]; varType {
+	case "int":
+		typ.Kind, typ.Type = reflectIntKindAndType(false, varSize)
+		typ.Size = varSize
+		typ.T = IntTy
+	case "uint":
+		typ.Kind, typ.Type = reflectIntKindAndType(true, varSize)
+		typ.Size = varSize
+		typ.T = UintTy
+	case "bool":
+		typ.Kind = reflect.Bool
+		typ.T = BoolTy
+		typ.Type = reflect.TypeOf(bool(false))
+	case "address":
+		typ.Kind = reflect.Array
+		typ.Type = addressT
+		typ.Size = 20
+		typ.T = AddressTy
+	case "string":
+		typ.Kind = reflect.String
+		typ.Type = reflect.TypeOf("")
+		typ.T = StringTy
+	case "bytes":
+		if varSize == 0 {
+			typ.T = BytesTy
+			typ.Kind = reflect.Slice
+			typ.Type = reflect.SliceOf(reflect.TypeOf(byte(0)))
+		} else {
+			typ.T = FixedBytesTy
+			typ.Kind = reflect.Array
+			typ.Size = varSize
+			typ.Type = reflect.ArrayOf(varSize, reflect.TypeOf(byte(0)))
+		}
+	case "function":
+		typ.Kind = reflect.Array
+		typ.T = FunctionTy
+		typ.Size = 24
+		typ.Type = reflect.ArrayOf(24, reflect.TypeOf(byte(0)))
+	default:
+		return Type{}, fmt.Errorf("unsupported arg type: %s", t)
+	}
+
+	return
+}
+
+// String implements Stringer
+func (t Type) String() (out string) {
+	return t.stringKind
+}
+
+func (t Type) pack(v reflect.Value) ([]byte, error) {
+	// dereference pointer first if it's a pointer
+	v = indirect(v)
+
+	if err := typeCheck(t, v); err != nil {
+		return nil, err
+	}
+
+	if t.T == SliceTy || t.T == ArrayTy {
+		var packed []byte
+
+		for i := 0; i < v.Len(); i++ {
+			val, err := t.Elem.pack(v.Index(i))
+			if err != nil {
+				return nil, err
+			}
+			packed = append(packed, val...)
+		}
+		if t.T == SliceTy {
+			return packBytesSlice(packed, v.Len()), nil
+		} else if t.T == ArrayTy {
+			return packed, nil
+		}
+	}
+	return packElement(t, v), nil
+}
+
+// requireLengthPrefix returns whether the type requires any sort of length
+// prefixing.
+func (t Type) requiresLengthPrefix() bool {
+	return t.T == StringTy || t.T == BytesTy || t.T == SliceTy
+}

--- a/abi/unpack.go
+++ b/abi/unpack.go
@@ -1,0 +1,230 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package abi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// reads the integer based on its kind
+func readInteger(kind reflect.Kind, b []byte) interface{} {
+	switch kind {
+	case reflect.Uint8:
+		return b[len(b)-1]
+	case reflect.Uint16:
+		return binary.BigEndian.Uint16(b[len(b)-2:])
+	case reflect.Uint32:
+		return binary.BigEndian.Uint32(b[len(b)-4:])
+	case reflect.Uint64:
+		return binary.BigEndian.Uint64(b[len(b)-8:])
+	case reflect.Int8:
+		return int8(b[len(b)-1])
+	case reflect.Int16:
+		return int16(binary.BigEndian.Uint16(b[len(b)-2:]))
+	case reflect.Int32:
+		return int32(binary.BigEndian.Uint32(b[len(b)-4:]))
+	case reflect.Int64:
+		return int64(binary.BigEndian.Uint64(b[len(b)-8:]))
+	default:
+		return new(big.Int).SetBytes(b)
+	}
+}
+
+// reads a bool
+func readBool(word []byte) (bool, error) {
+	for _, b := range word[:31] {
+		if b != 0 {
+			return false, errBadBool
+		}
+	}
+	switch word[31] {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, errBadBool
+	}
+}
+
+// A function type is simply the address with the function selection signature at the end.
+// This enforces that standard by always presenting it as a 24-array (address + sig = 24 bytes)
+func readFunctionType(t Type, word []byte) (funcTy [24]byte, err error) {
+	if t.T != FunctionTy {
+		return [24]byte{}, fmt.Errorf("abi: invalid type in call to make function type byte array")
+	}
+	if garbage := binary.BigEndian.Uint64(word[24:32]); garbage != 0 {
+		err = fmt.Errorf("abi: got improperly encoded function type, got %v", word)
+	} else {
+		copy(funcTy[:], word[0:24])
+	}
+	return
+}
+
+// through reflection, creates a fixed array to be read from
+func readFixedBytes(t Type, word []byte) (interface{}, error) {
+	if t.T != FixedBytesTy {
+		return nil, fmt.Errorf("abi: invalid type in call to make fixed byte array")
+	}
+	// convert
+	array := reflect.New(t.Type).Elem()
+
+	reflect.Copy(array, reflect.ValueOf(word[0:t.Size]))
+	return array.Interface(), nil
+
+}
+
+func getFullElemSize(elem *Type) int {
+	//all other should be counted as 32 (slices have pointers to respective elements)
+	size := 32
+	//arrays wrap it, each element being the same size
+	for elem.T == ArrayTy {
+		size *= elem.Size
+		elem = elem.Elem
+	}
+	return size
+}
+
+// iteratively unpack elements
+func forEachUnpack(t Type, output []byte, start, size int) (interface{}, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("cannot marshal input to array, size is negative (%d)", size)
+	}
+	if start+32*size > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go array: offset %d would go over slice boundary (len=%d)", len(output), start+32*size)
+	}
+
+	// this value will become our slice or our array, depending on the type
+	var refSlice reflect.Value
+
+	if t.T == SliceTy {
+		// declare our slice
+		refSlice = reflect.MakeSlice(t.Type, size, size)
+	} else if t.T == ArrayTy {
+		// declare our array
+		refSlice = reflect.New(t.Type).Elem()
+	} else {
+		return nil, fmt.Errorf("abi: invalid type in array/slice unpacking stage")
+	}
+
+	// Arrays have packed elements, resulting in longer unpack steps.
+	// Slices have just 32 bytes per element (pointing to the contents).
+	elemSize := 32
+	if t.T == ArrayTy {
+		elemSize = getFullElemSize(t.Elem)
+	}
+
+	for i, j := start, 0; j < size; i, j = i+elemSize, j+1 {
+
+		inter, err := toGoType(i, *t.Elem, output)
+		if err != nil {
+			return nil, err
+		}
+
+		// append the item to our reflect slice
+		refSlice.Index(j).Set(reflect.ValueOf(inter))
+	}
+
+	// return the interface
+	return refSlice.Interface(), nil
+}
+
+// toGoType parses the output bytes and recursively assigns the value of these bytes
+// into a go type with accordance with the ABI spec.
+func toGoType(index int, t Type, output []byte) (interface{}, error) {
+	if index+32 > len(output) {
+		return nil, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %d require %d", len(output), index+32)
+	}
+
+	var (
+		returnOutput []byte
+		begin, end   int
+		err          error
+	)
+
+	// if we require a length prefix, find the beginning word and size returned.
+	if t.requiresLengthPrefix() {
+		begin, end, err = lengthPrefixPointsTo(index, output)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		returnOutput = output[index : index+32]
+	}
+
+	switch t.T {
+	case SliceTy:
+		return forEachUnpack(t, output, begin, end)
+	case ArrayTy:
+		return forEachUnpack(t, output, index, t.Size)
+	case StringTy: // variable arrays are written at the end of the return bytes
+		return string(output[begin : begin+end]), nil
+	case IntTy, UintTy:
+		return readInteger(t.Kind, returnOutput), nil
+	case BoolTy:
+		return readBool(returnOutput)
+	case AddressTy:
+		return common.BytesToAddress(returnOutput), nil
+	case HashTy:
+		return common.BytesToHash(returnOutput), nil
+	case BytesTy:
+		return output[begin : begin+end], nil
+	case FixedBytesTy:
+		return readFixedBytes(t, returnOutput)
+	case FunctionTy:
+		return readFunctionType(t, returnOutput)
+	default:
+		return nil, fmt.Errorf("abi: unknown type %v", t.T)
+	}
+}
+
+// interprets a 32 byte slice as an offset and then determines which indice to look to decode the type.
+func lengthPrefixPointsTo(index int, output []byte) (start int, length int, err error) {
+	bigOffsetEnd := big.NewInt(0).SetBytes(output[index : index+32])
+	bigOffsetEnd.Add(bigOffsetEnd, common.Big32)
+	outputLength := big.NewInt(int64(len(output)))
+
+	if bigOffsetEnd.Cmp(outputLength) > 0 {
+		return 0, 0, fmt.Errorf("abi: cannot marshal in to go slice: offset %v would go over slice boundary (len=%v)", bigOffsetEnd, outputLength)
+	}
+
+	if bigOffsetEnd.BitLen() > 63 {
+		return 0, 0, fmt.Errorf("abi offset larger than int64: %v", bigOffsetEnd)
+	}
+
+	offsetEnd := int(bigOffsetEnd.Uint64())
+	lengthBig := big.NewInt(0).SetBytes(output[offsetEnd-32 : offsetEnd])
+
+	totalSize := big.NewInt(0)
+	totalSize.Add(totalSize, bigOffsetEnd)
+	totalSize.Add(totalSize, lengthBig)
+	if totalSize.BitLen() > 63 {
+		return 0, 0, fmt.Errorf("abi length larger than int64: %v", totalSize)
+	}
+
+	if totalSize.Cmp(outputLength) > 0 {
+		return 0, 0, fmt.Errorf("abi: cannot marshal in to go type: length insufficient %v require %v", outputLength, totalSize)
+	}
+	start = int(bigOffsetEnd.Uint64())
+	length = int(lengthBig.Uint64())
+	return
+}

--- a/contract_function_selector.go
+++ b/contract_function_selector.go
@@ -589,6 +589,8 @@ func (selector *ContractFunctionSelector) AddUint248() *ContractFunctionSelector
 	})
 }
 
+//For better usage you may use abi package
+//example: bytes := abi.U256(big.NewInt(some number))
 func (selector *ContractFunctionSelector) AddUint256() *ContractFunctionSelector {
 	return selector._AddParam(_Solidity{
 		ty:    aUint256,


### PR DESCRIPTION
**Description**: Added abi package from go ethereum. It needs to use it for converting big.Int into uint256. See my issue for understanding problem.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**: https://github.com/hashgraph/hedera-sdk-go/issues/534

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
