### PR TITLE
Fixed the 10 seconds blocking on creating a Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.17.7
+
+### Fixed
+
+* 10 seconds blocking on creating a `Client`
+
 ## v2.17.6
 
 ### Fixed

--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -218,9 +218,7 @@ func _NewMockClient() (*Client, error) {
 	var net = make(map[string]AccountID)
 	net["nonexistent-testnet:56747"] = AccountID{Account: 3}
 
-	client := ClientForTestnet()
-	client.SetMirrorNetwork([]string{})
-	client.SetNetwork(net)
+	client := ClientForNetwork(net)
 	client.SetOperator(AccountID{Account: 2}, privateKey)
 
 	return client, nil


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:

There was a 10 seconds blocking when creating a new Client. This PR removes the blocking.


**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/579

**Notes for reviewer**:
Added the use of context.Context in Client.go. For custom networks /i.e. not mainnnet, testnet, previewnet/ the network update is off by default, because there are no mirror nodes to update.


