### PR TITLE
Fix: Remove minimum requirement for 25th on queries

### DIFF
--- a/account_info_query.go
+++ b/account_info_query.go
@@ -166,9 +166,6 @@ func (query *AccountInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetCryptoGetInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 
 	return HbarFromTinybar(cost), nil
 }

--- a/contract_info_query.go
+++ b/contract_info_query.go
@@ -141,9 +141,6 @@ func (query *ContractInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetContractGetInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 
 	return HbarFromTinybar(cost), nil
 }

--- a/file_info_query.go
+++ b/file_info_query.go
@@ -134,9 +134,6 @@ func (query *FileInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetFileGetInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -773,6 +773,7 @@ func NewMockServer(responses []interface{}) (server *MockServer) {
 	server.server.RegisterService(NewServiceDescription(handler, &services.TokenService_ServiceDesc), nil)
 	server.server.RegisterService(NewServiceDescription(handler, &services.ScheduleService_ServiceDesc), nil)
 	server.server.RegisterService(NewServiceDescription(handler, &services.FreezeService_ServiceDesc), nil)
+	server.server.RegisterService(NewServiceDescription(handler, &services.NetworkService_ServiceDesc), nil)
 	server.server.RegisterService(NewMirrorServiceDescription(streamHandler, &mirror.NetworkService_ServiceDesc), nil)
 
 	server.listener, err = net.Listen("tcp", "localhost:0")

--- a/network_version_info_query.go
+++ b/network_version_info_query.go
@@ -78,9 +78,6 @@ func (query *NetworkVersionInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetNetworkGetVersionInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/nework_version_info_query_unit_test.go
+++ b/nework_version_info_query_unit_test.go
@@ -1,0 +1,72 @@
+//go:build all || unit
+// +build all unit
+
+package hedera
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashgraph/hedera-protobufs-go/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitNetworkVersionInfoQuerySetNothing(t *testing.T) {
+	query := NewNetworkVersionQuery()
+
+	require.Equal(t, []AccountID{}, query.GetNodeAccountIDs())
+	require.Equal(t, 250*time.Millisecond, query.GetMinBackoff())
+	require.Equal(t, 8*time.Second, query.GetMaxBackoff())
+	require.Equal(t, 10, query.GetMaxRetryCount())
+	require.Equal(t, TransactionID{}, query.GetPaymentTransactionID())
+	require.Equal(t, Hbar{}, query.GetQueryPayment())
+	require.Equal(t, Hbar{}, query.GetMaxQueryPayment())
+}
+
+func TestNetworkVersionInfoQuery_Get(t *testing.T) {
+	deadline := time.Duration(time.Minute)
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+	query := NewNetworkVersionQuery().
+		SetQueryPayment(NewHbar(2)).
+		SetMaxQueryPayment(NewHbar(10)).
+		SetNodeAccountIDs([]AccountID{{Account: 3}, {Account: 4}}).
+		SetMaxRetry(5).
+		SetMaxBackoff(10 * time.Second).
+		SetMinBackoff(1 * time.Second).
+		SetPaymentTransactionID(transactionID).
+		SetGrpcDeadline(&deadline)
+
+	require.Equal(t, NewHbar(2), query.GetQueryPayment())
+	require.Equal(t, NewHbar(10), query.GetMaxQueryPayment())
+	require.Equal(t, []AccountID{{Account: 3}, {Account: 4}}, query.GetNodeAccountIDs())
+	require.Equal(t, 5, query.GetMaxRetryCount())
+	require.Equal(t, 10*time.Second, query.GetMaxBackoff())
+	require.Equal(t, 1*time.Second, query.GetMinBackoff())
+	require.Equal(t, transactionID, query.GetPaymentTransactionID())
+	require.Equal(t, &deadline, query.GetGrpcDeadline())
+	require.Equal(t, fmt.Sprintf("NetworkVersionInfoQuery:%v", transactionID.ValidStart.UnixNano()), query._GetLogID())
+}
+
+func TestUnitNetworkVersionInfoQueryMock(t *testing.T) {
+	responses := [][]interface{}{{
+		&services.Response{
+			Response: &services.Response_NetworkGetVersionInfo{
+				NetworkGetVersionInfo: &services.NetworkGetVersionInfoResponse{
+					Header: &services.ResponseHeader{NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK, ResponseType: services.ResponseType_COST_ANSWER, Cost: 2},
+				},
+			},
+		},
+	}}
+
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+
+	query := NewNetworkVersionQuery().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		SetMaxQueryPayment(NewHbar(1))
+
+	cost, err := query.GetCost(client)
+	require.NoError(t, err)
+	require.Equal(t, HbarFromTinybar(2), cost)
+}

--- a/schedule_info_query.go
+++ b/schedule_info_query.go
@@ -137,9 +137,6 @@ func (query *ScheduleInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetScheduleGetInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/token_info_query.go
+++ b/token_info_query.go
@@ -136,9 +136,6 @@ func (query *TokenInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetTokenGetInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/token_nft_info_query.go
+++ b/token_nft_info_query.go
@@ -198,9 +198,6 @@ func (query *TokenNftInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetTokenGetNftInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/topic_info_query.go
+++ b/topic_info_query.go
@@ -138,9 +138,6 @@ func (query *TopicInfoQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetConsensusGetTopicInfo().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 

--- a/transaction_record_query.go
+++ b/transaction_record_query.go
@@ -178,9 +178,6 @@ func (query *TransactionRecordQuery) GetCost(client *Client) (Hbar, error) {
 	}
 
 	cost := int64(resp.(*services.Response).GetTransactionGetRecord().Header.Cost)
-	if cost < 25 {
-		return HbarFromTinybar(25), nil
-	}
 	return HbarFromTinybar(cost), nil
 }
 


### PR DESCRIPTION
**Description**:
Each Query has a certain cost. When asked `GetCost()` the consensus node returns the cost of the query.
If the answer was below 25th, the SDK was returning 25th, so in effect making the minimum query cost 25th.
This PR removes this, the `GetCost()` now returns the correct amount even if it is below 25th.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/692

**Notes for reviewer**:
It's mostly tests in this PR.

**Checklist**

- [ x ] Documented (Code comments, README, etc.)
- [ x ] Tested (unit, integration, etc.)
