### PR TITLE
Fix panic in address book query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `CustomFee.AllCollectorsAreExempt`
 
+### Fixed
+
+* Addressbook Query no logner panics
+
 ## v2.17.7
 
 ### Added

--- a/address_book_query.go
+++ b/address_book_query.go
@@ -110,7 +110,7 @@ func (query *AddressBookQuery) _Build() *mirror.AddressBookQuery {
 func (query *AddressBookQuery) Execute(client *Client) (NodeAddressBook, error) {
 	var cancel func()
 	var ctx context.Context
-
+	var subClientError error
 	err := query._ValidateNetworkOnIDs(client)
 	if err != nil {
 		return NodeAddressBook{}, err
@@ -142,12 +142,14 @@ func (query *AddressBookQuery) Execute(client *Client) (NodeAddressBook, error) 
 						time.Sleep(time.Duration(delay) * time.Millisecond)
 						query.attempt++
 					} else {
-						panic(grpcErr.Err())
+						subClientError = grpcErr.Err()
+						break
 					}
 				} else if err == io.EOF {
 					break
 				} else {
-					panic(err)
+					subClientError = err
+					break
 				}
 			}
 
@@ -185,5 +187,5 @@ func (query *AddressBookQuery) Execute(client *Client) (NodeAddressBook, error) 
 
 	return NodeAddressBook{
 		NodeAddresses: result,
-	}, nil
+	}, subClientError
 }

--- a/client.go
+++ b/client.go
@@ -157,8 +157,8 @@ func (client *Client) _ScheduleNetworkUpdate(ctx context.Context, duration time.
 			Execute(client)
 		if err == nil && len(addressbook.NodeAddresses) > 0 {
 			client.SetNetworkFromAddressBook(addressbook)
-			client._ScheduleNetworkUpdate(ctx, client.defaultNetworkUpdatePeriod)
 		}
+		client._ScheduleNetworkUpdate(ctx, client.defaultNetworkUpdatePeriod)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:

This PR modifies removes the panic when there is an error getting the address book from mirror node.
It should now just return an error.


**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/625
