### PR TITLE
Expose AccountID Equality Methods

### DIFF
--- a/account_id.go
+++ b/account_id.go
@@ -293,8 +293,16 @@ func _AccountIDFromProtobuf(accountID *services.AccountID) *AccountID {
 	}
 }
 
+func (id AccountID) IsZero() bool {
+	return id._IsZero()
+}
+
 func (id AccountID) _IsZero() bool {
 	return id.Shard == 0 && id.Realm == 0 && id.Account == 0 && id.AliasKey == nil
+}
+
+func (id AccountID) Equals(other AccountID) bool {
+	return id._Equals(other)
 }
 
 func (id AccountID) _Equals(other AccountID) bool {


### PR DESCRIPTION
This PR updates the AccountID object to allow users to directly call the IsZero() and Equals() methods on an AccountID object to enable direct comparison of two AccountID objects and to check whether or not an AccountID is the Zero Account ID. 