### PR TITLE
fix: Add better error handling in test utils

### DIFF
--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -24,6 +24,7 @@ package hedera
  */
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -84,12 +85,10 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 		env.Client = ClientForTestnet()
 	} else if os.Getenv("CONFIG_FILE") != "" {
 		env.Client, err = ClientFromConfigFile(os.Getenv("CONFIG_FILE"))
-		if err != nil {
-			panic(err)
-		}
 	} else {
-		panic("Failed to construct client from environment variables")
+		err = fmt.Errorf("Failed to construct client from environment variables")
 	}
+	require.NoError(t, err)
 
 	configOperatorID := os.Getenv("OPERATOR_ID")
 	configOperatorKey := os.Getenv("OPERATOR_KEY")
@@ -142,7 +141,8 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 	_ = env.Client.SetNetwork(network)
 
 	if len(network) == 0 {
-		panic("failed to construct network; each node returned an error")
+		t.Log("failed to construct network; each node returned an error")
+		t.FailNow()
 	}
 
 	env.OriginalOperatorID = env.Client.GetOperatorAccountID()
@@ -154,14 +154,11 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 			SetInitialBalance(NewHbar(150)).
 			SetAutoRenewPeriod(time.Hour*24*81 + time.Minute*26 + time.Second*39).
 			Execute(env.Client)
-		if err != nil {
-			panic(err)
-		}
+
+		require.NoError(t, err)
 
 		receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
-		if err != nil {
-			panic(err)
-		}
+		require.NoError(t, err)
 
 		env.OriginalOperatorID = env.Client.GetOperatorAccountID()
 		env.OriginalOperatorKey = env.Client.GetOperatorPublicKey()
@@ -196,6 +193,11 @@ func CloseIntegrationTestEnv(env IntegrationTestEnv, token *TokenID) error {
 		_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 		if err != nil {
 			return err
+		}
+
+		// Check if env.Client.operator is nil
+		if env.Client.operator == nil {
+			return fmt.Errorf("client operator is nil")
 		}
 
 		// This is needed, because we can't delete the account while still having tokens.

--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -161,8 +161,6 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 		receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
 		require.NoError(t, err)
 
-		// env.OriginalOperatorID = env.Client.GetOperatorAccountID()
-		// env.OriginalOperatorKey = env.Client.GetOperatorPublicKey()
 		env.OperatorID = *receipt.AccountID
 		env.OperatorKey = newKey
 		env.NodeAccountIDs = []AccountID{resp.NodeID}

--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -89,6 +89,7 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 		err = fmt.Errorf("Failed to construct client from environment variables")
 	}
 	require.NoError(t, err)
+	assert.NotNil(t, env.Client)
 
 	configOperatorID := os.Getenv("OPERATOR_ID")
 	configOperatorKey := os.Getenv("OPERATOR_KEY")
@@ -160,8 +161,8 @@ func NewIntegrationTestEnv(t *testing.T) IntegrationTestEnv {
 		receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
 		require.NoError(t, err)
 
-		env.OriginalOperatorID = env.Client.GetOperatorAccountID()
-		env.OriginalOperatorKey = env.Client.GetOperatorPublicKey()
+		// env.OriginalOperatorID = env.Client.GetOperatorAccountID()
+		// env.OriginalOperatorKey = env.Client.GetOperatorPublicKey()
 		env.OperatorID = *receipt.AccountID
 		env.OperatorKey = newKey
 		env.NodeAccountIDs = []AccountID{resp.NodeID}


### PR DESCRIPTION
**Description**:
Methods like `NewIntegrationTestEnv` and `CloseIntegrationTestEnv` might panic ungracefully in certain circumstances.
This PR adds better error handling by adding asserts when error occures.

**Related issue(s)**:

Fixes #943

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
