### PR TITLE
chore: add linter timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
               uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
               with:
                   skip-cache: true
+                  args: --timeout=5m
 
     test:
         name: Unit and Integration Tests


### PR DESCRIPTION
**Description**:
Currently the go-linter is breaking the build because it times out.
Add linter timeout of 5 minutes

**Related issue(s)**:

Fixes #940

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
