### PR TITLE
Revert NewAccountBalanceQuery deprecation

### DIFF
--- a/account_balance.go
+++ b/account_balance.go
@@ -40,9 +40,20 @@ func _AccountBalanceFromProtobuf(pb *services.CryptoGetAccountBalanceResponse) A
 	if pb == nil {
 		return AccountBalance{}
 	}
-
+	var tokens map[TokenID]uint64
+	if pb.TokenBalances != nil {
+		tokens = make(map[TokenID]uint64, len(pb.TokenBalances))
+		for _, token := range pb.TokenBalances {
+			if t := _TokenIDFromProtobuf(token.TokenId); t != nil {
+				tokens[*t] = token.Balance
+			}
+		}
+	}
 	return AccountBalance{
-		Hbars: HbarFromTinybar(int64(pb.Balance)),
+		Hbars:         HbarFromTinybar(int64(pb.Balance)),
+		Token:         tokens,
+		Tokens:        _TokenBalanceMapFromProtobuf(pb.TokenBalances),
+		TokenDecimals: _TokenDecimalMapFromProtobuf(pb.TokenBalances),
 	}
 }
 

--- a/token_balance_map.go
+++ b/token_balance_map.go
@@ -19,6 +19,9 @@ package hedera
  * limitations under the License.
  *
  */
+import (
+	"github.com/hashgraph/hedera-protobufs-go/services"
+)
 
 type TokenBalanceMap struct {
 	balances map[string]uint64
@@ -30,4 +33,30 @@ func (tokenBalances *TokenBalanceMap) Get(tokenID TokenID) uint64 {
 		Realm: tokenID.Realm,
 		Token: tokenID.Token,
 	}.String()]
+}
+func _TokenBalanceMapFromProtobuf(pb []*services.TokenBalance) TokenBalanceMap {
+	balances := make(map[string]uint64)
+
+	for _, tokenBalance := range pb {
+		balances[_TokenIDFromProtobuf(tokenBalance.TokenId).String()] = tokenBalance.Balance
+	}
+
+	return TokenBalanceMap{balances}
+}
+
+func (tokenBalances *TokenBalanceMap) _ToProtobuf() []*services.TokenBalance { // nolint
+	decimals := make([]*services.TokenBalance, 0)
+
+	for s, t := range tokenBalances.balances {
+		token, err := TokenIDFromString(s)
+		if err != nil {
+			return []*services.TokenBalance{}
+		}
+		decimals = append(decimals, &services.TokenBalance{
+			TokenId: token._ToProtobuf(),
+			Balance: t,
+		})
+	}
+
+	return decimals
 }

--- a/token_decimal_map.go
+++ b/token_decimal_map.go
@@ -19,6 +19,9 @@ package hedera
  * limitations under the License.
  *
  */
+import (
+	"github.com/hashgraph/hedera-protobufs-go/services"
+)
 
 type TokenDecimalMap struct {
 	decimals map[string]uint64
@@ -30,4 +33,31 @@ func (tokenDecimals *TokenDecimalMap) Get(tokenID TokenID) uint64 {
 		Realm: tokenID.Realm,
 		Token: tokenID.Token,
 	}.String()]
+}
+
+func _TokenDecimalMapFromProtobuf(pb []*services.TokenBalance) TokenDecimalMap {
+	decimals := make(map[string]uint64)
+
+	for _, tokenDecimal := range pb {
+		decimals[_TokenIDFromProtobuf(tokenDecimal.TokenId).String()] = uint64(tokenDecimal.Decimals)
+	}
+
+	return TokenDecimalMap{decimals}
+}
+
+func (tokenDecimals TokenDecimalMap) _ToProtobuf() []*services.TokenBalance { // nolint
+	decimals := make([]*services.TokenBalance, 0)
+
+	for s, t := range tokenDecimals.decimals {
+		token, err := TokenIDFromString(s)
+		if err != nil {
+			return []*services.TokenBalance{}
+		}
+		decimals = append(decimals, &services.TokenBalance{
+			TokenId:  token._ToProtobuf(),
+			Decimals: uint32(t),
+		})
+	}
+
+	return decimals
 }


### PR DESCRIPTION
**Description**:

The NewAccountBallanceQuery was depricated by mistake, this PR reverts this. 

This PR modifies:
  account_balance.go
  token_balance_map.go
  token_decimal_map.go

**Related issue(s)**:

Fixes # [589](https://github.com/hashgraph/hedera-sdk-go/issues/589)

