### PR TITLE
Bump github actions and Go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Vet Examples
         run: go vet ./examples/...
@@ -37,14 +37,14 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - run: go test -tags="unit" -v -timeout 9999s
 
@@ -56,4 +56,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.50

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,14 +55,14 @@ jobs:
         working-directory: hedera-services
         run: docker build -t services-node:$TAG .
 
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Fetch Hedera SDK
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: hedera-sdk-go
 

--- a/.github/workflows/previewnet.yml
+++ b/.github/workflows/previewnet.yml
@@ -14,14 +14,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Vet Examples
         run: go vet ./examples/...
@@ -30,9 +30,9 @@ jobs:
         run: go vet .
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.50
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -13,14 +13,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Vet Examples
         run: go vet ./examples/...
@@ -35,10 +35,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
@@ -50,8 +50,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.50


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:

Currently all builds are failing mainly because of the Go version not being supported anymore.
This PR modifies the workflow files to fix the builds. 
