### PR TITLE
Fix transaction ID with leading zeroes

### DIFF
--- a/transaction_id.go
+++ b/transaction_id.go
@@ -90,7 +90,8 @@ func (id TransactionID) String() string {
 	var returnString string
 	if id.AccountID != nil && id.ValidStart != nil {
 		pb = _TimeToProtobuf(*id.ValidStart)
-		returnString = id.AccountID.String() + "@" + strconv.FormatInt(pb.Seconds, 10) + "." + fmt.Sprint(pb.Nanos)
+		// Use fmt.Sprintf to format the string with leading zeros
+		returnString = id.AccountID.String() + "@" + fmt.Sprintf("%d.%09d", pb.Seconds, pb.Nanos)
 	}
 
 	if id.scheduled {

--- a/transaction_id_unit_test.go
+++ b/transaction_id_unit_test.go
@@ -47,3 +47,15 @@ func TestUnitTransactionIDFromStringNonce(t *testing.T) {
 	require.Equal(t, *txID.Nonce, int32(4))
 	require.Equal(t, txID.AccountID.String(), "0.0.3")
 }
+
+func TestUnitTransactionIDFromStringLeadingZero(t *testing.T) {
+	txID, err := TransactionIdFromString("0.0.3@1614997926.074912965")
+	require.NoError(t, err)
+	require.Equal(t, txID.String(), "0.0.3@1614997926.074912965")
+}
+
+func TestUnitTransactionIDFromStringTrimmedZeroes(t *testing.T) {
+	txID, err := TransactionIdFromString("0.0.3@1614997926.5")
+	require.NoError(t, err)
+	require.Equal(t, txID.String(), "0.0.3@1614997926.000000005")
+}


### PR DESCRIPTION
**Description**:
When the transaction ID starts with 0, when the `String()` is called it trims the leading zeroes. This PR fixes this, so it is consistent with Mirror Node.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/733

