### PR TITLE
Add method for getting SignedTransaction body bytes

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -87,6 +87,10 @@ func _NewTransaction() Transaction {
 	}
 }
 
+func (this *Transaction) GetSignedTransactionBodyBytes(transactionIndex int) []byte {
+	return this.signedTransactions._Get(transactionIndex).(*services.SignedTransaction).GetBodyBytes()
+}
+
 // TransactionFromBytes converts Transaction bytes to a related *Transaction.
 func TransactionFromBytes(data []byte) (interface{}, error) { // nolint
 	list := sdk.TransactionList{}


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
Expose a method to get the SignedTransaction body bytes before it is signed.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/643

