### PR TITLE
Feat: Add ToJSON on recepit, record, response

### DIFF
--- a/account_id_e2e_test.go
+++ b/account_id_e2e_test.go
@@ -46,7 +46,6 @@ func TestIntegrationAccountIDCanPopulateAccountNumber(t *testing.T) {
 	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
-
 	idMirror, err := AccountIDFromEvmPublicAddress(evmAddress)
 	require.NoError(t, err)
 	time.Sleep(5 * time.Second)

--- a/client_e2e_test.go
+++ b/client_e2e_test.go
@@ -83,7 +83,7 @@ func TestIntegrationClientCanFailGracefullyWhenDoesNotHaveNodeOfAnotherClient(t 
 	// Try to execute it with the second client, which does not have the node
 	_, err = txFromBytes.Execute(client2)
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "Invalid node AccountID was set for transaction: 0.0.3")	
+	require.Equal(t, err.Error(), "Invalid node AccountID was set for transaction: 0.0.3")
 }
 
 func DisabledTestIntegrationClientPingAllBadNetwork(t *testing.T) { // nolint

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ethereum/go-ethereum v1.13.2
 	github.com/getsentry/sentry-go v0.24.1 // indirect
 	github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20230720072335-ed5726877e99
+	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1356,6 +1356,7 @@ github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -1512,9 +1513,11 @@ github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iP
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=

--- a/transaction_response.go
+++ b/transaction_response.go
@@ -1,5 +1,11 @@
 package hedera
 
+import (
+	"encoding/hex"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
 /*-
  *
  * Hedera Go SDK
@@ -31,6 +37,17 @@ type TransactionResponse struct {
 	NodeID                 AccountID
 	Hash                   []byte
 	ValidateStatus         bool
+}
+
+// MarshalJSON returns the JSON representation of the TransactionResponse.
+// This should yield the same result in all SDK's.
+func (response TransactionResponse) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	obj := make(map[string]interface{})
+	obj["nodeID"] = response.NodeID.String()
+	obj["hash"] = hex.EncodeToString(response.Hash)
+	obj["transactionID"] = response.TransactionID.String()
+	return json.Marshal(obj)
 }
 
 // GetReceipt retrieves the receipt for the transaction

--- a/transfer.go
+++ b/transfer.go
@@ -26,8 +26,9 @@ import (
 
 // Transfer is a transfer of hbars or tokens from one account to another
 type Transfer struct {
-	AccountID AccountID
-	Amount    Hbar
+	AccountID  AccountID
+	Amount     Hbar
+	IsApproved bool
 }
 
 func _TransferFromProtobuf(pb *services.AccountAmount) Transfer {
@@ -41,8 +42,9 @@ func _TransferFromProtobuf(pb *services.AccountAmount) Transfer {
 	}
 
 	return Transfer{
-		AccountID: accountID,
-		Amount:    HbarFromTinybar(pb.Amount),
+		AccountID:  accountID,
+		Amount:     HbarFromTinybar(pb.Amount),
+		IsApproved: pb.GetIsApproval(),
 	}
 }
 


### PR DESCRIPTION
**Description**:
We need ToJSON method for receipt, record and response that matches the output of JS SDK.
This PR adds `MarshalJSON` to these structs that does this.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-go/issues/797

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
