### PR TITLE
Test: Unique concurent transaction ids

### DIFF
--- a/transaction_id_unit_test.go
+++ b/transaction_id_unit_test.go
@@ -24,6 +24,7 @@ package hedera
  */
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,4 +69,36 @@ func TestUnitTransactionIDFromStringTrimmedZeroes(t *testing.T) {
 	txID, err := TransactionIdFromString("0.0.3@1614997926.5")
 	require.NoError(t, err)
 	require.Equal(t, txID.String(), "0.0.3@1614997926.000000005")
+}
+
+func TestUnitConcurrentTransactionIDsAreUnique(t *testing.T) {
+	const numOfTxns = 100000
+
+	account := AccountID{Account: 1}
+
+	// Channel to collect generated transaction IDs
+	idsCh := make(chan TransactionID, numOfTxns)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numOfTxns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			idsCh <- TransactionIDGenerate(account)
+		}()
+	}
+
+	// Close idsCh after all goroutines complete
+	go func() {
+		wg.Wait()
+		close(idsCh)
+	}()
+
+	seen := make(map[TransactionID]bool)
+	for id := range idsCh {
+		require.False(t, seen[id], "Transaction ID %v is not unique", id)
+		seen[id] = true
+	}
+
+	require.Equal(t, len(seen), numOfTxns)
 }


### PR DESCRIPTION
**Description**:
This PR adds a test verifying that the generated transaction id's are unique by generating 100k ids within 0.1 seconds.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/800

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
