### PR TITLE
fix: Retry when getting `THROTTLED_AT_CONSENSUS`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/ethereum/go-ethereum v1.13.15
-	github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240828100549-72dfb73947c6
+	github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240910141930-3e9d10484c9a
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
-github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240828100549-72dfb73947c6 h1:gtphIZkv7KESCPsZTFvB4AN6vIDhRdQRmh5Mfac6D7I=
-github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240828100549-72dfb73947c6/go.mod h1:vN4EAg6FOvgRjeqR7tYBqv9lxT0wqImRh/FVxBUHOkM=
+github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240910141930-3e9d10484c9a h1:pevBrJ/CTxZlKOYfOP3UU2pNStEeP7deGXQOfX+ivKA=
+github.com/hashgraph/hedera-protobufs-go v0.2.1-0.20240910141930-3e9d10484c9a/go.mod h1:vN4EAg6FOvgRjeqR7tYBqv9lxT0wqImRh/FVxBUHOkM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=

--- a/transaction.go
+++ b/transaction.go
@@ -4755,7 +4755,7 @@ func TransactionExecute(transaction interface{}, client *Client) (TransactionRes
 func (tx *Transaction) shouldRetry(_ Executable, response interface{}) _ExecutionState {
 	status := Status(response.(*services.TransactionResponse).NodeTransactionPrecheckCode)
 	switch status {
-	case StatusPlatformTransactionNotCreated, StatusPlatformNotActive, StatusBusy:
+	case StatusPlatformTransactionNotCreated, StatusPlatformNotActive, StatusBusy, StatusThrottledAtConsensus:
 		return executionStateRetry
 	case StatusTransactionExpired:
 		return executionStateExpired

--- a/transaction_unit_test.go
+++ b/transaction_unit_test.go
@@ -602,6 +602,32 @@ func TestUnitTransactionSignSwitchCasesPointers(t *testing.T) {
 	}
 }
 
+func TestUnitTransactionThrottleAtConsensusGracefulHandling(t *testing.T) {
+	t.Parallel()
+
+	responses := [][]interface{}{{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_THROTTLED_AT_CONSENSUS,
+		},
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_THROTTLED_AT_CONSENSUS,
+		},
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+	}}
+
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+	_, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	client.SetMaxAttempts(3)
+	require.NoError(t, err)
+
+}
 func TestUnitTransactionAttributes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Description**

 - updates protobufs to v0.54.0
 - handles `THROTTLED_AT_CONSENSUS` status by retrying the execution of the transaction

**Related issue(s)**:

Fixes #1061

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
