### PR TITLE
chore: add Operator Key and ID to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,9 @@ jobs:
         needs:
             - build
         env:
-            HEDERA_NETWORK: localhost
-            OPERATOR_ID: ${{ secrets.LOCAL_OPERATOR_ID }}
-            OPERATOR_KEY: ${{ secrets.LOCAL_OPERATOR_KEY }}
+          OPERATOR_KEY: "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"
+          OPERATOR_ID: "0.0.2"
+          HEDERA_NETWORK: "localhost"
 
         steps:
             - name: Check out code into the Go module directory


### PR DESCRIPTION
**Description**:
This PR is introducing essential environment variables, `OPERATOR_KEY` and `OPERATOR_ID`, necessary for seamless integration of pull requests from forked repositories into the CI pipeline.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
