### PR TITLE
Fix: TransactionFromBytes remove hardcoded duration

### DIFF
--- a/account_create_transaction_e2e_test.go
+++ b/account_create_transaction_e2e_test.go
@@ -158,7 +158,6 @@ func TestIntegrationAccountCreateTransactionAddSignature(t *testing.T) {
 		SetTransferAccountID(env.Client.GetOperatorAccountID()).
 		FreezeWith(env.Client)
 	require.NoError(t, err)
-
 	updateBytes, err := tx.ToBytes()
 	require.NoError(t, err)
 

--- a/transaction.go
+++ b/transaction.go
@@ -91,7 +91,6 @@ func (this *Transaction) GetSignedTransactionBodyBytes(transactionIndex int) []b
 // TransactionFromBytes converts Transaction bytes to a related *Transaction.
 func TransactionFromBytes(data []byte) (interface{}, error) { // nolint
 	list := sdk.TransactionList{}
-	duration := 120 * time.Second
 	minBackoff := 250 * time.Millisecond
 	maxBackoff := 8 * time.Second
 	err := protobuf.Unmarshal(data, &list)
@@ -108,18 +107,17 @@ func TransactionFromBytes(data []byte) (interface{}, error) { // nolint
 	}
 
 	tx := Transaction{
-		maxRetry:                 10,
-		transactionValidDuration: &duration,
-		transactionIDs:           _NewLockableSlice(),
-		transactions:             transactions,
-		signedTransactions:       _NewLockableSlice(),
-		nodeAccountIDs:           _NewLockableSlice(),
-		publicKeys:               make([]PublicKey, 0),
-		transactionSigners:       make([]TransactionSigner, 0),
-		freezeError:              nil,
-		regenerateTransactionID:  true,
-		minBackoff:               &minBackoff,
-		maxBackoff:               &maxBackoff,
+		maxRetry:                10,
+		transactionIDs:          _NewLockableSlice(),
+		transactions:            transactions,
+		signedTransactions:      _NewLockableSlice(),
+		nodeAccountIDs:          _NewLockableSlice(),
+		publicKeys:              make([]PublicKey, 0),
+		transactionSigners:      make([]TransactionSigner, 0),
+		freezeError:             nil,
+		regenerateTransactionID: true,
+		minBackoff:              &minBackoff,
+		maxBackoff:              &maxBackoff,
 	}
 
 	comp, err := _TransactionCompare(&list)
@@ -166,6 +164,12 @@ func TransactionFromBytes(data []byte) (interface{}, error) { // nolint
 		}
 		var transactionID TransactionID
 		var nodeAccountID AccountID
+
+		if body.GetTransactionValidDuration() != nil {
+			duration := _DurationFromProtobuf(body.GetTransactionValidDuration())
+			tx.transactionValidDuration = &duration
+		}
+
 		if body.GetTransactionID() != nil {
 			transactionID = _TransactionIDFromProtobuf(body.GetTransactionID())
 		}

--- a/transaction_unit_test.go
+++ b/transaction_unit_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashgraph/hedera-protobufs-go/sdk"
 	"github.com/hashgraph/hedera-protobufs-go/services"
@@ -225,6 +226,7 @@ func DisabledTestUnitTransactionValidateBodiesNotEqual(t *testing.T) {
 }
 
 func TestUnitTransactionToFromBytes(t *testing.T) {
+	duration := time.Second * 10
 	operatorID := AccountID{Account: 5}
 	recepientID := AccountID{Account: 4}
 	node := []AccountID{{Account: 3}}
@@ -234,6 +236,7 @@ func TestUnitTransactionToFromBytes(t *testing.T) {
 		AddHbarTransfer(operatorID, NewHbar(-1)).
 		AddHbarTransfer(recepientID, NewHbar(1)).
 		SetTransactionMemo("go sdk example multi_app_transfer/main.go").
+		SetTransactionValidDuration(duration).
 		Freeze()
 	require.NoError(t, err)
 
@@ -247,6 +250,7 @@ func TestUnitTransactionToFromBytes(t *testing.T) {
 	require.Equal(t, tx.TransactionID.String(), testTransactionID._ToProtobuf().String())
 	require.Equal(t, tx.NodeAccountID.String(), node[0]._ToProtobuf().String())
 	require.Equal(t, tx.Memo, "go sdk example multi_app_transfer/main.go")
+	require.Equal(t, duration, _DurationFromProtobuf(tx.TransactionValidDuration))
 	require.Equal(t, tx.Data, &services.TransactionBody_CryptoTransfer{
 		CryptoTransfer: &services.CryptoTransferTransactionBody{
 			Transfers: &services.TransferList{
@@ -273,6 +277,7 @@ func TestUnitTransactionToFromBytes(t *testing.T) {
 	require.Equal(t, tx.TransactionID.String(), testTransactionID._ToProtobuf().String())
 	require.Equal(t, tx.NodeAccountID.String(), node[0]._ToProtobuf().String())
 	require.Equal(t, tx.Memo, "go sdk example multi_app_transfer/main.go")
+	require.Equal(t, duration, _DurationFromProtobuf(tx.TransactionValidDuration))
 	require.Equal(t, tx.Data, &services.TransactionBody_CryptoTransfer{
 		CryptoTransfer: &services.CryptoTransferTransactionBody{
 			Transfers: &services.TransferList{
@@ -292,6 +297,7 @@ func TestUnitTransactionToFromBytes(t *testing.T) {
 }
 
 func TestUnitTransactionToFromBytesWithClient(t *testing.T) {
+	duration := time.Second * 10
 	operatorID := AccountID{Account: 5}
 	recepientID := AccountID{Account: 4}
 	client := ClientForTestnet()
@@ -302,6 +308,7 @@ func TestUnitTransactionToFromBytesWithClient(t *testing.T) {
 		AddHbarTransfer(operatorID, NewHbar(-1)).
 		AddHbarTransfer(recepientID, NewHbar(1)).
 		SetTransactionMemo("go sdk example multi_app_transfer/main.go").
+		SetTransactionValidDuration(duration).
 		FreezeWith(client)
 	require.NoError(t, err)
 
@@ -309,6 +316,7 @@ func TestUnitTransactionToFromBytesWithClient(t *testing.T) {
 	_ = protobuf.Unmarshal(transaction.signedTransactions._Get(0).(*services.SignedTransaction).BodyBytes, &tx)
 	require.NotNil(t, tx.TransactionID, tx.NodeAccountID)
 	require.Equal(t, tx.Memo, "go sdk example multi_app_transfer/main.go")
+	require.Equal(t, duration, _DurationFromProtobuf(tx.TransactionValidDuration))
 	require.Equal(t, tx.Data, &services.TransactionBody_CryptoTransfer{
 		CryptoTransfer: &services.CryptoTransferTransactionBody{
 			Transfers: &services.TransferList{
@@ -339,6 +347,7 @@ func TestUnitTransactionToFromBytesWithClient(t *testing.T) {
 	require.Equal(t, tx.TransactionID.String(), initialTxID.String())
 	require.Equal(t, tx.NodeAccountID.String(), initialNode.String())
 	require.Equal(t, tx.Memo, "go sdk example multi_app_transfer/main.go")
+	require.Equal(t, duration, _DurationFromProtobuf(tx.TransactionValidDuration))
 	require.Equal(t, tx.Data, &services.TransactionBody_CryptoTransfer{
 		CryptoTransfer: &services.CryptoTransferTransactionBody{
 			Transfers: &services.TransferList{


### PR DESCRIPTION
**Description**:
TransactionFromByte hardcodes duration to 120s instead of reading it. This PR fixes this.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/664
