### PR TITLE
Add default max query and  transaction fee

### DIFF
--- a/account_allowance_adjust_transaction.go
+++ b/account_allowance_adjust_transaction.go
@@ -40,7 +40,7 @@ func NewAccountAllowanceAdjustTransaction() *AccountAllowanceAdjustTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/account_allowance_approve_transaction.go
+++ b/account_allowance_approve_transaction.go
@@ -58,7 +58,7 @@ func NewAccountAllowanceApproveTransaction() *AccountAllowanceApproveTransaction
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/account_allowance_delete_transaction.go
+++ b/account_allowance_delete_transaction.go
@@ -29,7 +29,7 @@ func NewAccountAllowanceDeleteTransaction() *AccountAllowanceDeleteTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/account_create_transaction.go
+++ b/account_create_transaction.go
@@ -61,7 +61,7 @@ func NewAccountCreateTransaction() *AccountCreateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(7890000 * time.Second)
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/account_delete_transaction.go
+++ b/account_delete_transaction.go
@@ -58,7 +58,7 @@ func NewAccountDeleteTransaction() *AccountDeleteTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/account_info_query.go
+++ b/account_info_query.go
@@ -217,7 +217,7 @@ func (query *AccountInfoQuery) Execute(client *Client) (AccountInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/account_records_query.go
+++ b/account_records_query.go
@@ -183,7 +183,7 @@ func (query *AccountRecordsQuery) Execute(client *Client) ([]TransactionRecord, 
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/account_stakers_query.go
+++ b/account_stakers_query.go
@@ -181,7 +181,7 @@ func (query *AccountStakersQuery) Execute(client *Client) ([]Transfer, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/account_update_transaction.go
+++ b/account_update_transaction.go
@@ -64,7 +64,7 @@ func NewAccountUpdateTransaction() *AccountUpdateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(7890000 * time.Second)
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/client-config-with-operator.json
+++ b/client-config-with-operator.json
@@ -1,12 +1,12 @@
 {
-    "network": {
-        "0.previewnet.hedera.com:50211" : "0.0.3",
-        "1.previewnet.hedera.com:50211"  : "0.0.4",
-        "2.previewnet.hedera.com:50211" : "0.0.5",
-        "3.previewnet.hedera.com:50211" : "0.0.6"
-    },
-    "operator": {
-        "accountId": "0.0.3",
-        "privateKey": "302e020100300506032b657004220420eaa013282e"
-    }
+  "network": {
+      "0.previewnet.hedera.com:50211" : "0.0.3",
+      "1.previewnet.hedera.com:50211"  : "0.0.4",
+      "2.previewnet.hedera.com:50211" : "0.0.5",
+      "3.previewnet.hedera.com:50211" : "0.0.6"
+  },
+  "operator": {
+      "accountId": "0.0.3",
+      "privateKey": "302e020100300506032b657004220420eaa013282e"
+  }
 }

--- a/contract_bytecode_query.go
+++ b/contract_bytecode_query.go
@@ -178,7 +178,7 @@ func (query *ContractBytecodeQuery) Execute(client *Client) ([]byte, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/contract_call_query.go
+++ b/contract_call_query.go
@@ -49,7 +49,6 @@ type ContractCallQuery struct {
 func NewContractCallQuery() *ContractCallQuery {
 	header := services.QueryHeader{}
 	query := _NewQuery(true, &header)
-	query.SetMaxQueryPayment(NewHbar(2))
 
 	return &ContractCallQuery{
 		Query: query,
@@ -259,7 +258,7 @@ func (query *ContractCallQuery) Execute(client *Client) (ContractFunctionResult,
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/contract_create_transaction.go
+++ b/contract_create_transaction.go
@@ -59,7 +59,7 @@ func NewContractCreateTransaction() *ContractCreateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(131500 * time.Minute)
-	transaction.SetMaxTransactionFee(NewHbar(20))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(20))
 
 	return &transaction
 }

--- a/contract_delete_transaction.go
+++ b/contract_delete_transaction.go
@@ -44,7 +44,7 @@ func NewContractDeleteTransaction() *ContractDeleteTransaction {
 	transaction := ContractDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/contract_execute_transaction.go
+++ b/contract_execute_transaction.go
@@ -49,7 +49,7 @@ func NewContractExecuteTransaction() *ContractExecuteTransaction {
 	transaction := ContractExecuteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/contract_info_query.go
+++ b/contract_info_query.go
@@ -40,8 +40,6 @@ func NewContractInfoQuery() *ContractInfoQuery {
 	header := services.QueryHeader{}
 	query := _NewQuery(true, &header)
 
-	query.SetMaxQueryPayment(NewHbar(2))
-
 	return &ContractInfoQuery{
 		Query: query,
 	}
@@ -187,7 +185,7 @@ func (query *ContractInfoQuery) Execute(client *Client) (ContractInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/contract_update_transaction.go
+++ b/contract_update_transaction.go
@@ -77,7 +77,7 @@ func NewContractUpdateTransaction() *ContractUpdateTransaction {
 	transaction := ContractUpdateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/ethereum_flow.go
+++ b/ethereum_flow.go
@@ -15,7 +15,7 @@ func NewEthereumFlow() *EthereumFlow {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(20))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(20))
 
 	return &transaction
 }

--- a/ethereum_transaction.go
+++ b/ethereum_transaction.go
@@ -21,7 +21,7 @@ func NewEthereumTransaction() *EthereumTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/file_append_transaction.go
+++ b/file_append_transaction.go
@@ -49,7 +49,7 @@ func NewFileAppendTransaction() *FileAppendTransaction {
 		contents:    make([]byte, 0),
 		chunkSize:   2048,
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/file_contents_query.go
+++ b/file_contents_query.go
@@ -177,7 +177,7 @@ func (query *FileContentsQuery) Execute(client *Client) ([]byte, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/file_create_transaction.go
+++ b/file_create_transaction.go
@@ -59,7 +59,7 @@ func NewFileCreateTransaction() *FileCreateTransaction {
 	}
 
 	transaction.SetExpirationTime(time.Now().Add(7890000 * time.Second))
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/file_create_transaction_e2e_test.go
+++ b/file_create_transaction_e2e_test.go
@@ -33,13 +33,13 @@ import (
 
 func TestIntegrationFileCreateTransactionCanExecute(t *testing.T) {
 	env := NewIntegrationTestEnv(t)
-
 	resp, err := NewFileCreateTransaction().
 		SetKeys(env.Client.GetOperatorPublicKey()).
 		SetNodeAccountIDs(env.NodeAccountIDs).
 		SetContents([]byte("Hello, World")).
 		SetTransactionMemo("go sdk e2e tests").
 		Execute(env.Client)
+
 
 	require.NoError(t, err)
 

--- a/file_delete_transaction.go
+++ b/file_delete_transaction.go
@@ -50,7 +50,7 @@ func NewFileDeleteTransaction() *FileDeleteTransaction {
 	transaction := FileDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/file_info_query.go
+++ b/file_info_query.go
@@ -177,7 +177,7 @@ func (query *FileInfoQuery) Execute(client *Client) (FileInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/file_update_transaction.go
+++ b/file_update_transaction.go
@@ -55,7 +55,7 @@ func NewFileUpdateTransaction() *FileUpdateTransaction {
 	transaction := FileUpdateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/freeze_transaction.go
+++ b/freeze_transaction.go
@@ -42,7 +42,7 @@ func NewFreezeTransaction() *FreezeTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/live_hash_add_transaction.go
+++ b/live_hash_add_transaction.go
@@ -59,7 +59,7 @@ func NewLiveHashAddTransaction() *LiveHashAddTransaction {
 	transaction := LiveHashAddTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/live_hash_delete_transaction.go
+++ b/live_hash_delete_transaction.go
@@ -43,7 +43,7 @@ func NewLiveHashDeleteTransaction() *LiveHashDeleteTransaction {
 	transaction := LiveHashDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/live_hash_query.go
+++ b/live_hash_query.go
@@ -191,7 +191,7 @@ func (query *LiveHashQuery) Execute(client *Client) (LiveHash, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/mock_test.go
+++ b/mock_test.go
@@ -458,8 +458,7 @@ func NewMockClientAndServer(allNodeResponses [][]interface{}) (*Client, *MockSer
 	servers := make([]*MockServer, len(allNodeResponses))
 	ctx, cancel := context.WithCancel(context.Background())
 	client := &Client{
-		maxQueryPayment:                 defaultMaxQueryPayment,
-		maxTransactionFee:               defaultMaxTransactionFee,
+		defaultMaxQueryPayment:          NewHbar(1),
 		network:                         _NewNetwork(),
 		mirrorNetwork:                   _NewMirrorNetwork(),
 		autoValidateChecksums:           false,

--- a/network_version_info_query.go
+++ b/network_version_info_query.go
@@ -116,7 +116,7 @@ func (query *NetworkVersionInfoQuery) Execute(client *Client) (NetworkVersionInf
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/prng_transaction.go
+++ b/prng_transaction.go
@@ -37,7 +37,7 @@ func NewPrngTransaction() *PrngTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/schedule_create_transaction.go
+++ b/schedule_create_transaction.go
@@ -53,7 +53,7 @@ func NewScheduleCreateTransaction() *ScheduleCreateTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/schedule_delete_transaction.go
+++ b/schedule_delete_transaction.go
@@ -43,7 +43,7 @@ func NewScheduleDeleteTransaction() *ScheduleDeleteTransaction {
 	transaction := ScheduleDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/schedule_info_query.go
+++ b/schedule_info_query.go
@@ -180,7 +180,7 @@ func (query *ScheduleInfoQuery) Execute(client *Client) (ScheduleInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/schedule_sign_transaction.go
+++ b/schedule_sign_transaction.go
@@ -55,7 +55,7 @@ func NewScheduleSignTransaction() *ScheduleSignTransaction {
 		Transaction: _NewTransaction(),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/system_delete_transaction.go
+++ b/system_delete_transaction.go
@@ -38,7 +38,7 @@ func NewSystemDeleteTransaction() *SystemDeleteTransaction {
 	transaction := SystemDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/system_undelete_transaction.go
+++ b/system_undelete_transaction.go
@@ -38,7 +38,7 @@ func NewSystemUndeleteTransaction() *SystemUndeleteTransaction {
 	transaction := SystemUndeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/token_associate_transaction.go
+++ b/token_associate_transaction.go
@@ -72,7 +72,7 @@ func NewTokenAssociateTransaction() *TokenAssociateTransaction {
 	transaction := TokenAssociateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/token_burn_transaction.go
+++ b/token_burn_transaction.go
@@ -54,7 +54,7 @@ func NewTokenBurnTransaction() *TokenBurnTransaction {
 	transaction := TokenBurnTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/token_create_transaction.go
+++ b/token_create_transaction.go
@@ -138,7 +138,7 @@ func NewTokenCreateTransaction() *TokenCreateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(7890000 * time.Second)
-	transaction.SetMaxTransactionFee(NewHbar(40))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(40))
 	transaction.SetTokenType(TokenTypeFungibleCommon)
 
 	return &transaction

--- a/token_delete_transaction.go
+++ b/token_delete_transaction.go
@@ -48,7 +48,7 @@ func NewTokenDeleteTransaction() *TokenDeleteTransaction {
 	transaction := TokenDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_dissociate_transaction.go
+++ b/token_dissociate_transaction.go
@@ -67,7 +67,7 @@ func NewTokenDissociateTransaction() *TokenDissociateTransaction {
 	transaction := TokenDissociateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/token_fee_schedule_update_transaction.go
+++ b/token_fee_schedule_update_transaction.go
@@ -57,7 +57,7 @@ func NewTokenFeeScheduleUpdateTransaction() *TokenFeeScheduleUpdateTransaction {
 	transaction := TokenFeeScheduleUpdateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(5))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(5))
 
 	return &transaction
 }

--- a/token_freeze_transaction.go
+++ b/token_freeze_transaction.go
@@ -59,7 +59,7 @@ func NewTokenFreezeTransaction() *TokenFreezeTransaction {
 	transaction := TokenFreezeTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_grant_kyc_transaction.go
+++ b/token_grant_kyc_transaction.go
@@ -57,7 +57,7 @@ func NewTokenGrantKycTransaction() *TokenGrantKycTransaction {
 	transaction := TokenGrantKycTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_info_query.go
+++ b/token_info_query.go
@@ -180,7 +180,7 @@ func (query *TokenInfoQuery) Execute(client *Client) (TokenInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/token_mint_transaction.go
+++ b/token_mint_transaction.go
@@ -52,7 +52,7 @@ func NewTokenMintTransaction() *TokenMintTransaction {
 	transaction := TokenMintTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_nft_info_query.go
+++ b/token_nft_info_query.go
@@ -241,7 +241,7 @@ func (query *TokenNftInfoQuery) Execute(client *Client) ([]TokenNftInfo, error) 
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/token_pause_transaction.go
+++ b/token_pause_transaction.go
@@ -52,7 +52,7 @@ func NewTokenPauseTransaction() *TokenPauseTransaction {
 	transaction := TokenPauseTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_revoke_kyc_transaction.go
+++ b/token_revoke_kyc_transaction.go
@@ -57,7 +57,7 @@ func NewTokenRevokeKycTransaction() *TokenRevokeKycTransaction {
 	transaction := TokenRevokeKycTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_unfreeze_transaction.go
+++ b/token_unfreeze_transaction.go
@@ -59,7 +59,7 @@ func NewTokenUnfreezeTransaction() *TokenUnfreezeTransaction {
 	transaction := TokenUnfreezeTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_unpause_transaction.go
+++ b/token_unpause_transaction.go
@@ -50,7 +50,7 @@ func NewTokenUnpauseTransaction() *TokenUnpauseTransaction {
 	transaction := TokenUnpauseTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_update_transaction.go
+++ b/token_update_transaction.go
@@ -92,7 +92,7 @@ func NewTokenUpdateTransaction() *TokenUpdateTransaction {
 	transaction := TokenUpdateTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/token_wipe_transaction.go
+++ b/token_wipe_transaction.go
@@ -73,7 +73,7 @@ func NewTokenWipeTransaction() *TokenWipeTransaction {
 	transaction := TokenWipeTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(30))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(30))
 
 	return &transaction
 }

--- a/topic_create_transaction.go
+++ b/topic_create_transaction.go
@@ -45,7 +45,7 @@ func NewTopicCreateTransaction() *TopicCreateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(7890000 * time.Second)
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	// Default to maximum values for record thresholds. Without this records would be
 	// auto-created whenever a send or receive transaction takes place for this new account.

--- a/topic_delete_transaction.go
+++ b/topic_delete_transaction.go
@@ -40,7 +40,7 @@ func NewTopicDeleteTransaction() *TopicDeleteTransaction {
 	transaction := TopicDeleteTransaction{
 		Transaction: _NewTransaction(),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/topic_info_query.go
+++ b/topic_info_query.go
@@ -182,7 +182,7 @@ func (query *TopicInfoQuery) Execute(client *Client) (TopicInfo, error) {
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/topic_message_submit_transaction.go
+++ b/topic_message_submit_transaction.go
@@ -49,7 +49,7 @@ func NewTopicMessageSubmitTransaction() *TopicMessageSubmitTransaction {
 		maxChunks:   20,
 		message:     make([]byte, 0),
 	}
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/topic_update_transaction.go
+++ b/topic_update_transaction.go
@@ -50,7 +50,7 @@ func NewTopicUpdateTransaction() *TopicUpdateTransaction {
 	}
 
 	transaction.SetAutoRenewPeriod(7890000 * time.Second)
-	transaction.SetMaxTransactionFee(NewHbar(2))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(2))
 
 	return &transaction
 }

--- a/transaction_record_query.go
+++ b/transaction_record_query.go
@@ -326,7 +326,7 @@ func (query *TransactionRecordQuery) Execute(client *Client) (TransactionRecord,
 		cost = query.queryPayment
 	} else {
 		if query.maxQueryPayment.tinybar == 0 {
-			cost = client.maxQueryPayment
+			cost = client.GetDefaultMaxQueryPayment()
 		} else {
 			cost = query.maxQueryPayment
 		}

--- a/transaction_unit_test.go
+++ b/transaction_unit_test.go
@@ -400,3 +400,43 @@ func TestUnitQueryRegression(t *testing.T) {
 		},
 	})
 }
+func TestUnitTransactionInitFeeMaxTransactionWithouthSettingFee(t *testing.T) {
+	//Default Max Fee for TransferTransaction
+	fee := NewHbar(1)
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	transaction, err := NewTransferTransaction().
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-100)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(100)).
+		FreezeWith(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(fee.AsTinybar()), transaction.transactionFee)
+}
+
+func TestUnitTransactionInitFeeMaxTransactionFeeSetExplicitly(t *testing.T) {
+	clientMaxFee := NewHbar(14)
+	explicitMaxFee := NewHbar(15)
+	client, err := _NewMockClient()
+	client.SetDefaultMaxTransactionFee(clientMaxFee)
+	require.NoError(t, err)
+	transaction, err := NewTransferTransaction().
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-100)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(100)).
+		SetMaxTransactionFee(explicitMaxFee).
+		FreezeWith(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(explicitMaxFee.AsTinybar()), transaction.transactionFee)
+}
+
+func TestUnitTransactionInitFeeMaxTransactionFromClientDefault(t *testing.T) {
+	fee := NewHbar(14)
+	client, err := _NewMockClient()
+	client.SetDefaultMaxTransactionFee(fee)
+	require.NoError(t, err)
+	transaction, err := NewTransferTransaction().
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-100)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(100)).
+		FreezeWith(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(fee.AsTinybar()), transaction.transactionFee)
+}

--- a/transfer_transaction.go
+++ b/transfer_transaction.go
@@ -65,7 +65,7 @@ func NewTransferTransaction() *TransferTransaction {
 		nftTransfers:   make(map[TokenID][]*TokenNftTransfer),
 	}
 
-	transaction.SetMaxTransactionFee(NewHbar(1))
+	transaction._SetDefaultMaxTransactionFee(NewHbar(1))
 
 	return &transaction
 }


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
This PR adds the functionality to set a default query and transaction fee.
There are 3 ways to set these fees:
1. Set the fee explicitly for the current transaction/query
2. Set the default fee for all transactions/queries 
3. Set nothing and it should use some predefined fees

The priority is in the same order.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/601
