### PR TITLE
chore: Add pre-commit git hook for golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ and `OPERATOR_KEY` and `OPERATOR_ID` **must** be provided.
 
 [Example Config File](./client-config-with-operator.json)
 
+## Linting
+
+This repository uses golangci-lint for linting. You can install a pre-commit git hook that runs golangci-lint before each commit by running the following command:
+
+```sh
+scripts/install-hooks.sh
+```
+
 ## Support
 
 If you have a question on how to use the product, please see our

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Check if golangci-lint is installed
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  echo "Error: golangci-lint is not installed. Please install it before committing."
+  exit 1
+fi
+
+# Run golangci-lint
+golangci-lint run
+
+# Capture the exit code of golangci-lint
+EXIT_CODE=$?
+
+# If golangci-lint fails, prevent commit
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "golangci-lint found issues. Please fix them before committing."
+  exit 1
+fi
+
+# If linting passes, allow commit
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# source
+HOOKS_DIR="$(dirname "$0")/git-hooks"
+
+# target
+GIT_HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+
+# Copy hooks to the .git/hooks directory
+for hook in "$HOOKS_DIR"/*; do
+    echo "Installing $(basename "$hook") hook..."
+    cp "$hook" "$GIT_HOOKS_DIR/$(basename "$hook")"
+    chmod +x "$GIT_HOOKS_DIR/$(basename "$hook")"
+done
+
+echo "Git hooks have been set up."


### PR DESCRIPTION
**Description**:

This  PR adds a pre-commit git hook that runs golangci-lint before each commit. 
This hook can be installed by running the `scripts/install-hooks.sh` script.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1006 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
