### PR TITLE
Fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -18,12 +17,9 @@ linters:
     - ineffassign
     - misspell
     - nakedret
-    - scopelint
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace

--- a/account_balance.go
+++ b/account_balance.go
@@ -41,9 +41,9 @@ func _AccountBalanceFromProtobuf(pb *services.CryptoGetAccountBalanceResponse) A
 		return AccountBalance{}
 	}
 	var tokens map[TokenID]uint64
-	if pb.TokenBalances != nil {
-		tokens = make(map[TokenID]uint64, len(pb.TokenBalances))
-		for _, token := range pb.TokenBalances {
+	if pb.TokenBalances != nil { //nolint
+		tokens = make(map[TokenID]uint64, len(pb.TokenBalances))//nolint
+		for _, token := range pb.TokenBalances { //nolint
 			if t := _TokenIDFromProtobuf(token.TokenId); t != nil {
 				tokens[*t] = token.Balance
 			}
@@ -52,8 +52,8 @@ func _AccountBalanceFromProtobuf(pb *services.CryptoGetAccountBalanceResponse) A
 	return AccountBalance{
 		Hbars:         HbarFromTinybar(int64(pb.Balance)),
 		Token:         tokens,
-		Tokens:        _TokenBalanceMapFromProtobuf(pb.TokenBalances),
-		TokenDecimals: _TokenDecimalMapFromProtobuf(pb.TokenBalances),
+		Tokens:        _TokenBalanceMapFromProtobuf(pb.TokenBalances),//nolint
+		TokenDecimals: _TokenDecimalMapFromProtobuf(pb.TokenBalances),//nolint
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 )
@@ -315,7 +315,7 @@ func ClientFromConfigFile(filename string) (*Client, error) {
 		err = file.Close()
 	}()
 
-	configBytes, err := ioutil.ReadAll(file)
+	configBytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/contract_function_parameters.go
+++ b/contract_function_parameters.go
@@ -31,7 +31,7 @@ import (
 // Use the builder methods `Add<Type>()` to add a parameter. Not all solidity types
 // are supported out of the box, but the most common types are. The larger variants
 // of number types require the parameter to be `[]byte`. This is a little unintuitive,
-// so here is an exmaple of how to use those larger number variants using
+// so here is an example of how to use those larger number variants using
 // "github.com/ethereum/go-ethereum/common/math" and "math/big"
 // ```
 // AddUint88(math.PaddedBigBytes(n, 88 / 8))

--- a/ed25519_private_key.go
+++ b/ed25519_private_key.go
@@ -29,7 +29,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/hashgraph/hedera-protobufs-go/services"
@@ -172,7 +171,7 @@ func _Ed25519PrivateKeyFromKeystore(ks []byte, passphrase string) (*_Ed25519Priv
 
 // PrivateKeyReadKeystore recovers an _Ed25519PrivateKey from an encrypted _Keystore file.
 func _Ed25519PrivateKeyReadKeystore(source io.Reader, passphrase string) (*_Ed25519PrivateKey, error) {
-	keystoreBytes, err := ioutil.ReadAll(source)
+	keystoreBytes, err := io.ReadAll(source)
 	if err != nil {
 		return &_Ed25519PrivateKey{}, err
 	}
@@ -230,7 +229,7 @@ func _Ed25519PrivateKeyReadPem(source io.Reader, passphrase string) (*_Ed25519Pr
 	// note: Passphrases are currently not supported, but included in the function definition to avoid breaking
 	// changes in the future.
 
-	pemFileBytes, err := ioutil.ReadAll(source)
+	pemFileBytes, err := io.ReadAll(source)
 	if err != nil {
 		return &_Ed25519PrivateKey{}, err
 	}

--- a/examples/create_simple_contract/main.go
+++ b/examples/create_simple_contract/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashgraph/hedera-sdk-go/v2"
@@ -56,7 +55,7 @@ func main() {
 	}()
 
 	// R contents from hello_world.json file
-	rawContract, err := ioutil.ReadFile("./hello_world.json")
+	rawContract, err := os.ReadFile("./hello_world.json")
 	if err != nil {
 		println(err.Error(), ": error reading hello_world.json")
 		return

--- a/examples/create_stateful_contract/main.go
+++ b/examples/create_stateful_contract/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashgraph/hedera-sdk-go/v2"
@@ -57,7 +56,7 @@ func main() {
 	}()
 
 	// Read in the compiled contract from stateful.json
-	rawSmartContract, err := ioutil.ReadFile("./stateful.json")
+	rawSmartContract, err := os.ReadFile("./stateful.json")
 	if err != nil {
 		println(err.Error(), ": error reading stateful.json")
 		return

--- a/examples/zero_token_operations/main.go
+++ b/examples/zero_token_operations/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/hashgraph/hedera-sdk-go/v2"
 	"github.com/hashgraph/hedera-sdk-go/v2/examples/contract_helper"
-	"io/ioutil"
 	"os"
 )
 
@@ -75,7 +74,7 @@ func main() {
 	//Submit the transaction to a Hedera network
 	transaction.Execute(client)
 
-	rawContract, err := ioutil.ReadFile("../precompile_example/ZeroTokenOperations.json")
+	rawContract, err := os.ReadFile("../precompile_example/ZeroTokenOperations.json")
 	if err != nil {
 		println(err.Error(), ": error reading json")
 		return

--- a/file_append_transaction.go
+++ b/file_append_transaction.go
@@ -22,7 +22,6 @@ package hedera
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/hashgraph/hedera-protobufs-go/services"
@@ -362,7 +361,7 @@ func (transaction *FileAppendTransaction) FreezeWith(client *Client) (*FileAppen
 	}
 	body := transaction._Build()
 
-	chunks := uint64(math.Floor(float64((len(transaction.contents) + (transaction.chunkSize - 1)) / transaction.chunkSize)))
+	chunks := uint64((len(transaction.contents) + (transaction.chunkSize - 1)) / transaction.chunkSize)
 	if chunks > transaction.maxChunks {
 		return transaction, ErrMaxChunksExceeded{
 			Chunks:    chunks,

--- a/managed_network.go
+++ b/managed_network.go
@@ -119,10 +119,6 @@ func (this *_ManagedNetwork) _ReadmitNodes() {
 		}
 	}
 
-	if nextEarliestReadmitTime.Before(now.Add(this.minNodeReadmitPeriod)) {
-		nextEarliestReadmitTime = now.Add(this.minNodeReadmitPeriod)
-	}
-
 outer:
 	for _, node := range this.nodes {
 		for _, healthyNode := range this.healthyNodes {

--- a/token_associate_transaction.go
+++ b/token_associate_transaction.go
@@ -116,10 +116,7 @@ func (transaction *TokenAssociateTransaction) GetAccountID() AccountID {
 func (transaction *TokenAssociateTransaction) SetTokenIDs(ids ...TokenID) *TokenAssociateTransaction {
 	transaction._RequireNotFrozen()
 	transaction.tokens = make([]TokenID, len(ids))
-
-	for i, tokenID := range ids {
-		transaction.tokens[i] = tokenID
-	}
+	copy(transaction.tokens, ids)
 
 	return transaction
 }
@@ -138,10 +135,7 @@ func (transaction *TokenAssociateTransaction) AddTokenID(id TokenID) *TokenAssoc
 
 func (transaction *TokenAssociateTransaction) GetTokenIDs() []TokenID {
 	tokenIDs := make([]TokenID, len(transaction.tokens))
-
-	for i, tokenID := range transaction.tokens {
-		tokenIDs[i] = tokenID
-	}
+	copy(tokenIDs, transaction.tokens)
 
 	return tokenIDs
 }

--- a/token_dissociate_transaction.go
+++ b/token_dissociate_transaction.go
@@ -111,10 +111,7 @@ func (transaction *TokenDissociateTransaction) GetAccountID() AccountID {
 func (transaction *TokenDissociateTransaction) SetTokenIDs(ids ...TokenID) *TokenDissociateTransaction {
 	transaction._RequireNotFrozen()
 	transaction.tokens = make([]TokenID, len(ids))
-
-	for i, tokenID := range ids {
-		transaction.tokens[i] = tokenID
-	}
+	copy(transaction.tokens, ids)
 
 	return transaction
 }
@@ -133,10 +130,7 @@ func (transaction *TokenDissociateTransaction) AddTokenID(id TokenID) *TokenDiss
 
 func (transaction *TokenDissociateTransaction) GetTokenIDs() []TokenID {
 	tokenIDs := make([]TokenID, len(transaction.tokens))
-
-	for i, tokenID := range transaction.tokens {
-		tokenIDs[i] = tokenID
-	}
+	copy(tokenIDs, transaction.tokens)
 
 	return tokenIDs
 }


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:

This PR contains only fixes for lint errors. 

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/609

**Notes for reviewer**:
1. Modifies `.golangci.yml` to remove warnings for deprecated checks. Those checks are being done by `unused` check. 
2. There was a redundant `if` statement in `managed_network.go`, the logic of this file will be reviewed and eventually refactored.  
3. Added some `//no lint` for the deprecated `pb.TokenBalances`. This functionality will be removed, once we have it released to mainnet. so it isn't exactly deprecated yet.
4. The rest of the files are just following lint recommendations. 

