### PR TITLE
Fix: Receipt silencing error

### DIFF
--- a/executable.go
+++ b/executable.go
@@ -280,7 +280,7 @@ func _Execute( // nolint
 		return TransactionResponse{}, errors.Wrapf(errPersistent, "retry %d/%d", attempt, maxAttempts)
 	}
 
-	return &services.Response{}, errors.Wrapf(errPersistent, "retry %d/%d", attempt, maxAttempts)
+	return &services.Response{}, errPersistent
 }
 
 func _DelayForAttempt(logID string, backoff time.Duration, attempt int64) {

--- a/transaction_receipt_query.go
+++ b/transaction_receipt_query.go
@@ -206,7 +206,7 @@ func _TransactionReceiptQueryShouldRetry(logID string, request interface{}, resp
 
 func _TransactionReceiptQueryMapStatusError(request interface{}, response interface{}) error {
 	switch Status(response.(*services.Response).GetTransactionGetReceipt().GetHeader().GetNodeTransactionPrecheckCode()) {
-	case StatusPlatformTransactionNotCreated, StatusBusy, StatusUnknown, StatusReceiptNotFound, StatusRecordNotFound, StatusOk:
+	case StatusPlatformTransactionNotCreated, StatusBusy, StatusUnknown, StatusOk:
 		break
 	default:
 		return ErrHederaPreCheckStatus{
@@ -337,8 +337,8 @@ func (query *TransactionReceiptQuery) Execute(client *Client) (TransactionReceip
 		if resp.(*services.Response).GetTransactionGetReceipt() != nil {
 			return _TransactionReceiptFromProtobuf(resp.(*services.Response).GetTransactionGetReceipt(), query.transactionID), err
 		}
-
-		return TransactionReceipt{}, err
+		// Manually add the receipt status, because an empty receipt has no status and no status defaults to 0, which means success
+		return TransactionReceipt{Status: err.Status}, err
 	}
 
 	return _TransactionReceiptFromProtobuf(resp.(*services.Response).GetTransactionGetReceipt(), query.transactionID), nil

--- a/transaction_record_query_unit_test.go
+++ b/transaction_record_query_unit_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"testing"
 
+	"github.com/hashgraph/hedera-protobufs-go/services"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
@@ -108,4 +109,51 @@ func TestUnitTransactionRecordQueryNothingSet(t *testing.T) {
 	balance.GetPaymentTransactionID()
 	balance.GetQueryPayment()
 	balance.GetMaxQueryPayment()
+}
+
+func TestUnitTransactionRecordReceiptNotFound(t *testing.T) {
+	responses := [][]interface{}{{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_RECEIPT_NOT_FOUND,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_RECEIPT_NOT_FOUND,
+					},
+				},
+			},
+		},
+	}}
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+		client.SetMaxAttempts(2)
+	require.NoError(t, err)	
+	record, err :=tx.SetValidateStatus(true).GetRecord(client)
+	require.Error(t, err)
+	require.Equal(t, "exceptional precheck status RECEIPT_NOT_FOUND", err.Error())
+	require.Equal(t, StatusReceiptNotFound, record.Receipt.Status)
 }

--- a/transaction_response.go
+++ b/transaction_response.go
@@ -42,13 +42,14 @@ func (response TransactionResponse) GetReceipt(client *Client) (TransactionRecei
 }
 
 func (response TransactionResponse) GetRecord(client *Client) (TransactionRecord, error) {
-	_, err := NewTransactionReceiptQuery().
+	receipt, err := NewTransactionReceiptQuery().
 		SetTransactionID(response.TransactionID).
 		SetNodeAccountIDs([]AccountID{response.NodeID}).
 		Execute(client)
 
 	if err != nil {
-		return TransactionRecord{}, err
+		// Manually add the receipt, because an empty TransactionRecord will have an empty receipt and empty receipt has no status and no status defaults to 0, which means success
+		return TransactionRecord{Receipt: receipt}, err
 	}
 
 	return NewTransactionRecordQuery().


### PR DESCRIPTION
**Description**:
When there is an error retrieving receipt, like `RECEIPT_NO_FOUND` the error is silenced and the status is `Success`.
This PR fixes this.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/672

**Notes for reviewer**:
The SDK retries to get the receipt even when the node returns `RECEIPT_NO_FOUND`, because we might try to get the receipt before it is ready.
When the receipt has expired, the node will return `RECEIPT_NO_FOUND`, in this case we will retry until we reach `MaxAttempts`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
