### PR TITLE
Fix: ContractCreateFlow

### DIFF
--- a/contract_create_flow_e2e_test.go
+++ b/contract_create_flow_e2e_test.go
@@ -74,3 +74,24 @@ func TestIntegrationContractCreateFlowCanExecute(t *testing.T) {
 	err = CloseIntegrationTestEnv(env, nil)
 	require.NoError(t, err)
 }
+
+func TestIntegrationContractCreateFlowSmallContractCanExecute(t *testing.T) {
+	testContractByteCode := []byte(`6080604052348015600f57600080fd5b50604051601a90603b565b604051809103906000f0801580156035573d6000803e3d6000fd5b50506047565b605c8061009483390190565b603f806100556000396000f3fe6080604052600080fdfea2646970667358221220a20122cbad3457fedcc0600363d6e895f17048f5caa4afdab9e655123737567d64736f6c634300081200336080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066735822122053dfd8835e3dc6fedfb8b4806460b9b7163f8a7248bac510c6d6808d9da9d6d364736f6c63430008120033`)
+
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+
+	resp, err := NewContractCreateFlow().
+		SetBytecode(testContractByteCode).
+		SetAdminKey(env.OperatorKey).
+		SetGas(100000).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	require.NotNil(t, receipt.ContractID)
+
+	err = CloseIntegrationTestEnv(env, nil)
+	require.NoError(t, err)
+}

--- a/contract_create_transaction_e2e_test.go
+++ b/contract_create_transaction_e2e_test.go
@@ -24,6 +24,8 @@ package hedera
  */
 
 import (
+	"encoding/hex"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -252,6 +254,29 @@ func TestIntegrationContractCreateTransactionNoBytecodeFileID(t *testing.T) {
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
+
+	err = CloseIntegrationTestEnv(env, nil)
+	require.NoError(t, err)
+}
+
+func TestIntegrationContractCreateTransactionSetBytecode(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	
+	hexData := `608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101cb806100606000396000f3fe608060405260043610610046576000357c01000000000000000000000000000000000000000000000000000000009004806341c0e1b51461004b578063cfae321714610062575b600080fd5b34801561005757600080fd5b506100606100f2565b005b34801561006e57600080fd5b50610077610162565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100b757808201518184015260208101905061009c565b50505050905090810190601f1680156100e45780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610160573373ffffffffffffffffffffffffffffffffffffffff16ff5b565b60606040805190810160405280600d81526020017f48656c6c6f2c20776f726c64210000000000000000000000000000000000000081525090509056fea165627a7a72305820ae96fb3af7cde9c0abfe365272441894ab717f816f07f41f07b1cbede54e256e0029`
+	hexBytecode, err := hex.DecodeString(hexData)
+	require.NoError(t, err)
+
+	resp, err := NewContractCreateTransaction().
+		SetAdminKey(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetGas(10000000).
+		SetBytecode(hexBytecode).
+		Execute(env.Client)
+	require.NoError(t, err)
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	require.NotNil(t, receipt.ContractID)
 
 	err = CloseIntegrationTestEnv(env, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description**:
ContractCreateFlow was failing/passing depending on whether the user passed hex/ascii and also size.
It now works with ascii and does not depend on the size of the contract.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/758

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
