### PR TITLE
Fix panic in multiple node account id locking

### DIFF
--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -36,7 +36,7 @@ func TestUnitClientFromConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotNil(t, client)
-	assert.Equal(t, 7, len(client.network.network))
+	assert.Equal(t, 10, len(client.network.network))
 	assert.Nil(t, client.operator)
 }
 
@@ -49,7 +49,7 @@ func TestUnitClientFromConfigWithOperator(t *testing.T) {
 	testOperatorKey, err := PrivateKeyFromString("302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10")
 	require.NoError(t, err)
 
-	assert.Equal(t, 7, len(client.network.network))
+	assert.Equal(t, 10, len(client.network.network))
 	assert.NotNil(t, client.operator)
 	assert.Equal(t, testOperatorKey.ed25519PrivateKey.keyData, client.operator.privateKey.ed25519PrivateKey.keyData)
 	assert.Equal(t, AccountID{Account: 3}.Account, client.operator.accountID.Account)


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
This PR fixes the issue where `GetTransactionHash` would return nil, and creating a transaction with multiple NodeAccountId's would panic.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/654, https://github.com/hashgraph/hedera-sdk-go/issues/640


