### PR TITLE
Don't send MaxAutomaticTokenAssociations on ContractUpdate if not set

### DIFF
--- a/address_book_query_e2e_test.go
+++ b/address_book_query_e2e_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -57,7 +58,8 @@ func TestIntegrationAddressBookQueryUpdateAll(t *testing.T) {
 	require.NoError(t, err)
 
 	client = ClientForTestnet()
-
+	// Testnet has limitation on requests: unexpected HTTP status code received from server: 429 (Too Many Requests)
+	time.Sleep(time.Second*5)
 	testnet, err := NewAddressBookQuery().
 		SetFileID(FileIDForAddressBook()).
 		Execute(client)

--- a/contract_update_transaction.go
+++ b/contract_update_transaction.go
@@ -344,8 +344,11 @@ func (transaction *ContractUpdateTransaction) _ValidateNetworkOnIDs(client *Clie
 
 func (transaction *ContractUpdateTransaction) _Build() *services.TransactionBody {
 	body := &services.ContractUpdateTransactionBody{
-		MaxAutomaticTokenAssociations: &wrapperspb.Int32Value{Value: transaction.maxAutomaticTokenAssociations},
-		DeclineReward:                 &wrapperspb.BoolValue{Value: transaction.declineReward},
+		DeclineReward: &wrapperspb.BoolValue{Value: transaction.declineReward},
+	}
+
+	if transaction.maxAutomaticTokenAssociations != 0 {
+		body.MaxAutomaticTokenAssociations = &wrapperspb.Int32Value{Value: transaction.maxAutomaticTokenAssociations}
 	}
 
 	if transaction.expirationTime != nil {
@@ -406,8 +409,11 @@ func (transaction *ContractUpdateTransaction) Schedule() (*ScheduleCreateTransac
 
 func (transaction *ContractUpdateTransaction) _ConstructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
 	body := &services.ContractUpdateTransactionBody{
-		MaxAutomaticTokenAssociations: &wrapperspb.Int32Value{Value: transaction.maxAutomaticTokenAssociations},
-		DeclineReward:                 &wrapperspb.BoolValue{Value: transaction.declineReward},
+		DeclineReward: &wrapperspb.BoolValue{Value: transaction.declineReward},
+	}
+
+	if transaction.maxAutomaticTokenAssociations != 0 {
+		body.MaxAutomaticTokenAssociations = &wrapperspb.Int32Value{Value: transaction.maxAutomaticTokenAssociations}
 	}
 
 	if transaction.expirationTime != nil {


### PR DESCRIPTION
Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
The MaxAutomaticTokenAssociations field in ContractUpdate should be set to 0 by default.
This PR just changes the ContractUpdate to not send MaxAutomaticTokenAssociations if it is 0.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/662
