### PR TITLE
Fixed bug (Added check inside root  for nodeAccountId)

### DIFF
--- a/executable.go
+++ b/executable.go
@@ -225,9 +225,13 @@ func _Execute(client *Client, e Executable) (interface{}, error) {
 		}
 
 		protoRequest = e.makeRequest()
-		nodeAccountID := e.getNodeAccountID()
-		if node, ok = client.network._GetNodeForAccountID(nodeAccountID); !ok {
-			return TransactionResponse{}, ErrInvalidNodeAccountIDSet{nodeAccountID}
+		if len(e.GetNodeAccountIDs()) == 0 {
+			node = client.network._GetNode()
+		} else {
+			nodeAccountID := e.getNodeAccountID()
+			if node, ok = client.network._GetNodeForAccountID(nodeAccountID); !ok {
+				return TransactionResponse{}, ErrInvalidNodeAccountIDSet{nodeAccountID}
+			}
 		}
 
 		if e.isTransaction() {


### PR DESCRIPTION
**Description**:
Added check in the root `_execute` function about `nodeAccountIDs` and functionality to fetch node ID from client, if the structure is empty. 

**Related issue(s)**:
#852
Fixes #

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
