### PR TITLE
Fix schedule network recursive call

### DIFF
--- a/address_book_query.go
+++ b/address_book_query.go
@@ -154,7 +154,7 @@ func (query *AddressBookQuery) Execute(client *Client) (NodeAddressBook, error) 
 			}
 
 			if subClient == nil {
-				ctx, cancel = context.WithCancel(context.TODO())
+				ctx, cancel = context.WithCancel(client.networkUpdateContext)
 
 				subClient, err = (*channel).GetNodes(ctx, pb)
 				if err != nil {

--- a/client.go
+++ b/client.go
@@ -97,7 +97,7 @@ func ClientForNetwork(network map[string]AccountID) *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForMainnet() *Client {
-	return _NewClient(*_NetworkForTestnet(mainnetNodes._ToMap()), mainnetMirror, NetworkNameMainnet)
+	return _NewClient(*_NetworkForMainnet(mainnetNodes._ToMap()), mainnetMirror, NetworkNameMainnet)
 }
 
 // ClientForTestnet returns a preconfigured client for use with the standard
@@ -105,7 +105,7 @@ func ClientForMainnet() *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForTestnet() *Client {
-	return _NewClient(*_NetworkForPreviewnet(testnetNodes._ToMap()), testnetMirror, NetworkNameTestnet)
+	return _NewClient(*_NetworkForTestnet(testnetNodes._ToMap()), testnetMirror, NetworkNameTestnet)
 }
 
 // ClientForPreviewnet returns a preconfigured client for use with the standard
@@ -113,7 +113,7 @@ func ClientForTestnet() *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForPreviewnet() *Client {
-	return _NewClient(*_NetworkForMainnet(previewnetNodes._ToMap()), previewnetMirror, NetworkNamePreviewnet)
+	return _NewClient(*_NetworkForPreviewnet(previewnetNodes._ToMap()), previewnetMirror, NetworkNamePreviewnet)
 }
 
 // newClient takes in a map of _Node addresses to their respective IDS (_Network)
@@ -140,7 +140,7 @@ func _NewClient(network _Network, mirrorNetwork []string, name NetworkName) *Cli
 
 	// We can't ask for AddressBook from non existent Mirror node
 	if len(mirrorNetwork) > 0 {
-		// Update the Addressbook, before the deafult timeout starts
+		// Update the Addressbook, before the default timeout starts
 		client._UpdateAddressBook()
 		go client._ScheduleNetworkUpdate(ctx, client.defaultNetworkUpdatePeriod)
 	}

--- a/client.go
+++ b/client.go
@@ -65,7 +65,6 @@ type Client struct {
 	minBackoff time.Duration
 
 	requestTimeout             *time.Duration
-	networkUpdateInitialDelay  time.Duration
 	defaultNetworkUpdatePeriod time.Duration
 	networkUpdateContext       context.Context
 	cancelNetworkUpdate        context.CancelFunc
@@ -87,7 +86,7 @@ var previewnetMirror = []string{"hcs.previewnet.mirrornode.hedera.com:5600"}
 
 func ClientForNetwork(network map[string]AccountID) *Client {
 	net := _NewNetwork()
-	client := _NewClient(net, []string{}, "mainnet", false)
+	client := _NewClient(net, []string{}, "mainnet")
 	_ = client.SetNetwork(network)
 	net._SetLedgerID(*NewLedgerIDMainnet())
 	return client
@@ -98,7 +97,7 @@ func ClientForNetwork(network map[string]AccountID) *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForMainnet() *Client {
-	return _NewClient(*_NetworkForTestnet(mainnetNodes._ToMap()), mainnetMirror, NetworkNameMainnet, true)
+	return _NewClient(*_NetworkForTestnet(mainnetNodes._ToMap()), mainnetMirror, NetworkNameMainnet)
 }
 
 // ClientForTestnet returns a preconfigured client for use with the standard
@@ -106,7 +105,7 @@ func ClientForMainnet() *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForTestnet() *Client {
-	return _NewClient(*_NetworkForPreviewnet(testnetNodes._ToMap()), testnetMirror, NetworkNameTestnet, true)
+	return _NewClient(*_NetworkForPreviewnet(testnetNodes._ToMap()), testnetMirror, NetworkNameTestnet)
 }
 
 // ClientForPreviewnet returns a preconfigured client for use with the standard
@@ -114,12 +113,12 @@ func ClientForTestnet() *Client {
 // Most users will want to set an _Operator account with .SetOperator so
 // transactions can be automatically given TransactionIDs and signed.
 func ClientForPreviewnet() *Client {
-	return _NewClient(*_NetworkForMainnet(previewnetNodes._ToMap()), previewnetMirror, NetworkNamePreviewnet, true)
+	return _NewClient(*_NetworkForMainnet(previewnetNodes._ToMap()), previewnetMirror, NetworkNamePreviewnet)
 }
 
 // newClient takes in a map of _Node addresses to their respective IDS (_Network)
 // and returns a Client instance which can be used to
-func _NewClient(network _Network, mirrorNetwork []string, name NetworkName, networkUpdate bool) *Client {
+func _NewClient(network _Network, mirrorNetwork []string, name NetworkName) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	client := Client{
 		maxQueryPayment:                 defaultMaxQueryPayment,
@@ -132,7 +131,6 @@ func _NewClient(network _Network, mirrorNetwork []string, name NetworkName, netw
 		maxBackoff:                      8 * time.Second,
 		defaultRegenerateTransactionIDs: true,
 		defaultNetworkUpdatePeriod:      24 * time.Hour,
-		networkUpdateInitialDelay:       10 * time.Second,
 		networkUpdateContext:            ctx,
 		cancelNetworkUpdate:             cancel,
 	}
@@ -140,25 +138,33 @@ func _NewClient(network _Network, mirrorNetwork []string, name NetworkName, netw
 	client.SetMirrorNetwork(mirrorNetwork)
 	client.network._SetNetworkName(name)
 
-	if networkUpdate {
-		go client._ScheduleNetworkUpdate(ctx, 0)
+	// We can't ask for AddressBook from non existent Mirror node
+	if len(mirrorNetwork) > 0 {
+		// Update the Addressbook, before the deafult timeout starts
+		client._UpdateAddressBook()
+		go client._ScheduleNetworkUpdate(ctx, client.defaultNetworkUpdatePeriod)
 	}
 
 	return &client
 }
 
+func (client *Client) _UpdateAddressBook() {
+	addressbook, err := NewAddressBookQuery().
+		SetFileID(FileIDForAddressBook()).
+		Execute(client)
+	if err == nil && len(addressbook.NodeAddresses) > 0 {
+		client.SetNetworkFromAddressBook(addressbook)
+	}
+}
+
 func (client *Client) _ScheduleNetworkUpdate(ctx context.Context, duration time.Duration) {
-	select {
-	case <-ctx.Done():
-		return
-	case <-time.After(duration):
-		addressbook, err := NewAddressBookQuery().
-			SetFileID(FileIDForAddressBook()).
-			Execute(client)
-		if err == nil && len(addressbook.NodeAddresses) > 0 {
-			client.SetNetworkFromAddressBook(addressbook)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(duration):
+			client._UpdateAddressBook()
 		}
-		client._ScheduleNetworkUpdate(ctx, client.defaultNetworkUpdatePeriod)
 	}
 }
 
@@ -168,7 +174,9 @@ func (client *Client) CancelScheduledNetworkUpdate() {
 
 func (client *Client) SetNetworkUpdatePeriod(period time.Duration) *Client {
 	client.defaultNetworkUpdatePeriod = period
-	client._ScheduleNetworkUpdate(client.networkUpdateContext, period)
+	client.CancelScheduledNetworkUpdate()
+	client.networkUpdateContext, client.cancelNetworkUpdate = context.WithCancel(context.Background())
+	go client._ScheduleNetworkUpdate(client.networkUpdateContext, period)
 	return client
 }
 
@@ -259,16 +267,16 @@ func ClientFromConfig(jsonBytes []byte) (*Client, error) {
 				return client, errors.New("mirrorNetwork is expected to be either string or an array of strings")
 			}
 		}
-		client = _NewClient(network, arr, NetworkNameMainnet, false)
+		client = _NewClient(network, arr, NetworkNameMainnet)
 	case string:
 		if len(mirror) > 0 {
 			switch mirror {
 			case string(NetworkNameMainnet):
-				client = _NewClient(network, mainnetMirror, NetworkNameMainnet, true)
+				client = _NewClient(network, mainnetMirror, NetworkNameMainnet)
 			case string(NetworkNamePreviewnet):
-				client = _NewClient(network, previewnetMirror, NetworkNamePreviewnet, true)
+				client = _NewClient(network, previewnetMirror, NetworkNamePreviewnet)
 			case string(NetworkNameTestnet):
-				client = _NewClient(network, testnetMirror, NetworkNameTestnet, true)
+				client = _NewClient(network, testnetMirror, NetworkNameTestnet)
 			}
 		}
 	default:

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -36,7 +36,7 @@ func TestUnitClientFromConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotNil(t, client)
-	assert.Equal(t, 10, len(client.network.network))
+	assert.Equal(t, 7, len(client.network.network))
 	assert.Nil(t, client.operator)
 }
 
@@ -49,7 +49,7 @@ func TestUnitClientFromConfigWithOperator(t *testing.T) {
 	testOperatorKey, err := PrivateKeyFromString("302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10")
 	require.NoError(t, err)
 
-	assert.Equal(t, 10, len(client.network.network))
+	assert.Equal(t, 7, len(client.network.network))
 	assert.NotNil(t, client.operator)
 	assert.Equal(t, testOperatorKey.ed25519PrivateKey.keyData, client.operator.privateKey.ed25519PrivateKey.keyData)
 	assert.Equal(t, AccountID{Account: 3}.Account, client.operator.accountID.Account)

--- a/managed_network.go
+++ b/managed_network.go
@@ -104,7 +104,6 @@ func (this *_ManagedNetwork) _SetNetwork(network map[string]_IManagedNode) error
 	this.nodes = newNodes
 	this.network = newNetwork
 	this.healthyNodes = newHealthyNodes
-	this.ledgerID = nil
 
 	return nil
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -456,6 +456,7 @@ func NewMockClientAndServer(allNodeResponses [][]interface{}) (*Client, *MockSer
 	network := map[string]AccountID{}
 	mirrorNetwork := make([]string, len(allNodeResponses))
 	servers := make([]*MockServer, len(allNodeResponses))
+	ctx, cancel := context.WithCancel(context.Background())
 	client := &Client{
 		maxQueryPayment:                 defaultMaxQueryPayment,
 		maxTransactionFee:               defaultMaxTransactionFee,
@@ -467,7 +468,8 @@ func NewMockClientAndServer(allNodeResponses [][]interface{}) (*Client, *MockSer
 		maxBackoff:                      8 * time.Second,
 		defaultRegenerateTransactionIDs: true,
 		defaultNetworkUpdatePeriod:      24 * time.Hour,
-		networkUpdateInitialDelay:       1 * time.Millisecond,
+		networkUpdateContext:            ctx,
+		cancelNetworkUpdate:             cancel,
 	}
 
 	for i, responses := range allNodeResponses {


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
Schedule Network update was a recursive call. This PR changes this method in client.go to use a loop instead of recursive call.
In addition also fixes ClientFor/Previewnet/Testnet/Mainnet methods setting the wrong LedgerID.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/619 https://github.com/hashgraph/hedera-sdk-go/issues/624

