### PR TITLE
fix: Raise an error if the transaction is not frozen while signing

### DIFF
--- a/account_create_transaction_e2e_test.go
+++ b/account_create_transaction_e2e_test.go
@@ -355,12 +355,14 @@ func TestIntegrationAccountCreateTransactionWithAliasFromAdminKeyWithReceiverSig
 		Execute(env.Client)
 	require.NoError(t, err)
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
-		Sign(adminKey).
-		Execute(env.Client)
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.Sign(adminKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	receipt, err := resp.GetReceipt(env.Client)
@@ -436,9 +438,13 @@ func TestIntegrationAccountCreateTransactionWithAlias(t *testing.T) {
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	tx, err := NewAccountCreateTransaction().
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := tx.
 		Sign(key).
 		Execute(env.Client)
 	require.NoError(t, err)
@@ -514,10 +520,14 @@ func TestIntegrationAccountCreateTransactionWithAliasWithReceiverSigRequired(t *
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.
 		Sign(key).
 		Sign(adminKey).
 		Execute(env.Client)
@@ -560,10 +570,14 @@ func TestIntegrationAccountCreateTransactionWithAliasWithReceiverSigRequiredWith
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.
 		Sign(key).
 		Execute(env.Client)
 	require.NoError(t, err)

--- a/serialize_deserialize_test.go
+++ b/serialize_deserialize_test.go
@@ -92,7 +92,10 @@ func TestIntegrationAddSignatureSerializeDeserializeAddAnotherSignatureExecute(t
 	assert.Equal(t, txFromBytes.signedTransactions._Length(), txBefore.signedTransactions._Length())
 	assert.Equal(t, txFromBytes.memo, txBefore.memo)
 
-	executed, err := txFromBytes.Sign(newKey).Execute(env.Client)
+	frozenTx, err := txFromBytes.FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	executed, err := frozenTx.Sign(newKey).Execute(env.Client)
 	if err != nil {
 		panic(err)
 	}

--- a/token_nft_allowance_e2e_test.go
+++ b/token_nft_allowance_e2e_test.go
@@ -106,7 +106,9 @@ func TestIntegrationCantTransferOnBehalfOfSpenderAfterRemovingTheAllowanceApprov
 	require.NoError(t, err)
 	tokenID := tokenReceipt.TokenID
 
-	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).Sign(spenderKey).Execute(env.Client)
+	frozenTx, err := NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	_, err = frozenTx.Sign(spenderKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*receiverAccountId).Sign(receiverKey).Execute(env.Client)
@@ -259,7 +261,9 @@ func TestIntegrationAfterGivenAllowanceForAllSerialsCanGiveSingleSerialToOtherAc
 	require.NoError(t, err)
 	tokenID := tokenReceipt.TokenID
 
-	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).Sign(spenderKey).Execute(env.Client)
+	frozenTx, err := NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	_, err = frozenTx.Sign(spenderKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*receiverAccountId).Sign(receiverKey).Execute(env.Client)

--- a/token_update_nfts_transaction_e2e_test.go
+++ b/token_update_nfts_transaction_e2e_test.go
@@ -237,11 +237,14 @@ func updateNftMetadata(t *testing.T, env *IntegrationTestEnv, tokenID TokenID, s
 			SetSerialNumbers(serials).
 			SetMetadata(updatedMetadata)
 	} else {
-		tokenUpdateNftsTx = NewTokenUpdateNftsTransaction().
+		frozenTx, err := NewTokenUpdateNftsTransaction().
 			SetTokenID(tokenID).
 			SetSerialNumbers(serials).
 			SetMetadata(updatedMetadata).
-			Sign(*metadataKey)
+			FreezeWith(env.Client)
+		require.NoError(t, err)
+
+		tokenUpdateNftsTx = frozenTx.Sign(*metadataKey)
 	}
 
 	tx, err := tokenUpdateNftsTx.Execute(env.Client)

--- a/transaction.go
+++ b/transaction.go
@@ -476,6 +476,12 @@ func (tx *Transaction) IsFrozen() bool {
 	return tx.signedTransactions._Length() > 0
 }
 
+func (tx *Transaction) _RequireFrozen() {
+	if !tx.IsFrozen() {
+		tx.freezeError = errTransactionIsNotFrozen
+	}
+}
+
 func (tx *Transaction) _RequireNotFrozen() {
 	if tx.IsFrozen() {
 		tx.freezeError = errTransactionIsFrozen
@@ -866,6 +872,7 @@ func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) 
 	return tx.SignWith(client.operator.publicKey, client.operator.signer), nil
 }
 func (tx *Transaction) SignWith(publicKey PublicKey, signer TransactionSigner) TransactionInterface {
+	tx._RequireFrozen()
 	if !tx._KeyAlreadySigned(publicKey) {
 		tx._SignWith(publicKey, signer)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -856,7 +856,6 @@ func (tx *Transaction) Sign(privateKey PrivateKey) TransactionInterface {
 func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) (TransactionInterface, error) { // nolint
 	// If the transaction is not signed by the _Operator, we need
 	// to sign the transaction with the _Operator
-
 	if client == nil {
 		return nil, errNoClientProvided
 	} else if client.operator == nil {
@@ -872,7 +871,9 @@ func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) 
 	return tx.SignWith(client.operator.publicKey, client.operator.signer), nil
 }
 func (tx *Transaction) SignWith(publicKey PublicKey, signer TransactionSigner) TransactionInterface {
+	// We need to make sure the request is frozen
 	tx._RequireFrozen()
+
 	if !tx._KeyAlreadySigned(publicKey) {
 		tx._SignWith(publicKey, signer)
 	}

--- a/transaction_e2e_test.go
+++ b/transaction_e2e_test.go
@@ -289,3 +289,21 @@ func DisabledTestTransactionFromBytes(t *testing.T) { // nolint
 		panic("Transaction was not a crypto transfer?")
 	}
 }
+
+func TestIntegrationTransactionFailsWhenSigningWithoutFreezing(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	tx := NewAccountCreateTransaction().
+		SetKey(newKey.PublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs)
+
+	_, err = tx.Sign(newKey).Execute(env.Client)
+	require.ErrorContains(t, err, "transaction is not frozen")
+
+	err = CloseIntegrationTestEnv(env, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Description**:

Signing requires the transaction to be frozen. We need to make sure the request is frozen before signing. Add check for this and propagate `errTransactionIsNotFrozen` if the check fails.

**Related issue(s)**:

Fixes #946

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
