### PR TITLE
Rename lazy to auto account creation in examples

### DIFF
--- a/examples/alias_id_example/main.go
+++ b/examples/alias_id_example/main.go
@@ -38,7 +38,7 @@ func main() {
 	client.SetOperator(operatorAccountID, operatorKey)
 
 	/*
-	 * Hedera supports a form of lazy account creation.
+	 * Hedera supports a form of auto account creation.
 	 *
 	 * You can "create" an account by generating a private key, and then deriving the public key,
 	 * without any need to interact with the Hedera network.  The public key more or less acts as the user's


### PR DESCRIPTION
**Description**:
Just changing `lazy account creation` to `auto account creation` in one example.
Fixes: https://github.com/hashgraph/hedera-sdk-go/issues/684
