### PR TITLE
Feat: Add LedgerID identifier functionality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - gochecknoinits

--- a/account_id_unit_test.go
+++ b/account_id_unit_test.go
@@ -33,13 +33,14 @@ import (
 
 func TestUnitAccountIDChecksumFromString(t *testing.T) {
 	id, err := AccountIDFromString("0.0.123-rmkyk")
-
+	require.NoError(t, err)
 	client := ClientForTestnet()
 	id.ToStringWithChecksum(client)
 	id.GetChecksum()
 	sol := id.ToSolidityAddress()
 	AccountIDFromSolidityAddress(sol)
-	id.Validate(client)
+	err = id.Validate(client)
+	require.Error(t, err)
 	evmID, err := AccountIDFromEvmAddress(0, 0, "ace082947b949651c703ff0f02bc1541")
 	require.NoError(t, err)
 	pb := evmID._ToProtobuf()

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -37,7 +37,7 @@ func DisabledTestIntegrationClientPingAllBadNetwork(t *testing.T) { // nolint
 	netwrk := _NewNetwork()
 	netwrk.SetNetwork(env.Client.GetNetwork())
 
-	tempClient := _NewClient(netwrk, env.Client.GetMirrorNetwork(), *env.Client.GetNetworkName())
+	tempClient := _NewClient(netwrk, env.Client.GetMirrorNetwork(), env.Client.GetLedgerID())
 	tempClient.SetOperator(env.OperatorID, env.OperatorKey)
 
 	tempClient.SetMaxNodeAttempts(1)

--- a/contract_id_unit_test.go
+++ b/contract_id_unit_test.go
@@ -38,7 +38,6 @@ func TestUnitContractIDChecksumFromString(t *testing.T) {
 	require.NoError(t, err)
 
 	client := ClientForTestnet()
-	fmt.Println(id.ToStringWithChecksum(*client))
 	sol := id.ToSolidityAddress()
 	ContractIDFromSolidityAddress(sol)
 	err = id.Validate(client)

--- a/contract_id_unit_test.go
+++ b/contract_id_unit_test.go
@@ -38,10 +38,11 @@ func TestUnitContractIDChecksumFromString(t *testing.T) {
 	require.NoError(t, err)
 
 	client := ClientForTestnet()
-	id.ToStringWithChecksum(*client)
+	fmt.Println(id.ToStringWithChecksum(*client))
 	sol := id.ToSolidityAddress()
 	ContractIDFromSolidityAddress(sol)
-	id.Validate(client)
+	err = id.Validate(client)
+	require.Error(t, err)
 	evmID, err := ContractIDFromEvmAddress(0, 0, "ace082947b949651c703ff0f02bc1541")
 	require.NoError(t, err)
 	pb := evmID._ToProtobuf()

--- a/delegatable_contract_id.go
+++ b/delegatable_contract_id.go
@@ -59,14 +59,14 @@ func DelegatableContractIDFromString(data string) (DelegatableContractID, error)
 		Shard:      uint64(shard),
 		Realm:      uint64(realm),
 		Contract:   uint64(num),
-		EvmAddress: []byte{},
+		EvmAddress: nil,
 		checksum:   checksum,
 	}, nil
 }
 
 // Verify that the client has a valid checksum.
 func (id *DelegatableContractID) ValidateChecksum(client *Client) error {
-	if !id._IsZero() && client != nil && client.network.ledgerID != nil {
+	if !id._IsZero() && client != nil {
 		var tempChecksum _ParseAddressResult
 		var err error
 		if client.network.ledgerID != nil {
@@ -83,18 +83,21 @@ func (id *DelegatableContractID) ValidateChecksum(client *Client) error {
 			return errChecksumMissing
 		}
 		if tempChecksum.correctChecksum != *id.checksum {
-			temp, _ := client.network.ledgerID.ToNetworkName()
+			networkName := NetworkNameOther
+			if client.network.ledgerID != nil {
+				networkName, _ = client.network.ledgerID.ToNetworkName()
+			}
 			return errors.New(fmt.Sprintf("network mismatch or wrong checksum given, given checksum: %s, correct checksum %s, network: %s",
 				*id.checksum,
 				tempChecksum.correctChecksum,
-				temp))
+				networkName))
 		}
 	}
 
 	return nil
 }
 
-// DelegatableContractIDFromSolidityAddress constructs a DelegatableContractID from a string representation of a _Solidity address
+// DelegatableContractIDFromEvmAddress constructs a DelegatableContractID from a string representation of a _Solidity address
 func DelegatableContractIDFromEvmAddress(shard uint64, realm uint64, evmAddress string) (DelegatableContractID, error) {
 	temp, err := hex.DecodeString(evmAddress)
 	if err != nil {

--- a/delegate_contract_id_unit_test.go
+++ b/delegate_contract_id_unit_test.go
@@ -1,0 +1,145 @@
+//go:build all || unit
+// +build all unit
+
+package hedera
+
+/*-
+ *
+ * Hedera Go SDK
+ *
+ * Copyright (C) 2020 - 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/hashgraph/hedera-protobufs-go/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitDelegatableContractIDChecksumFromString(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.123-rmkyk")
+	require.NoError(t, err)
+
+	client := ClientForTestnet()
+	err = id.ValidateChecksum(client)
+	require.Error(t, err)
+	require.Equal(t, id.Contract, uint64(123))
+	strChecksum, err := id.ToStringWithChecksum(*client)
+	require.NoError(t, err)
+	// different checksum because of different network
+	require.Equal(t, strChecksum, "0.0.123-esxsf")
+}
+
+func TestUnitDelegatableContractIDChecksumToString(t *testing.T) {
+	id := DelegatableContractID{
+		Shard:    50,
+		Realm:    150,
+		Contract: 520,
+	}
+	require.Equal(t, "50.150.520", id.String())
+}
+
+func TestUnitDelegatableContractIDFromStringEVM(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.0011223344556677889900112233445577889900")
+	require.NoError(t, err)
+
+	require.Equal(t, "0.0.0011223344556677889900112233445577889900", id.String())
+}
+
+func TestUnitDelegatableContractIDProtobuf(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.0011223344556677889900112233445577889900")
+	require.NoError(t, err)
+
+	pb := id._ToProtobuf()
+
+	decoded, err := hex.DecodeString("0011223344556677889900112233445577889900")
+	require.NoError(t, err)
+
+	require.Equal(t, pb, &services.ContractID{
+		ShardNum: 0,
+		RealmNum: 0,
+		Contract: &services.ContractID_EvmAddress{EvmAddress: decoded},
+	})
+
+	pbFrom := _DelegatableContractIDFromProtobuf(pb)
+
+	require.Equal(t, id, *pbFrom)
+}
+
+func TestUnitDelegatableContractIDEvm(t *testing.T) {
+	hexString, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	id, err := DelegatableContractIDFromString(fmt.Sprintf("0.0.%s", hexString.PublicKey().String()))
+	require.NoError(t, err)
+	require.Equal(t, hex.EncodeToString(id.EvmAddress), hexString.PublicKey().String())
+
+	pb := id._ToProtobuf()
+	require.Equal(t, pb, &services.ContractID{
+		ShardNum: 0,
+		RealmNum: 0,
+		Contract: &services.ContractID_EvmAddress{EvmAddress: id.EvmAddress},
+	})
+
+	id, err = DelegatableContractIDFromString("0.0.123")
+	require.NoError(t, err)
+	require.Equal(t, id.Contract, uint64(123))
+	require.Nil(t, id.EvmAddress)
+
+	pb = id._ToProtobuf()
+	require.Equal(t, pb, &services.ContractID{
+		ShardNum: 0,
+		RealmNum: 0,
+		Contract: &services.ContractID_ContractNum{ContractNum: 123},
+	})
+}
+
+func TestUnitDelegatableContractIDToFromBytes(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.123")
+	require.NoError(t, err)
+	require.Equal(t, id.Contract, uint64(123))
+	require.Nil(t, id.EvmAddress)
+
+	idBytes := id.ToBytes()
+	idFromBytes, err := DelegatableContractIDFromBytes(idBytes)
+	require.NoError(t, err)
+	require.Equal(t, id, idFromBytes)
+}
+
+func TestUnitDelegatableContractIDFromEvmAddress(t *testing.T) {
+	id, err := DelegatableContractIDFromEvmAddress(0, 0, "0011223344556677889900112233445566778899")
+	require.NoError(t, err)
+	require.Equal(t, id.Contract, uint64(0))
+	require.Equal(t, id.EvmAddress, []byte{0x0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99})
+}
+
+func TestUnitDelegatableContractIDFromSolidityAddress(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.123-rmkyk")
+	require.NoError(t, err)
+	sol := id.ToSolidityAddress()
+	idFromSolidity, err := DelegatableContractIDFromSolidityAddress(sol)
+	require.NoError(t, err)
+	require.Equal(t, idFromSolidity.Contract, uint64(123))
+}
+
+func TestUnitDelegatableContractIDToProtoKey(t *testing.T) {
+	id, err := DelegatableContractIDFromString("0.0.123-rmkyk")
+	require.NoError(t, err)
+	pb := id._ToProtoKey()
+	require.Equal(t, pb.GetContractID().GetContractNum(), int64(123))
+}

--- a/errors.go
+++ b/errors.go
@@ -46,7 +46,6 @@ var errTransactionRequiresSingleNodeAccountID = errors.New("`PrivateKey.SignTran
 var errNoTransactions = errors.New("no transactions to execute")
 var errByteArrayNull = errors.New("byte array can't be null")
 var errParameterNull = errors.New("the parameter can't be null")
-var errNetworkMismatch = errors.New("network mismatch; some IDs have different networks set")
 var errNetworkNameMissing = errors.New("can't derive checksum for ID without knowing which _Network the ID is for")
 var errChecksumMissing = errors.New("no checksum provided")
 var errLockedSlice = errors.New("slice is locked")

--- a/network.go
+++ b/network.go
@@ -88,15 +88,6 @@ func (network *_Network) _GetNode() *_Node {
 	return network._ManagedNetwork._GetNode().(*_Node)
 }
 
-func (network *_Network) _GetNetworkName() *NetworkName {
-	if network._ManagedNetwork._GetLedgerID() != nil {
-		temp, _ := network._ManagedNetwork._GetLedgerID().ToNetworkName()
-		return &temp
-	}
-
-	return nil
-}
-
 func (network *_Network) _GetLedgerID() *LedgerID {
 	if network._ManagedNetwork._GetLedgerID() != nil {
 		return network._ManagedNetwork._GetLedgerID()
@@ -135,15 +126,6 @@ func (network *_Network) _SetLedgerID(id LedgerID) {
 			}
 		}
 	}
-}
-
-func (network *_Network) _SetNetworkName(net NetworkName) {
-	ledger, err := LedgerIDFromNetworkName(net)
-	if err != nil {
-		panic(err)
-	}
-
-	network._SetLedgerID(*ledger)
 }
 
 func (network *_Network) _GetNodeAccountIDsForExecute() []AccountID { //nolint

--- a/schedule_create_transaction_unit_test.go
+++ b/schedule_create_transaction_unit_test.go
@@ -69,7 +69,8 @@ func TestUnitScheduleSignTransactionValidate(t *testing.T) {
 	client.SetAutoValidateChecksums(true)
 	scheduleID, err := ScheduleIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-
+	err = scheduleID.Validate(client)
+	require.NoError(t, err)
 	scheduleSign := NewScheduleSignTransaction().
 		SetScheduleID(scheduleID)
 
@@ -82,7 +83,8 @@ func TestUnitScheduleSignTransactionValidateWrong(t *testing.T) {
 	client.SetAutoValidateChecksums(true)
 	scheduleID, err := ScheduleIDFromString("0.0.123-rmkykd")
 	require.NoError(t, err)
-
+	err = scheduleID.Validate(client)
+	require.Error(t, err)
 	scheduleSign := NewScheduleSignTransaction().
 		SetScheduleID(scheduleID)
 

--- a/token_allowance_unit_test.go
+++ b/token_allowance_unit_test.go
@@ -24,8 +24,9 @@ package hedera
  */
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnitNewTokenAllowance(t *testing.T) {

--- a/token_balance_map_unit_test.go
+++ b/token_balance_map_unit_test.go
@@ -24,9 +24,10 @@ package hedera
  */
 
 import (
+	"testing"
+
 	"github.com/hashgraph/hedera-protobufs-go/services"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUnitTokenBalanceMapGet(t *testing.T) {

--- a/token_decimal_map_unit_test.go
+++ b/token_decimal_map_unit_test.go
@@ -24,9 +24,10 @@ package hedera
  */
 
 import (
+	"testing"
+
 	"github.com/hashgraph/hedera-protobufs-go/services"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUnitTokenDecimalMapGet(t *testing.T) {

--- a/topic_id.go
+++ b/topic_id.go
@@ -54,7 +54,7 @@ func TopicIDFromString(data string) (TopicID, error) {
 
 // Verify that the client has a valid checksum.
 func (id *TopicID) ValidateChecksum(client *Client) error {
-	if !id._IsZero() && client != nil && client.network.ledgerID != nil {
+	if !id._IsZero() && client != nil {
 		tempChecksum, err := _ChecksumParseAddress(client.GetLedgerID(), fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.Topic))
 		if err != nil {
 			return err
@@ -67,43 +67,23 @@ func (id *TopicID) ValidateChecksum(client *Client) error {
 			return errChecksumMissing
 		}
 		if tempChecksum.correctChecksum != *id.checksum {
-			temp, _ := client.network.ledgerID.ToNetworkName()
+			networkName := NetworkNameOther
+			if client.network.ledgerID != nil {
+				networkName, _ = client.network.ledgerID.ToNetworkName()
+			}
 			return errors.New(fmt.Sprintf("network mismatch or wrong checksum given, given checksum: %s, correct checksum %s, network: %s",
 				*id.checksum,
 				tempChecksum.correctChecksum,
-				temp))
+				networkName))
 		}
 	}
 
 	return nil
 }
 
-// Deprecated
+// Deprecated - use ValidateChecksum instead
 func (id *TopicID) Validate(client *Client) error {
-	if !id._IsZero() && client != nil && client.network.ledgerID != nil {
-		var tempChecksum _ParseAddressResult
-		var err error
-		tempChecksum, err = _ChecksumParseAddress(client.GetLedgerID(), fmt.Sprintf("%d.%d.%d", id.Shard, id.Realm, id.Topic))
-		if err != nil {
-			return err
-		}
-		err = _ChecksumVerify(tempChecksum.status)
-		if err != nil {
-			return err
-		}
-		if id.checksum == nil {
-			return errChecksumMissing
-		}
-		if tempChecksum.correctChecksum != *id.checksum {
-			temp, _ := client.network.ledgerID.ToNetworkName()
-			return errors.New(fmt.Sprintf("network mismatch or wrong checksum given, given checksum: %s, correct checksum %s, network: %s",
-				*id.checksum,
-				tempChecksum.correctChecksum,
-				temp))
-		}
-	}
-
-	return nil
+	return id.ValidateChecksum(client)
 }
 
 func (id TopicID) _IsZero() bool {

--- a/topic_info_query_unit_test.go
+++ b/topic_info_query_unit_test.go
@@ -38,7 +38,8 @@ func TestUnitTopicInfoQueryValidate(t *testing.T) {
 	client.SetAutoValidateChecksums(true)
 	topicID, err := TopicIDFromString("0.0.123-esxsf")
 	require.NoError(t, err)
-
+	err = topicID.Validate(client)
+	require.NoError(t, err)
 	topicInfo := NewTopicInfoQuery().
 		SetTopicID(topicID)
 
@@ -51,7 +52,8 @@ func TestUnitTopicInfoQueryValidateWrong(t *testing.T) {
 	client.SetAutoValidateChecksums(true)
 	topicID, err := TopicIDFromString("0.0.123-rmkykd")
 	require.NoError(t, err)
-
+	err = topicID.Validate(client)
+	require.Error(t, err)
 	topicInfo := NewTopicInfoQuery().
 		SetTopicID(topicID)
 


### PR DESCRIPTION
**Description**:
LedgerID is just a way of representing networks: mainnet, testnet, previewnet, other.

LegerID identifier was already built, but wasn't finished properly. This PR finishes the implementation.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/603

**Checklist**

- [ x ] Documented (Code comments, README, etc.)
- [ x ] Tested (unit, integration, etc.)
