### PR TITLE
841 add account balanceinfo contract info mirror node queries

### DIFF
--- a/account_balance_query.go
+++ b/account_balance_query.go
@@ -116,9 +116,9 @@ func (q *AccountBalanceQuery) Execute(client *Client) (AccountBalance, error) {
 
 	network := obtainUrlForMirrorNode(client)
 	if q.accountID != nil {
-		_, err = queryBalanceFromMirrorNode(network, q.accountID.String(), &result)
+		err = queryBalanceFromMirrorNode(network, q.accountID.String(), &result)
 	} else {
-		_, err = queryBalanceFromMirrorNode(network, q.contractID.String(), &result)
+		err = queryBalanceFromMirrorNode(network, q.contractID.String(), &result)
 	}
 	if err != nil {
 		return AccountBalance{}, nil
@@ -128,10 +128,10 @@ func (q *AccountBalanceQuery) Execute(client *Client) (AccountBalance, error) {
 
 // Helper function, which query the mirror node and if the balance has tokens, it iterate over the tokens and assign them
 // inside `AccountBalance` tokens field
-func queryBalanceFromMirrorNode(network string, id string, result *AccountBalance) (*AccountBalance, error) {
+func queryBalanceFromMirrorNode(network string, id string, result *AccountBalance) error {
 	response, err := accountBalanceQuery(network, id)
 	if err != nil {
-		return result, err
+		return err
 	}
 	// If user has tokens
 	result.Tokens.balances = make(map[string]uint64)
@@ -143,7 +143,7 @@ func queryBalanceFromMirrorNode(network string, id string, result *AccountBalanc
 		}
 	}
 
-	return result, nil
+	return nil
 }
 
 // SetMaxQueryPayment sets the maximum payment allowed for this query.

--- a/account_balance_query_e2e_test.go
+++ b/account_balance_query_e2e_test.go
@@ -24,6 +24,7 @@ package hedera
  */
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,6 +195,8 @@ func TestIntegrationAccountBalanceQueryNoAccountIDError(t *testing.T) {
 	_, err := NewAccountBalanceQuery().
 		SetNodeAccountIDs(env.NodeAccountIDs).
 		Execute(env.Client)
+
+	fmt.Println(env.Client.network.ledgerID)
 	assert.Error(t, err)
 	assert.True(t, err.Error() == "exceptional precheck status INVALID_ACCOUNT_ID")
 

--- a/account_info_query.go
+++ b/account_info_query.go
@@ -58,6 +58,9 @@ func (q *AccountInfoQuery) Execute(client *Client) (AccountInfo, error) {
 	}
 
 	result, err := _AccountInfoFromProtobuf(resp.GetCryptoGetInfo().AccountInfo)
+	if err != nil {
+		return AccountInfo{}, err
+	}
 
 	network := obtainUrlForMirrorNode(client)
 	_, err = accountInfoqueryTokensRelationshipFromMirrorNode(network, q.accountID.String(), &result)

--- a/account_info_query_e2e_test.go
+++ b/account_info_query_e2e_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func TestIntegrationAccountInfoQueryCanExecute(t *testing.T) {
 
 	accountID := *receipt.AccountID
 	require.NoError(t, err)
-	//time.Sleep(3 * time.Second) // Wait for account to be fetched in the mirror node
+	time.Sleep(3 * time.Second)
 
 	info, err := NewAccountInfoQuery().
 		SetAccountID(accountID).
@@ -82,8 +83,8 @@ func TestIntegrationAccountInfoQueryCanExecute(t *testing.T) {
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 
-	//err = CloseIntegrationTestEnv(env, nil)
-	//require.NoError(t, err)
+	err = CloseIntegrationTestEnv(env, nil)
+	require.NoError(t, err)
 }
 
 func TestIntegrationAccountInfoQueryGetCost(t *testing.T) {
@@ -116,7 +117,7 @@ func TestIntegrationAccountInfoQueryGetCost(t *testing.T) {
 
 	cost, err := accountInfo.GetCost(env.Client)
 	require.NoError(t, err)
-
+	time.Sleep(3 * time.Second)
 	info, err := accountInfo.SetQueryPayment(cost).Execute(env.Client)
 	require.NoError(t, err)
 
@@ -230,6 +231,7 @@ func TestIntegrationAccountInfoQuerySetBigMaxPayment(t *testing.T) {
 	_, err = accountInfo.GetCost(env.Client)
 	require.NoError(t, err)
 
+	time.Sleep(3 * time.Second)
 	info, err := accountInfo.SetQueryPayment(NewHbar(1)).Execute(env.Client)
 	require.NoError(t, err)
 

--- a/account_info_query_e2e_test.go
+++ b/account_info_query_e2e_test.go
@@ -24,10 +24,8 @@ package hedera
  */
 
 import (
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +51,7 @@ func TestIntegrationAccountInfoQueryCanExecute(t *testing.T) {
 
 	accountID := *receipt.AccountID
 	require.NoError(t, err)
-	time.Sleep(3 * time.Second) // Wait for account to be fetched in the mirror node
+	//time.Sleep(3 * time.Second) // Wait for account to be fetched in the mirror node
 
 	info, err := NewAccountInfoQuery().
 		SetAccountID(accountID).

--- a/account_info_query_e2e_test.go
+++ b/account_info_query_e2e_test.go
@@ -25,6 +25,7 @@ package hedera
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -52,6 +53,7 @@ func TestIntegrationAccountInfoQueryCanExecute(t *testing.T) {
 
 	accountID := *receipt.AccountID
 	require.NoError(t, err)
+	time.Sleep(3 * time.Second) // Wait for account to be fetched in the mirror node
 
 	info, err := NewAccountInfoQuery().
 		SetAccountID(accountID).

--- a/contract_info.go
+++ b/contract_info.go
@@ -29,15 +29,17 @@ import (
 
 // Current information on the smart contract instance, including its balance.
 type ContractInfo struct {
-	AccountID                     AccountID
-	ContractID                    ContractID
-	ContractAccountID             string
-	AdminKey                      Key
-	ExpirationTime                time.Time
-	AutoRenewPeriod               time.Duration
-	Storage                       uint64
-	ContractMemo                  string
-	Balance                       uint64
+	AccountID         AccountID
+	ContractID        ContractID
+	ContractAccountID string
+	AdminKey          Key
+	ExpirationTime    time.Time
+	AutoRenewPeriod   time.Duration
+	Storage           uint64
+	ContractMemo      string
+	Balance           uint64
+	// Deprecated
+	TokenRelationships            []*TokenRelationship
 	LedgerID                      LedgerID
 	AutoRenewAccountID            *AccountID
 	MaxAutomaticTokenAssociations int32

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -32,25 +32,37 @@ var restUrls = map[string]string{
 	"mainnet":    "https://mainnet-public.mirrornode.hedera.com/api/" + apiVersion,
 	"testnet":    "https://testnet.mirrornode.hedera.com/api/" + apiVersion,
 	"previewnet": "https://previewnet.mirrornode.hedera.com/api/" + apiVersion,
+	"localhost":  "localhost:5551/api" + apiVersion,
 }
 var queryTypes = map[string]string{
 	"account":  "accounts/",
-	"contract": "contracts/"}
+	"contract": "contracts/",
+	"token":    "tokens/"}
 
+// Function to obtain balance of tokens for given account ID. Return the pure JSON response as mapping
 func accountBalanceQuery(network string, accountId string) (map[string]interface{}, error) {
 	info, err := accountInfoQuery(network, accountId)
 	// Cast balance body to map
 	return info["balance"].(map[string]interface{}), err
 }
 
+// Function to obtain account info for given account ID. Return the pure JSON response as mapping
 func accountInfoQuery(network string, accountId string) (map[string]interface{}, error) {
 	accountInfoUrl := restUrls[network] + queryTypes["account"] + accountId
 	return makeGetRequest(accountInfoUrl)
 }
 
-func contractInfoQuery(network string, accountId string) (map[string]interface{}, error) {
-	contractInfoUrl := restUrls[network] + queryTypes["contract"] + accountId
+// Function to obtain balance of tokens for given contract ID. Return the pure JSON response as mapping
+func contractInfoQuery(network string, contractId string) (map[string]interface{}, error) {
+	contractInfoUrl := restUrls[network] + queryTypes["contract"] + contractId
 	return makeGetRequest(contractInfoUrl)
+}
+
+// A function to get details about given token ID. Currently we need it to obtain token decimals, when querying account balance
+// 'Decimals' field is depricated in `AccountBalance`,  so this should disappear soon
+func tokenQuery(network string, tokenId string) (map[string]interface{}, error) {
+	tokenInfoUrl := restUrls[network] + queryTypes["token"] + tokenId
+	return makeGetRequest(tokenInfoUrl)
 }
 
 // Make a GET HTTP request to provided URL and map it's json response to a generic `interface` map and return it

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -47,7 +47,7 @@ func accountInfoQuery(network string, accountId string) (map[string]interface{},
 }
 
 // Function to obtain balance of tokens for given contract ID. Return the pure JSON response as mapping
-func contractInfoQuery(network string, contractId string) (map[string]interface{}, error) {
+func contractInfoQuery(network string, contractId string) (map[string]interface{}, error) { // nolint
 	contractInfoUrl := buildUrl(network, queryTypes["contract"], contractId)
 	return makeGetRequest(contractInfoUrl)
 }
@@ -59,9 +59,9 @@ func tokenReleationshipQuery(network string, id string) (map[string]interface{},
 
 // Make a GET HTTP request to provided URL and map it's json response to a generic `interface` map and return it
 func makeGetRequest(url string) (response map[string]interface{}, e error) {
-	fmt.Println(url)
 	// Make an HTTP request
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint
+
 	if err != nil {
 		return nil, err
 	}

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -2,7 +2,6 @@ package hedera
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 )
@@ -87,44 +86,6 @@ func obtainUrlForMirrorNode(client *Client) string {
 	} else {
 		return client.GetMirrorNetwork()[0]
 	}
-}
-
-func mapTokenRelationship(tokens []interface{}) ([]*TokenRelationship, error) {
-	var tokenRelationships []*TokenRelationship
-
-	for _, tokenObj := range tokens {
-		token, ok := tokenObj.(map[string]interface{})
-		if !ok {
-			return nil, errors.New("invalid token object")
-		}
-
-		tokenId, err := TokenIDFromString(token["token_id"].(string))
-		if err != nil {
-			return nil, err
-		}
-
-		freezeStatus := false
-		if tokenFreezeStatus, ok := token["freeze_status"].(string); ok {
-			freezeStatus = tokenFreezeStatus == "FROZEN"
-		}
-
-		kycStatus := false
-		if tokenKycStatus, ok := token["kyc_status"].(string); ok {
-			kycStatus = tokenKycStatus == "GRANTED"
-		}
-
-		tokenRelationship := &TokenRelationship{
-			TokenID:              tokenId,
-			Balance:              uint64(token["balance"].(float64)),
-			KycStatus:            &kycStatus,
-			FreezeStatus:         &freezeStatus,
-			AutomaticAssociation: token["automatic_association"].(bool),
-		}
-
-		tokenRelationships = append(tokenRelationships, tokenRelationship)
-	}
-
-	return tokenRelationships, nil
 }
 
 func buildUrl(network string, args ...string) string {

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -25,15 +25,9 @@ import (
  * limitations under the License.
  *
  */
+const httpPrefix = "https://"
+const apiPathVersion = "/api/v1/"
 
-const apiVersion = "v1/"
-
-var restUrls = map[string]string{
-	"mainnet":    "https://mainnet-public.mirrornode.hedera.com/api/" + apiVersion,
-	"testnet":    "https://testnet.mirrornode.hedera.com/api/" + apiVersion,
-	"previewnet": "https://previewnet.mirrornode.hedera.com/api/" + apiVersion,
-	"localhost":  "localhost:5551/api" + apiVersion,
-}
 var queryTypes = map[string]string{
 	"account":  "accounts/",
 	"contract": "contracts/",
@@ -48,21 +42,14 @@ func accountBalanceQuery(network string, accountId string) (map[string]interface
 
 // Function to obtain account info for given account ID. Return the pure JSON response as mapping
 func accountInfoQuery(network string, accountId string) (map[string]interface{}, error) {
-	accountInfoUrl := restUrls[network] + queryTypes["account"] + accountId
+	accountInfoUrl := fmt.Sprintf("%s%s%s%s%s", httpPrefix, network, apiPathVersion, queryTypes["account"], accountId)
 	return makeGetRequest(accountInfoUrl)
 }
 
 // Function to obtain balance of tokens for given contract ID. Return the pure JSON response as mapping
 func contractInfoQuery(network string, contractId string) (map[string]interface{}, error) {
-	contractInfoUrl := restUrls[network] + queryTypes["contract"] + contractId
+	contractInfoUrl := fmt.Sprintf("%s%s%s%s%s", httpPrefix, network, apiPathVersion, queryTypes["contract"], contractId)
 	return makeGetRequest(contractInfoUrl)
-}
-
-// A function to get details about given token ID. Currently we need it to obtain token decimals, when querying account balance
-// 'Decimals' field is depricated in `AccountBalance`,  so this should disappear soon
-func tokenQuery(network string, tokenId string) (map[string]interface{}, error) {
-	tokenInfoUrl := restUrls[network] + queryTypes["token"] + tokenId
-	return makeGetRequest(tokenInfoUrl)
 }
 
 // Make a GET HTTP request to provided URL and map it's json response to a generic `interface` map and return it

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -59,6 +59,7 @@ func tokenReleationshipQuery(network string, id string) (map[string]interface{},
 
 // Make a GET HTTP request to provided URL and map it's json response to a generic `interface` map and return it
 func makeGetRequest(url string) (response map[string]interface{}, e error) {
+	fmt.Println(url)
 	// Make an HTTP request
 	resp, err := http.Get(url)
 	if err != nil {

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -1,0 +1,77 @@
+package hedera
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+/*-
+ *
+ * Hedera Go SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const apiVersion = "v1/"
+
+var restUrls = map[string]string{
+	"mainnet":    "https://mainnet-public.mirrornode.hedera.com/api/" + apiVersion,
+	"testnet":    "https://testnet.mirrornode.hedera.com/api/" + apiVersion,
+	"previewnet": "https://previewnet.mirrornode.hedera.com/api/" + apiVersion,
+}
+var queryTypes = map[string]string{
+	"account":  "accounts/",
+	"contract": "contracts/"}
+
+func accountBalanceQuery(network string, accountId string) (map[string]interface{}, error) {
+	info, err := accountInfoQuery(network, accountId)
+	// Cast balance body to map
+	return info["balance"].(map[string]interface{}), err
+}
+
+func accountInfoQuery(network string, accountId string) (map[string]interface{}, error) {
+	accountInfoUrl := restUrls[network] + queryTypes["account"] + accountId
+	return makeGetRequest(accountInfoUrl)
+}
+
+func contractInfoQuery(network string, accountId string) (map[string]interface{}, error) {
+	contractInfoUrl := restUrls[network] + queryTypes["contract"] + accountId
+	return makeGetRequest(contractInfoUrl)
+}
+
+// Make a GET HTTP request to provided URL and map it's json response to a generic `interface` map and return it
+func makeGetRequest(url string) (response map[string]interface{}, e error) {
+	// Make an HTTP request
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println("Error making HTTP request:", err)
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status code: %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	// Decode the JSON response into a map
+	var resultMap map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&resultMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return resultMap, nil
+}

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -2,6 +2,7 @@ package hedera
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -94,4 +95,42 @@ func buildUrl(network string, args ...string) string {
 		url += "/" + arg
 	}
 	return url
+}
+
+func mapTokenRelationship(tokens []interface{}) ([]*TokenRelationship, error) {
+	var tokenRelationships []*TokenRelationship
+
+	for _, tokenObj := range tokens {
+		token, ok := tokenObj.(map[string]interface{})
+		if !ok {
+			return nil, errors.New("invalid token object")
+		}
+
+		tokenId, err := TokenIDFromString(token["token_id"].(string))
+		if err != nil {
+			return nil, err
+		}
+
+		freezeStatus := false
+		if tokenFreezeStatus, ok := token["freeze_status"].(string); ok {
+			freezeStatus = tokenFreezeStatus == "FROZEN"
+		}
+
+		kycStatus := false
+		if tokenKycStatus, ok := token["kyc_status"].(string); ok {
+			kycStatus = tokenKycStatus == "GRANTED"
+		}
+
+		tokenRelationship := &TokenRelationship{
+			TokenID:              tokenId,
+			Balance:              uint64(token["balance"].(float64)),
+			KycStatus:            &kycStatus,
+			FreezeStatus:         &freezeStatus,
+			AutomaticAssociation: token["automatic_association"].(bool),
+		}
+
+		tokenRelationships = append(tokenRelationships, tokenRelationship)
+	}
+
+	return tokenRelationships, nil
 }

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -89,14 +89,6 @@ func obtainUrlForMirrorNode(client *Client) string {
 	}
 }
 
-func buildUrl(network string, args ...string) string {
-	url := httpsPrefix + network + apiPathVersion
-	for _, arg := range args {
-		url += "/" + arg
-	}
-	return url
-}
-
 func mapTokenRelationship(tokens []interface{}) ([]*TokenRelationship, error) {
 	var tokenRelationships []*TokenRelationship
 
@@ -133,4 +125,12 @@ func mapTokenRelationship(tokens []interface{}) ([]*TokenRelationship, error) {
 	}
 
 	return tokenRelationships, nil
+}
+
+func buildUrl(network string, args ...string) string {
+	url := httpsPrefix + network + apiPathVersion
+	for _, arg := range args {
+		url += "/" + arg
+	}
+	return url
 }

--- a/mirror_node_gateway_e2e_test.go
+++ b/mirror_node_gateway_e2e_test.go
@@ -28,14 +28,18 @@ import (
  * limitations under the License.
  *
  */
+const mainnetMirrorNodeUrl = "mainnet-public.mirrornode.hedera.com"
+const testnetMirrorNodeUrl = "testnet.mirrornode.hedera.com"
+const previewnetMirrorNodeUrl = "previewnet.mirrornode.hedera.com"
+
 func TestAccountInfoTestnet(t *testing.T) {
-	testAccountInfoQuery(t, "testnet")
+	testAccountInfoQuery(t, testnetMirrorNodeUrl)
 }
 func TestAccountInfoMainnet(t *testing.T) {
-	testAccountInfoQuery(t, "mainnet")
+	testAccountInfoQuery(t, mainnetMirrorNodeUrl)
 }
 func TestAccountInfoPreviewnet(t *testing.T) {
-	testAccountInfoQuery(t, "previewnet")
+	testAccountInfoQuery(t, previewnetMirrorNodeUrl)
 }
 func testAccountInfoQuery(t *testing.T, network string) {
 	t.Parallel()
@@ -46,13 +50,13 @@ func testAccountInfoQuery(t *testing.T, network string) {
 }
 
 func TestAccountBalanceTestnet(t *testing.T) {
-	testAccountBalanceQuery(t, "testnet")
+	testAccountBalanceQuery(t, testnetMirrorNodeUrl)
 }
 func TestAccountBalanceMainnet(t *testing.T) {
-	testAccountBalanceQuery(t, "mainnet")
+	testAccountBalanceQuery(t, mainnetMirrorNodeUrl)
 }
 func TestAccountBalancePreviewnet(t *testing.T) {
-	testAccountBalanceQuery(t, "previewnet")
+	testAccountBalanceQuery(t, previewnetMirrorNodeUrl)
 }
 func testAccountBalanceQuery(t *testing.T, network string) {
 	t.Parallel()
@@ -71,15 +75,22 @@ func testAccountBalanceQuery(t *testing.T, network string) {
 func TestContractInfoPreviewnetContractNotFound(t *testing.T) {
 	t.Parallel()
 
-	result, e := contractInfoQuery("previewnet", "1")
+	result, e := contractInfoQuery(previewnetMirrorNodeUrl, "1")
 	require.Error(t, e)
 	assert.True(t, result == nil)
 }
 func TestContractInfoTestnet(t *testing.T) {
 	t.Parallel()
 
-	result, e := contractInfoQuery("testnet", "0.0.7376843")
+	result, e := contractInfoQuery(testnetMirrorNodeUrl, "0.0.7376843")
 	require.NoError(t, e)
 	_, exist := result["bytecode"]
 	require.True(t, exist)
+}
+
+func TestBuildUrlReturnCorrectUrl(t *testing.T) {
+	url := "https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.7477022/tokens"
+
+	result := buildUrl("testnet.mirrornode.hedera.com", "accounts", "0.0.7477022", "tokens")
+	assert.Equal(t, url, result)
 }

--- a/mirror_node_gateway_e2e_test.go
+++ b/mirror_node_gateway_e2e_test.go
@@ -1,0 +1,85 @@
+//go:build all || e2e
+// +build all e2e
+
+package hedera
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+/*-
+ *
+ * Hedera Go SDK
+ *
+ * Copyright (C) 2020 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+func TestAccountInfoTestnet(t *testing.T) {
+	testAccountInfoQuery(t, "testnet")
+}
+func TestAccountInfoMainnet(t *testing.T) {
+	testAccountInfoQuery(t, "mainnet")
+}
+func TestAccountInfoPreviewnet(t *testing.T) {
+	testAccountInfoQuery(t, "previewnet")
+}
+func testAccountInfoQuery(t *testing.T, network string) {
+	t.Parallel()
+
+	result, e := accountInfoQuery(network, "1")
+	require.NoError(t, e)
+	assert.Equal(t, 20, len(result))
+}
+
+func TestAccountBalanceTestnet(t *testing.T) {
+	testAccountBalanceQuery(t, "testnet")
+}
+func TestAccountBalanceMainnet(t *testing.T) {
+	testAccountBalanceQuery(t, "mainnet")
+}
+func TestAccountBalancePreviewnet(t *testing.T) {
+	testAccountBalanceQuery(t, "previewnet")
+}
+func testAccountBalanceQuery(t *testing.T, network string) {
+	t.Parallel()
+
+	result, e := accountBalanceQuery(network, "1")
+	require.NoError(t, e)
+	assert.Equal(t, 3, len(result))
+	_, exist := result["balance"]
+	require.True(t, exist)
+	_, exist = result["timestamp"]
+	require.True(t, exist)
+	_, exist = result["tokens"]
+	require.True(t, exist)
+}
+
+func TestContractInfoPreviewnetContractNotFound(t *testing.T) {
+	t.Parallel()
+
+	result, e := contractInfoQuery("previewnet", "1")
+	require.Error(t, e)
+	assert.True(t, result == nil)
+}
+func TestContractInfoTestnet(t *testing.T) {
+	t.Parallel()
+
+	result, e := contractInfoQuery("testnet", "0.0.7376843")
+	require.NoError(t, e)
+	_, exist := result["bytecode"]
+	require.True(t, exist)
+}


### PR DESCRIPTION
**Description**:
Draft PR with temp solution on querying mirror node REST API for different token balances.
We should implement solution to fetch the missing data, which was previously returned from the consensus node:
- token decimals
- token symbol

**Related issue(s)**:
#841

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ x] Tested (unit, integration, etc.)
