### PR TITLE
feat: Add option to create file from config without mirror network

### DIFF
--- a/client-config-with-operator.json
+++ b/client-config-with-operator.json
@@ -7,6 +7,6 @@
   },
   "operator": {
       "accountId": "0.0.3",
-      "privateKey": "302e020100300506032b657004220420eaa013282e"
+      "privateKey": "a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4"
   }
 }

--- a/client.go
+++ b/client.go
@@ -281,8 +281,10 @@ func ClientFromConfig(jsonBytes []byte) (*Client, error) {
 				client = _NewClient(network, previewnetMirror, NewLedgerIDPreviewnet())
 			}
 		}
+	case nil:
+		client = _NewClient(network, []string{}, nil)
 	default:
-		return client, errors.New("mirrorNetwork is expected to be either string or an array of strings")
+		return client, errors.New("mirrorNetwork is expected to be a string, an array of strings or nil")
 	}
 
 	// if the _Operator is not provided, finish here

--- a/client_all_test.go
+++ b/client_all_test.go
@@ -43,6 +43,25 @@ const testClientJSONWithOperator string = `{
     "mirrorNetwork": "testnet"
 }`
 
+const testClientJSONWithoutMirrorNetwork string = `{
+    "network": {
+		"35.237.200.180:50211": "0.0.3",
+		"35.186.191.247:50211": "0.0.4",
+		"35.192.2.25:50211": "0.0.5",
+		"35.199.161.108:50211": "0.0.6",
+		"35.203.82.240:50211": "0.0.7",
+		"35.236.5.219:50211": "0.0.8",
+		"35.197.192.225:50211": "0.0.9",
+		"35.242.233.154:50211": "0.0.10",
+		"35.240.118.96:50211": "0.0.11",
+		"35.204.86.32:50211": "0.0.12"
+    },
+    "operator": {
+        "accountId": "0.0.3",
+        "privateKey": "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10"
+    }
+}`
+
 const testClientJSONWrongTypeMirror string = `{
     "network": "testnet",
     "operator": {
@@ -56,6 +75,15 @@ const testClientJSONWrongTypeNetwork string = `{
     "network": 1,
     "operator": {
         "accountId": "0.0.3",
+        "privateKey": "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10"
+    },
+ 	"mirrorNetwork": ["hcs.testnet.mirrornode.hedera.com:5600"]
+}`
+
+const testClientJSONWrongAccountIDNetwork string = `{
+    "network": {"35.237.200.180:50211": "0.0.3"},
+    "operator": {
+        "accountId": "wrong",
         "privateKey": "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10"
     },
  	"mirrorNetwork": ["hcs.testnet.mirrornode.hedera.com:5600"]

--- a/client_unit_test.go
+++ b/client_unit_test.go
@@ -55,18 +55,52 @@ func TestUnitClientFromConfigWithOperator(t *testing.T) {
 	assert.Equal(t, AccountID{Account: 3}.Account, client.operator.accountID.Account)
 }
 
-func TestUnitClientFromConfigWrongType(t *testing.T) {
+func TestUnitClientFromConfigWithoutMirrorNetwork(t *testing.T) {
+	client, err := ClientFromConfig([]byte(testClientJSONWithoutMirrorNetwork))
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+
+	assert.True(t, len(client.network.network) > 0)
+	assert.True(t, len(client.GetMirrorNetwork()) == 0)
+}
+
+func TestUnitClientFromConfigWrongMirrorNetworkType(t *testing.T) {
 	_, err := ClientFromConfig([]byte(testClientJSONWrongTypeMirror))
 	assert.Error(t, err)
 	if err != nil {
-		assert.Equal(t, "mirrorNetwork is expected to be either string or an array of strings", err.Error())
+		assert.Equal(t, "mirrorNetwork is expected to be a string, an array of strings or nil", err.Error())
 	}
+}
 
-	_, err = ClientFromConfig([]byte(testClientJSONWrongTypeNetwork))
+func TestUnitClientFromConfigWrongNetworkType(t *testing.T) {
+	_, err := ClientFromConfig([]byte(testClientJSONWrongTypeNetwork))
 	assert.Error(t, err)
 	if err != nil {
 		assert.Equal(t, "network is expected to be map of string to string, or string", err.Error())
 	}
+}
+
+func TestUnitClientFromConfigWrongAccountIDNetworkType(t *testing.T) {
+	_, err := ClientFromConfig([]byte(testClientJSONWrongAccountIDNetwork))
+	assert.Error(t, err)
+	if err != nil {
+		assert.Equal(t, "expected {shard}.{realm}.{num}", err.Error())
+	}
+}
+
+func TestUnitClientFromCorrectConfigFile(t *testing.T) {
+	client, err := ClientFromConfigFile("client-config-with-operator.json")
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.NotNil(t, client.operator)
+	assert.Equal(t, AccountID{Account: 3}.Account, client.operator.accountID.Account)
+	assert.Equal(t, "a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4", client.operator.privateKey.StringRaw())
+}
+
+func TestUnitClientFromMissingConfigFile(t *testing.T) {
+	client, err := ClientFromConfigFile("missing.json")
+	assert.Error(t, err)
+	assert.Nil(t, client)
 }
 
 func TestUnitClientSetNetworkExtensive(t *testing.T) {


### PR DESCRIPTION
**Description**:
This PR adds the option to be able to create a client from config file without mirror network.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/748

**Checklist**
- [ x ] Tested (unit, integration, etc.)
