### PR TITLE
Test: Add receipt status unknown test

### DIFF
--- a/transaction_receipt_query_unit_test.go
+++ b/transaction_receipt_query_unit_test.go
@@ -161,3 +161,50 @@ func TestUnitTransactionReceiptNotFound(t *testing.T) {
 	require.Equal(t, "exceptional precheck status RECEIPT_NOT_FOUND", err.Error())
 	require.Equal(t, StatusReceiptNotFound, receipt.Status)
 }
+func TestUnitTransactionReceiptUknown(t *testing.T) {
+	t.Parallel()
+
+	responses := [][]interface{}{{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_UNKNOWN,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_SUCCESS,
+					},
+				},
+			},
+		},
+	}}
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	client.SetMaxAttempts(2)
+	require.NoError(t, err)
+	receipt, err := tx.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, receipt.Status)
+}


### PR DESCRIPTION
**Description**:
We already retry when the receipt status is UNKNOWN, this PR just adds a test verifying that's the case.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/788

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
