### PR TITLE
fix: Account Alias Mirror Node Queries

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,7 +44,6 @@ tasks:
                         if [ -f main.go ]; then
                             echo "Running $example/main.go"
                             env OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" OPERATOR_ID="0.0.2" HEDERA_NETWORK="localhost" go run main.go
-                            fi
                         fi
                         popd > /dev/null
                     fi

--- a/account_balance_query.go
+++ b/account_balance_query.go
@@ -121,7 +121,12 @@ func (q *AccountBalanceQuery) Execute(client *Client) (AccountBalance, error) {
 		accountId = q.contractID.String()
 	}
 
-	err = fetchTokenBalances(fetchMirrorNodeUrlFromClient(client), accountId, &balance)
+	if q.accountID.AliasKey != nil && q.accountID.AliasKey.ecdsaPublicKey != nil {
+		evmAlias := q.accountID.AliasKey.ToEvmAddress()
+		err = fetchTokenBalances(fetchMirrorNodeUrlFromClient(client), evmAlias, &balance)
+	} else {
+		err = fetchTokenBalances(fetchMirrorNodeUrlFromClient(client), accountId, &balance)
+	}
 	if err != nil {
 		return balance, err
 	}

--- a/account_balance_query_e2e_test.go
+++ b/account_balance_query_e2e_test.go
@@ -42,6 +42,9 @@ func TestIntegrationAccountBalanceQueryCanExecute(t *testing.T) {
 		Execute(env.Client)
 	require.NoError(t, err)
 
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
+
 	_, err = NewAccountBalanceQuery().
 		SetAccountID(env.OperatorID).
 		SetNodeAccountIDs(env.NodeAccountIDs).
@@ -89,6 +92,7 @@ func TestIntegrationAccountBalanceQueryCanGetTokenBalance(t *testing.T) {
 
 	assert.Equal(t, uint64(1000000), balance.Tokens.Get(*tokenID))
 	assert.Equal(t, uint64(3), balance.TokenDecimals.Get(*tokenID))
+
 	err = CloseIntegrationTestEnv(env, tokenID)
 	require.NoError(t, err)
 }
@@ -96,6 +100,9 @@ func TestIntegrationAccountBalanceQueryCanGetTokenBalance(t *testing.T) {
 func TestIntegrationAccountBalanceQueryGetCost(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
+
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
 
 	balance := NewAccountBalanceQuery().
 		SetNodeAccountIDs(env.NodeAccountIDs).
@@ -116,6 +123,9 @@ func TestIntegrationAccountBalanceQuerySetBigMaxPayment(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
+
 	balance := NewAccountBalanceQuery().
 		SetMaxQueryPayment(NewHbar(10000)).
 		SetNodeAccountIDs(env.NodeAccountIDs).
@@ -135,6 +145,9 @@ func TestIntegrationAccountBalanceQuerySetSmallMaxPayment(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
+
 	balance := NewAccountBalanceQuery().
 		SetMaxQueryPayment(HbarFromTinybar(1)).
 		SetNodeAccountIDs(env.NodeAccountIDs).
@@ -153,6 +166,9 @@ func TestIntegrationAccountBalanceQuerySetSmallMaxPayment(t *testing.T) {
 func TestIntegrationAccountBalanceQueryCanSetQueryPayment(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
+
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
 
 	balance := NewAccountBalanceQuery().
 		SetMaxQueryPayment(NewHbar(10000)).
@@ -174,6 +190,8 @@ func TestIntegrationAccountBalanceQueryCostCanSetPaymentOneTinybar(t *testing.T)
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
 	balance := NewAccountBalanceQuery().
 		SetMaxQueryPayment(NewHbar(10000)).
 		SetQueryPayment(NewHbar(0)).

--- a/account_create_transaction_e2e_test.go
+++ b/account_create_transaction_e2e_test.go
@@ -355,12 +355,14 @@ func TestIntegrationAccountCreateTransactionWithAliasFromAdminKeyWithReceiverSig
 		Execute(env.Client)
 	require.NoError(t, err)
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
-		Sign(adminKey).
-		Execute(env.Client)
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.Sign(adminKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	receipt, err := resp.GetReceipt(env.Client)
@@ -436,9 +438,13 @@ func TestIntegrationAccountCreateTransactionWithAlias(t *testing.T) {
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	tx, err := NewAccountCreateTransaction().
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := tx.
 		Sign(key).
 		Execute(env.Client)
 	require.NoError(t, err)
@@ -514,10 +520,14 @@ func TestIntegrationAccountCreateTransactionWithAliasWithReceiverSigRequired(t *
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.
 		Sign(key).
 		Sign(adminKey).
 		Execute(env.Client)
@@ -560,10 +570,14 @@ func TestIntegrationAccountCreateTransactionWithAliasWithReceiverSigRequiredWith
 	key, err := PrivateKeyGenerateEcdsa()
 	evmAddress := key.PublicKey().ToEvmAddress()
 
-	resp, err := NewAccountCreateTransaction().
+	frozenTxn, err := NewAccountCreateTransaction().
 		SetReceiverSignatureRequired(true).
 		SetKey(adminKey).
 		SetAlias(evmAddress).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	resp, err := frozenTxn.
 		Sign(key).
 		Execute(env.Client)
 	require.NoError(t, err)

--- a/account_info_query.go
+++ b/account_info_query.go
@@ -21,6 +21,7 @@ package hedera
  */
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashgraph/hedera-protobufs-go/services"
@@ -56,17 +57,14 @@ func (q *AccountInfoQuery) Execute(client *Client) (AccountInfo, error) {
 		return AccountInfo{}, err
 	}
 
-	info, err := _AccountInfoFromProtobuf(resp.GetCryptoGetInfo().AccountInfo)
+	protobufResponse := resp.GetCryptoGetInfo().AccountInfo
+	info, err := _AccountInfoFromProtobuf(protobufResponse)
 	if err != nil {
 		return AccountInfo{}, err
 	}
 
-	if q.accountID.AliasKey != nil && q.accountID.AliasKey.ecdsaPublicKey != nil {
-		evmAlias := q.accountID.AliasKey.ToEvmAddress()
-		err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), evmAlias, &info)
-	} else {
-		err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), q.accountID.String(), &info)
-	}
+	err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), fmt.Sprint(protobufResponse.AccountID.GetAccountNum()), &info)
+
 	if err != nil {
 		return info, err
 	}

--- a/account_info_query.go
+++ b/account_info_query.go
@@ -61,7 +61,12 @@ func (q *AccountInfoQuery) Execute(client *Client) (AccountInfo, error) {
 		return AccountInfo{}, err
 	}
 
-	err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), q.accountID.String(), &info)
+	if q.accountID.AliasKey != nil && q.accountID.AliasKey.ecdsaPublicKey != nil {
+		evmAlias := q.accountID.AliasKey.ToEvmAddress()
+		err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), evmAlias, &info)
+	} else {
+		err = fetchAccountInfoTokenRelationships(fetchMirrorNodeUrlFromClient(client), q.accountID.String(), &info)
+	}
 	if err != nil {
 		return info, err
 	}

--- a/account_info_query_e2e_test.go
+++ b/account_info_query_e2e_test.go
@@ -600,3 +600,71 @@ func TestIntegrationAccountInfoQueryTokenRelationship(t *testing.T) {
 	assert.Equal(t, accountID, info.AccountID)
 	assert.Equal(t, 0, len(info.TokenRelationships))
 }
+
+func TestIntegrationAccountInfoQueryWorksWithHollowAccountAlias(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+
+	// Create NFT
+	cid := []string{"QmNPCiNA3Dsu3K5FxDPMG5Q3fZRwVTg14EXA92uqEeSRXn"}
+	// Creating the transaction for token creation
+	nftCreateTransaction, err := NewTokenCreateTransaction().
+		SetTokenName("HIP-542 Example Collection").SetTokenSymbol("HIP-542").
+		SetTokenType(TokenTypeNonFungibleUnique).SetDecimals(0).
+		SetInitialSupply(0).SetMaxSupply(int64(len(cid))).
+		SetTreasuryAccountID(env.OperatorID).SetSupplyType(TokenSupplyTypeFinite).
+		SetAdminKey(env.OperatorKey).SetFreezeKey(env.OperatorKey).SetWipeKey(env.OperatorKey).SetSupplyKey(env.OperatorKey).FreezeWith(env.Client)
+
+	// Sign the transaction with the operator key
+	nftSignTransaction := nftCreateTransaction.Sign(env.OperatorKey)
+	// Submit the transaction to the Hedera network
+	nftCreateSubmit, err := nftSignTransaction.Execute(env.Client)
+	require.NoError(t, err)
+
+	// Get transaction receipt information
+	nftCreateReceipt, err := nftCreateSubmit.GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Get token id from the transaction
+	nftTokenID := *nftCreateReceipt.TokenID
+
+	nftCollection := []TransactionReceipt{}
+
+	for _, s := range cid {
+		mintTransaction, err := NewTokenMintTransaction().SetTokenID(nftTokenID).SetMetadata([]byte(s)).FreezeWith(env.Client)
+		require.NoError(t, err)
+		mintTransactionSubmit, err := mintTransaction.Sign(env.OperatorKey).Execute(env.Client)
+		require.NoError(t, err)
+		receipt, err := mintTransactionSubmit.GetReceipt(env.Client)
+		require.NoError(t, err)
+		nftCollection = append(nftCollection, receipt)
+	}
+	exampleNftId := nftTokenID.Nft(nftCollection[0].SerialNumbers[0])
+
+	privateKey, err := PrivateKeyGenerateEcdsa()
+	require.NoError(t, err)
+
+	// Extract the ECDSA public key public key
+	publicKey := privateKey.PublicKey()
+	// Extract the Ethereum public address
+	aliasAccountId := publicKey.ToAccountID(0, 0)
+
+	nftTransferTransaction, err := NewTransferTransaction().AddNftTransfer(exampleNftId, env.OperatorID, *aliasAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	// Sign the transaction with the operator key
+	nftTransferTransactionSign := nftTransferTransaction.Sign(env.OperatorKey)
+	// Submit the transaction to the Hedera network
+	nftTransferTransactionSubmit, err := nftTransferTransactionSign.Execute(env.Client)
+	require.NoError(t, err)
+	_, err = nftTransferTransactionSubmit.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
+	_, err = NewAccountInfoQuery().
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetAccountID(*aliasAccountId).
+		Execute(env.Client)
+	assert.NoError(t, err)
+}

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -29,6 +29,7 @@ import (
 
 // Function to obtain the token relationships of the specified account
 func tokenRelationshipMirrorNodeQuery(networkUrl string, id string) (map[string]interface{}, error) {
+	fmt.Println("accountID:", id)
 	tokenRelationshipUrl := buildUrlParams(networkUrl, "accounts", id, "tokens")
 	return makeGetRequest(tokenRelationshipUrl)
 }
@@ -48,9 +49,10 @@ func contractInfoMirrorNodeQuery(networkUrl string, contractId string) (map[stri
 // Function to obtain balance of tokens for given account ID. Return the pure JSON response as mapping
 func accountTokenBalanceMirrorNodeQuery(networkUrl string, accountId string) (map[string]interface{}, error) {
 	info, err := tokenRelationshipMirrorNodeQuery(networkUrl, accountId)
+
 	// in case of empty info we won't be able to map to string interface
 	if len(info) == 0 {
-		return nil, nil
+		return nil, err
 	}
 	return info, err
 }

--- a/mirror_node_gateway.go
+++ b/mirror_node_gateway.go
@@ -29,7 +29,6 @@ import (
 
 // Function to obtain the token relationships of the specified account
 func tokenRelationshipMirrorNodeQuery(networkUrl string, id string) (map[string]interface{}, error) {
-	fmt.Println("accountID:", id)
 	tokenRelationshipUrl := buildUrlParams(networkUrl, "accounts", id, "tokens")
 	return makeGetRequest(tokenRelationshipUrl)
 }

--- a/serialize_deserialize_test.go
+++ b/serialize_deserialize_test.go
@@ -92,7 +92,10 @@ func TestIntegrationAddSignatureSerializeDeserializeAddAnotherSignatureExecute(t
 	assert.Equal(t, txFromBytes.signedTransactions._Length(), txBefore.signedTransactions._Length())
 	assert.Equal(t, txFromBytes.memo, txBefore.memo)
 
-	executed, err := txFromBytes.Sign(newKey).Execute(env.Client)
+	frozenTx, err := txFromBytes.FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	executed, err := frozenTx.Sign(newKey).Execute(env.Client)
 	if err != nil {
 		panic(err)
 	}

--- a/token_nft_allowance_e2e_test.go
+++ b/token_nft_allowance_e2e_test.go
@@ -106,7 +106,9 @@ func TestIntegrationCantTransferOnBehalfOfSpenderAfterRemovingTheAllowanceApprov
 	require.NoError(t, err)
 	tokenID := tokenReceipt.TokenID
 
-	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).Sign(spenderKey).Execute(env.Client)
+	frozenTx, err := NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	_, err = frozenTx.Sign(spenderKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*receiverAccountId).Sign(receiverKey).Execute(env.Client)
@@ -259,7 +261,9 @@ func TestIntegrationAfterGivenAllowanceForAllSerialsCanGiveSingleSerialToOtherAc
 	require.NoError(t, err)
 	tokenID := tokenReceipt.TokenID
 
-	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).Sign(spenderKey).Execute(env.Client)
+	frozenTx, err := NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*spenderAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	_, err = frozenTx.Sign(spenderKey).Execute(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewTokenAssociateTransaction().SetTokenIDs(*tokenID).SetAccountID(*receiverAccountId).Sign(receiverKey).Execute(env.Client)

--- a/token_transfer_transaction_e2e_test.go
+++ b/token_transfer_transaction_e2e_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,9 @@ func TestIntegrationTokenTransferTransactionCanExecute(t *testing.T) {
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
+
+	// Wait for mirror node to import data
+	time.Sleep(3 * time.Second)
 
 	_, err = NewAccountBalanceQuery().
 		SetAccountID(env.Client.GetOperatorAccountID()).

--- a/token_update_nfts_transaction_e2e_test.go
+++ b/token_update_nfts_transaction_e2e_test.go
@@ -237,11 +237,14 @@ func updateNftMetadata(t *testing.T, env *IntegrationTestEnv, tokenID TokenID, s
 			SetSerialNumbers(serials).
 			SetMetadata(updatedMetadata)
 	} else {
-		tokenUpdateNftsTx = NewTokenUpdateNftsTransaction().
+		frozenTx, err := NewTokenUpdateNftsTransaction().
 			SetTokenID(tokenID).
 			SetSerialNumbers(serials).
 			SetMetadata(updatedMetadata).
-			Sign(*metadataKey)
+			FreezeWith(env.Client)
+		require.NoError(t, err)
+
+		tokenUpdateNftsTx = frozenTx.Sign(*metadataKey)
 	}
 
 	tx, err := tokenUpdateNftsTx.Execute(env.Client)

--- a/token_wipe_transaction_e2e_test.go
+++ b/token_wipe_transaction_e2e_test.go
@@ -26,6 +26,7 @@ package hedera
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -110,6 +111,9 @@ func TestIntegrationTokenWipeTransactionCanExecute(t *testing.T) {
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
+
+	// Wait for mirror node to update
+	time.Sleep(3 * time.Second)
 
 	info, err := NewAccountBalanceQuery().
 		SetAccountID(accountID).

--- a/transaction.go
+++ b/transaction.go
@@ -476,6 +476,12 @@ func (tx *Transaction) IsFrozen() bool {
 	return tx.signedTransactions._Length() > 0
 }
 
+func (tx *Transaction) _RequireFrozen() {
+	if !tx.IsFrozen() {
+		tx.freezeError = errTransactionIsNotFrozen
+	}
+}
+
 func (tx *Transaction) _RequireNotFrozen() {
 	if tx.IsFrozen() {
 		tx.freezeError = errTransactionIsFrozen
@@ -866,6 +872,7 @@ func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) 
 	return tx.SignWith(client.operator.publicKey, client.operator.signer), nil
 }
 func (tx *Transaction) SignWith(publicKey PublicKey, signer TransactionSigner) TransactionInterface {
+	tx._RequireFrozen()
 	if !tx._KeyAlreadySigned(publicKey) {
 		tx._SignWith(publicKey, signer)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -856,7 +856,6 @@ func (tx *Transaction) Sign(privateKey PrivateKey) TransactionInterface {
 func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) (TransactionInterface, error) { // nolint
 	// If the transaction is not signed by the _Operator, we need
 	// to sign the transaction with the _Operator
-
 	if client == nil {
 		return nil, errNoClientProvided
 	} else if client.operator == nil {
@@ -872,7 +871,9 @@ func (tx *Transaction) signWithOperator(client *Client, e TransactionInterface) 
 	return tx.SignWith(client.operator.publicKey, client.operator.signer), nil
 }
 func (tx *Transaction) SignWith(publicKey PublicKey, signer TransactionSigner) TransactionInterface {
+	// We need to make sure the request is frozen
 	tx._RequireFrozen()
+
 	if !tx._KeyAlreadySigned(publicKey) {
 		tx._SignWith(publicKey, signer)
 	}

--- a/transaction_e2e_test.go
+++ b/transaction_e2e_test.go
@@ -289,3 +289,21 @@ func DisabledTestTransactionFromBytes(t *testing.T) { // nolint
 		panic("Transaction was not a crypto transfer?")
 	}
 }
+
+func TestIntegrationTransactionFailsWhenSigningWithoutFreezing(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	tx := NewAccountCreateTransaction().
+		SetKey(newKey.PublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs)
+
+	_, err = tx.Sign(newKey).Execute(env.Client)
+	require.ErrorContains(t, err, "transaction is not frozen")
+
+	err = CloseIntegrationTestEnv(env, nil)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Description**:

The mirror node does not accept der encoded account aliases. We cannot query newly created hollow account info and balanced because of this.

We should use the protobuf response in order to get the num of the account/contract and use it as parameter for the query.

**Related issue(s)**:

Fixes #948

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
