### PR TITLE
chore: revert the skipping of tests during the modularization triage

### DIFF
--- a/file_info_query_e2e_test.go
+++ b/file_info_query_e2e_test.go
@@ -262,7 +262,6 @@ func TestIntegrationFileInfoQueryInsufficientFee(t *testing.T) {
 }
 
 func TestIntegrationFileInfoQueryNoFileID(t *testing.T) {
-	t.Skip("Skipping test as it is not working with the modularized code ")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 

--- a/token_info_query_e2e_test.go
+++ b/token_info_query_e2e_test.go
@@ -299,7 +299,6 @@ func TestIntegrationTokenInfoQueryNoPayment(t *testing.T) {
 }
 
 func TestIntegrationTokenInfoQueryNoTokenID(t *testing.T) {
-	t.Skip("Skipping test as it is not working with the modularized code ")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 


### PR DESCRIPTION
**Description**:
 Revert the skipping of tests during the modularization triage

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
