### PR TITLE
Revert "Update mirror node endpoints (#677)"

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,8 +77,8 @@ type _Operator struct {
 }
 
 var mainnetMirror = []string{"mainnet-public.mirrornode.hedera.com:443"}
-var testnetMirror = []string{"testnet.mirrornode.hedera.com:443"}
-var previewnetMirror = []string{"previewnet.mirrornode.hedera.com:443"}
+var testnetMirror = []string{"hcs.testnet.mirrornode.hedera.com:5600"}
+var previewnetMirror = []string{"hcs.previewnet.mirrornode.hedera.com:5600"}
 
 func ClientForNetwork(network map[string]AccountID) *Client {
 	net := _NewNetwork()

--- a/client_all_test.go
+++ b/client_all_test.go
@@ -58,5 +58,5 @@ const testClientJSONWrongTypeNetwork string = `{
         "accountId": "0.0.3",
         "privateKey": "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10"
     },
- 	"mirrorNetwork": ["testnet.mirrornode.hedera.com:5600"]
+ 	"mirrorNetwork": ["hcs.testnet.mirrornode.hedera.com:5600"]
 }`

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -109,7 +109,7 @@ func TestUnitClientSetNetworkExtensive(t *testing.T) {
 	network = client.GetNetwork()
 	networkTLSMirror := client.GetMirrorNetwork()
 	assert.Equal(t, network["2.testnet.hedera.com:50212"], AccountID{0, 0, 5, nil, nil, nil})
-	assert.Equal(t, networkTLSMirror[0], "testnet.mirrornode.hedera.com:443")
+	assert.Equal(t, networkTLSMirror[0], "hcs.testnet.mirrornode.hedera.com:443")
 
 	err = client.Close()
 	require.NoError(t, err)
@@ -117,43 +117,43 @@ func TestUnitClientSetNetworkExtensive(t *testing.T) {
 
 func TestUnitClientSetMirrorNetwork(t *testing.T) {
 	defaultNetwork := make([]string, 0)
-	defaultNetwork = append(defaultNetwork, "testnet.mirrornode.hedera.com:5600")
+	defaultNetwork = append(defaultNetwork, "hcs.testnet.mirrornode.hedera.com:5600")
 	client := ClientForTestnet()
 	client.SetMirrorNetwork(defaultNetwork)
 
 	mirrorNetwork := client.GetMirrorNetwork()
 	assert.Equal(t, 1, len(mirrorNetwork))
-	assert.Equal(t, "testnet.mirrornode.hedera.com:5600", mirrorNetwork[0])
+	assert.Equal(t, "hcs.testnet.mirrornode.hedera.com:5600", mirrorNetwork[0])
 
 	defaultNetworkWithExtraNode := make([]string, 0)
-	defaultNetworkWithExtraNode = append(defaultNetworkWithExtraNode, "testnet.mirrornode.hedera.com:5600")
-	defaultNetworkWithExtraNode = append(defaultNetworkWithExtraNode, "testnet1.mirrornode.hedera.com:5600")
+	defaultNetworkWithExtraNode = append(defaultNetworkWithExtraNode, "hcs.testnet.mirrornode.hedera.com:5600")
+	defaultNetworkWithExtraNode = append(defaultNetworkWithExtraNode, "hcs.testnet1.mirrornode.hedera.com:5600")
 
 	client.SetMirrorNetwork(defaultNetworkWithExtraNode)
 	mirrorNetwork = client.GetMirrorNetwork()
 	assert.Equal(t, 2, len(mirrorNetwork))
-	require.True(t, contains(mirrorNetwork, "testnet.mirrornode.hedera.com:5600"))
-	require.True(t, contains(mirrorNetwork, "testnet1.mirrornode.hedera.com:5600"))
+	require.True(t, contains(mirrorNetwork, "hcs.testnet.mirrornode.hedera.com:5600"))
+	require.True(t, contains(mirrorNetwork, "hcs.testnet1.mirrornode.hedera.com:5600"))
 
 	defaultNetwork = make([]string, 0)
-	defaultNetwork = append(defaultNetwork, "testnet1.mirrornode.hedera.com:5600")
+	defaultNetwork = append(defaultNetwork, "hcs.testnet1.mirrornode.hedera.com:5600")
 
 	client.SetMirrorNetwork(defaultNetwork)
 	mirrorNetwork = client.GetMirrorNetwork()
 	assert.Equal(t, 1, len(mirrorNetwork))
-	assert.Equal(t, "testnet1.mirrornode.hedera.com:5600", mirrorNetwork[0])
+	assert.Equal(t, "hcs.testnet1.mirrornode.hedera.com:5600", mirrorNetwork[0])
 
 	defaultNetwork = make([]string, 0)
-	defaultNetwork = append(defaultNetwork, "testnet.mirrornode.hedera.com:5600")
+	defaultNetwork = append(defaultNetwork, "hcs.testnet.mirrornode.hedera.com:5600")
 
 	client.SetMirrorNetwork(defaultNetwork)
 	mirrorNetwork = client.GetMirrorNetwork()
 	assert.Equal(t, 1, len(mirrorNetwork))
-	assert.Equal(t, "testnet.mirrornode.hedera.com:5600", mirrorNetwork[0])
+	assert.Equal(t, "hcs.testnet.mirrornode.hedera.com:5600", mirrorNetwork[0])
 
 	client.SetTransportSecurity(true)
 	mirrorNetwork = client.GetMirrorNetwork()
-	assert.Equal(t, "testnet.mirrornode.hedera.com:443", mirrorNetwork[0])
+	assert.Equal(t, "hcs.testnet.mirrornode.hedera.com:443", mirrorNetwork[0])
 
 	err := client.Close()
 	require.NoError(t, err)

--- a/managed_node_address_unit_test.go
+++ b/managed_node_address_unit_test.go
@@ -62,25 +62,25 @@ func TestUnitManagedNodeAddressTest(t *testing.T) {
 	require.True(t, urlAddressInsecure.port == 50211)
 	require.True(t, urlAddressInsecure._String() == "0.testnet.hedera.com:50211")
 
-	mirrorNodeAddress, err := _ManagedNodeAddressFromString("mainnet-public.mirrornode.hedera.com:5600")
+	mirrorNodeAddress, err := _ManagedNodeAddressFromString("hcs.mainnet.mirrornode.hedera.com:5600")
 	require.NoError(t, err)
-	require.True(t, *mirrorNodeAddress.address == "mainnet-public.mirrornode.hedera.com")
+	require.True(t, *mirrorNodeAddress.address == "hcs.mainnet.mirrornode.hedera.com")
 	require.True(t, mirrorNodeAddress.port == 5600)
-	require.True(t, mirrorNodeAddress._String() == "mainnet-public.mirrornode.hedera.com:5600")
+	require.True(t, mirrorNodeAddress._String() == "hcs.mainnet.mirrornode.hedera.com:5600")
 
 	mirrorNodeAddressSecure := mirrorNodeAddress._ToSecure()
-	require.True(t, *mirrorNodeAddressSecure.address == "mainnet-public.mirrornode.hedera.com")
+	require.True(t, *mirrorNodeAddressSecure.address == "hcs.mainnet.mirrornode.hedera.com")
 	require.True(t, mirrorNodeAddressSecure.port == 443)
-	require.True(t, mirrorNodeAddressSecure._String() == "mainnet-public.mirrornode.hedera.com:443")
+	require.True(t, mirrorNodeAddressSecure._String() == "hcs.mainnet.mirrornode.hedera.com:443")
 
 	mirrorNodeAddressInsecure := mirrorNodeAddressSecure._ToInsecure()
-	require.True(t, *mirrorNodeAddressInsecure.address == "mainnet-public.mirrornode.hedera.com")
+	require.True(t, *mirrorNodeAddressInsecure.address == "hcs.mainnet.mirrornode.hedera.com")
 	require.True(t, mirrorNodeAddressInsecure.port == 5600)
-	require.True(t, mirrorNodeAddressInsecure._String() == "mainnet-public.mirrornode.hedera.com:5600")
+	require.True(t, mirrorNodeAddressInsecure._String() == "hcs.mainnet.mirrornode.hedera.com:5600")
 
 	_, err = _ManagedNodeAddressFromString("this is a random string with spaces:443")
 	require.Error(t, err)
 
-	_, err = _ManagedNodeAddressFromString("mainnet-public.mirrornode.hedera.com:notarealport")
+	_, err = _ManagedNodeAddressFromString("hcs.mainnet.mirrornode.hedera.com:notarealport")
 	require.Error(t, err)
 }

--- a/tls_e2e_test.go
+++ b/tls_e2e_test.go
@@ -41,7 +41,7 @@ func TestIntegrationPreviewnetTls(t *testing.T) {
 	client := ClientForNetwork(network)
 	ledger, _ := LedgerIDFromNetworkName(NetworkNamePreviewnet)
 	client.SetTransportSecurity(true)
-	client.SetMirrorNetwork([]string{"previewnet.mirrornode.hedera.com:5600"})
+	client.SetMirrorNetwork([]string{"hcs.previewnet.mirrornode.hedera.com:5600"})
 	client.SetLedgerID(*ledger)
 	client.SetMaxAttempts(3)
 
@@ -67,7 +67,7 @@ func TestIntegrationTestnetTls(t *testing.T) {
 	ledger, _ := LedgerIDFromNetworkName(NetworkNameTestnet)
 	client.SetTransportSecurity(true)
 	client.SetLedgerID(*ledger)
-	client.SetMirrorNetwork([]string{"testnet.mirrornode.hedera.com:5600"})
+	client.SetMirrorNetwork([]string{"hcs.testnet.mirrornode.hedera.com:5600"})
 	client.SetMaxAttempts(3)
 
 	for _, nodeAccountID := range network {


### PR DESCRIPTION
This reverts commit d2e046de6d10ad1b499ab041bd48bf54b39a4bae.

Signed-off-by: Emanuel Pargov <bamzedev@gmail.com>

**Description**:
Reverting the commit. Port 5600 is not serving. 
