### PR TITLE
Change AllowanceSpenderAccountID to SpenderID

### DIFF
--- a/token_nft_info.go
+++ b/token_nft_info.go
@@ -33,9 +33,7 @@ type TokenNftInfo struct {
 	CreationTime time.Time
 	Metadata     []byte
 	LedgerID     LedgerID
-	// Deprecated
-	SpenderID                 AccountID
-	AllowanceSpenderAccountID AccountID
+	SpenderID    AccountID
 }
 
 func _TokenNftInfoFromProtobuf(pb *services.TokenNftInfo) TokenNftInfo {
@@ -54,12 +52,12 @@ func _TokenNftInfoFromProtobuf(pb *services.TokenNftInfo) TokenNftInfo {
 	}
 
 	return TokenNftInfo{
-		NftID:                     _NftIDFromProtobuf(pb.NftID),
-		AccountID:                 accountID,
-		CreationTime:              _TimeFromProtobuf(pb.CreationTime),
-		Metadata:                  pb.Metadata,
-		LedgerID:                  LedgerID{pb.LedgerId},
-		AllowanceSpenderAccountID: spenderID,
+		NftID:        _NftIDFromProtobuf(pb.NftID),
+		AccountID:    accountID,
+		CreationTime: _TimeFromProtobuf(pb.CreationTime),
+		Metadata:     pb.Metadata,
+		LedgerID:     LedgerID{pb.LedgerId},
+		SpenderID:    spenderID,
 	}
 }
 
@@ -70,7 +68,7 @@ func (tokenNftInfo *TokenNftInfo) _ToProtobuf() *services.TokenNftInfo {
 		CreationTime: _TimeToProtobuf(tokenNftInfo.CreationTime),
 		Metadata:     tokenNftInfo.Metadata,
 		LedgerId:     tokenNftInfo.LedgerID.ToBytes(),
-		SpenderId:    tokenNftInfo.AllowanceSpenderAccountID._ToProtobuf(),
+		SpenderId:    tokenNftInfo.SpenderID._ToProtobuf(),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
Just a field name change. It was wrongfully renamed. This the correct one as it is in the proto.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/631
