### PR TITLE
fix: replace manual receipt query execution with `GetReceipt`

### DIFF
--- a/account_balance_query_e2e_test.go
+++ b/account_balance_query_e2e_test.go
@@ -204,7 +204,7 @@ func TestIntegrationAccountBalanceQueryWorksWithHollowAccountAlias(t *testing.T)
 	require.NoError(t, err)
 
 	// Get the child receipt or child record to return the Hedera Account ID for the new account that was created
-	_, err = tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	_, err = tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewAccountBalanceQuery().SetAccountID(aliasAccountId).Execute(env.Client)

--- a/account_id_e2e_test.go
+++ b/account_id_e2e_test.go
@@ -44,7 +44,7 @@ func TestIntegrationAccountIDCanPopulateAccountNumber(t *testing.T) {
 	tx, err := NewTransferTransaction().AddHbarTransfer(evmAddressAccount, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).Execute(env.Client)
 	require.NoError(t, err)
-	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	receipt, err := tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
 	idMirror, err := AccountIDFromEvmPublicAddress(evmAddress)
@@ -68,7 +68,7 @@ func TestIntegrationAccountIDCanPopulateAccountAliasEvmAddress(t *testing.T) {
 	tx, err := NewTransferTransaction().AddHbarTransfer(evmAddressAccount, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).Execute(env.Client)
 	require.NoError(t, err)
-	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	receipt, err := tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
 	time.Sleep(5 * time.Second)
@@ -90,7 +90,7 @@ func TestIntegrationAccountIDCanPopulateAccountAliasEvmAddressWithMirror(t *test
 	tx, err := NewTransferTransaction().AddHbarTransfer(evmAddressAccount, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).Execute(env.Client)
 	require.NoError(t, err)
-	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	receipt, err := tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
 	time.Sleep(5 * time.Second)
@@ -112,7 +112,7 @@ func TestIntegrationAccountIDCanPopulateAccountAliasEvmAddressWithNoMirror(t *te
 	tx, err := NewTransferTransaction().AddHbarTransfer(evmAddressAccount, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).Execute(env.Client)
 	require.NoError(t, err)
-	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	receipt, err := tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
 	env.Client.mirrorNetwork = nil
@@ -134,7 +134,7 @@ func TestIntegrationAccountIDCanPopulateAccountAliasEvmAddressWithMirrorAndNoEvm
 	tx, err := NewTransferTransaction().AddHbarTransfer(evmAddressAccount, NewHbar(1)).
 		AddHbarTransfer(env.OperatorID, NewHbar(-1)).Execute(env.Client)
 	require.NoError(t, err)
-	receipt, err := tx.GetReceiptQuery().SetIncludeChildren(true).Execute(env.Client)
+	receipt, err := tx.SetIncludeChildren(true).SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 	newAccountId := *receipt.Children[0].AccountID
 	env.Client.mirrorNetwork = nil

--- a/contract_create_flow.go
+++ b/contract_create_flow.go
@@ -310,12 +310,6 @@ func (tx *ContractCreateFlow) _CreateContractCreateTransaction(fileID FileID) *C
 	return contractCreateTx
 }
 
-func (tx *ContractCreateFlow) _CreateTransactionReceiptQuery(response TransactionResponse) *TransactionReceiptQuery {
-	return NewTransactionReceiptQuery().
-		SetNodeAccountIDs([]AccountID{response.NodeID}).
-		SetTransactionID(response.TransactionID)
-}
-
 func (tx *ContractCreateFlow) Execute(client *Client) (TransactionResponse, error) {
 	tx.splitBytecode()
 
@@ -323,7 +317,7 @@ func (tx *ContractCreateFlow) Execute(client *Client) (TransactionResponse, erro
 	if err != nil {
 		return TransactionResponse{}, err
 	}
-	fileCreateReceipt, err := tx._CreateTransactionReceiptQuery(fileCreateResponse).Execute(client)
+	fileCreateReceipt, err := fileCreateResponse.SetValidateStatus(true).GetReceipt(client)
 	if err != nil {
 		return TransactionResponse{}, err
 	}
@@ -337,7 +331,7 @@ func (tx *ContractCreateFlow) Execute(client *Client) (TransactionResponse, erro
 			return TransactionResponse{}, err
 		}
 
-		_, err = tx._CreateTransactionReceiptQuery(fileAppendResponse).Execute(client)
+		_, err = fileAppendResponse.SetValidateStatus(true).GetReceipt(client)
 		if err != nil {
 			return TransactionResponse{}, err
 		}
@@ -346,7 +340,7 @@ func (tx *ContractCreateFlow) Execute(client *Client) (TransactionResponse, erro
 	if err != nil {
 		return TransactionResponse{}, err
 	}
-	_, err = tx._CreateTransactionReceiptQuery(contractCreateResponse).Execute(client)
+	_, err = contractCreateResponse.SetValidateStatus(true).GetReceipt(client)
 	if err != nil {
 		return TransactionResponse{}, err
 	}

--- a/file_append_transaction.go
+++ b/file_append_transaction.go
@@ -392,10 +392,7 @@ func (tx *FileAppendTransaction) ExecuteAll(
 
 		list[i] = resp.(TransactionResponse)
 
-		_, err = NewTransactionReceiptQuery().
-			SetNodeAccountIDs([]AccountID{resp.(TransactionResponse).NodeID}).
-			SetTransactionID(resp.(TransactionResponse).TransactionID).
-			Execute(client)
+		_, err = list[i].SetValidateStatus(false).GetReceipt(client)
 		if err != nil {
 			return list, err
 		}

--- a/transaction_record_query_e2e_test.go
+++ b/transaction_record_query_e2e_test.go
@@ -55,10 +55,7 @@ func TestIntegrationTransactionRecordQueryCanExecute(t *testing.T) {
 	resp, err := tx.Execute(env.Client)
 	require.NoError(t, err)
 
-	_, err = NewTransactionReceiptQuery().
-		SetTransactionID(resp.TransactionID).
-		SetNodeAccountIDs([]AccountID{resp.NodeID}).
-		Execute(env.Client)
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 
 	record, err := NewTransactionRecordQuery().
@@ -118,11 +115,7 @@ func TestIntegrationTransactionRecordQueryReceiptPaymentZero(t *testing.T) {
 	resp, err := tx.Execute(env.Client)
 	require.NoError(t, err)
 
-	_, err = NewTransactionReceiptQuery().
-		SetTransactionID(resp.TransactionID).
-		SetNodeAccountIDs([]AccountID{resp.NodeID}).
-		SetMaxQueryPayment(HbarFromTinybar(0)).
-		Execute(env.Client)
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 
 	record, err := NewTransactionRecordQuery().
@@ -177,10 +170,7 @@ func TestIntegrationTransactionRecordQueryInsufficientFee(t *testing.T) {
 	resp, err := tx.Execute(env.Client)
 	require.NoError(t, err)
 
-	receipt, err := NewTransactionReceiptQuery().
-		SetTransactionID(resp.TransactionID).
-		SetNodeAccountIDs([]AccountID{resp.NodeID}).
-		Execute(env.Client)
+	receipt, err := resp.SetIncludeChildren(true).GetReceipt(env.Client)
 	require.NoError(t, err)
 
 	_, err = NewTransactionRecordQuery().

--- a/transaction_response.go
+++ b/transaction_response.go
@@ -37,6 +37,7 @@ type TransactionResponse struct {
 	NodeID                 AccountID
 	Hash                   []byte
 	ValidateStatus         bool
+	IncludeChildReceipts   bool
 	Transaction            TransactionInterface
 }
 
@@ -69,6 +70,7 @@ func (response TransactionResponse) GetReceipt(client *Client) (TransactionRecei
 	receipt, err := NewTransactionReceiptQuery().
 		SetTransactionID(response.TransactionID).
 		SetNodeAccountIDs([]AccountID{response.NodeID}).
+		SetIncludeChildren(response.IncludeChildReceipts).
 		Execute(client)
 
 	for receipt.Status == StatusThrottledAtConsensus {
@@ -123,4 +125,17 @@ func (response TransactionResponse) SetValidateStatus(validate bool) *Transactio
 // GetValidateStatus returns the validate status for the transaction
 func (response TransactionResponse) GetValidateStatus() bool {
 	return response.ValidateStatus
+}
+
+// SetIncludeChildren Sets whether the response should include the receipts of any child transactions spawned by the
+// top-level transaction with the given transactionID.
+func (response TransactionResponse) SetIncludeChildren(include bool) *TransactionResponse {
+	response.IncludeChildReceipts = include
+	return &response
+}
+
+// GetIncludeChildren returns whether the response should include the receipts of any child transactions spawned by the
+// top-level transaction with the given transactionID.
+func (response TransactionResponse) GetIncludeChildren() bool {
+	return response.IncludeChildReceipts
 }


### PR DESCRIPTION
**Description**:

When manual `ReceiptQuery` is executed, the status returned is not validated, meaning it will not return error object.
Error object is returned only when the receipt query is executed by `GetReceipt` on the transaction result.

Currently if a transaction fails with throttle status and we call `GetReceipt`, it will retry, but if we create the receipt separately it would not retry or return an error.
This causes some integration tests to have flaky behaviour. Additionally manual execution of `ReceiptQuery` will return no error when an error code is actually returned.

This PR:
1. Adds the ability to query child receipts from the transaction result.
2.  Replaces receipt query execution with `GetReceipt` in e2e tests.
3.  Replaces receipt query execution with `GetReceipt` in flows.

**Related issue(s)**:

Fixes #1079

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
