### PR TITLE
fix: Reset staked ids

### DIFF
--- a/account_create_transaction.go
+++ b/account_create_transaction.go
@@ -194,6 +194,7 @@ func (tx *AccountCreateTransaction) GetAccountMemo() string {
 func (tx *AccountCreateTransaction) SetStakedAccountID(id AccountID) *AccountCreateTransaction {
 	tx._RequireNotFrozen()
 	tx.stakedAccountID = &id
+	tx.stakedNodeID = nil
 	return tx
 }
 
@@ -210,6 +211,7 @@ func (tx *AccountCreateTransaction) GetStakedAccountID() AccountID {
 func (tx *AccountCreateTransaction) SetStakedNodeID(id int64) *AccountCreateTransaction {
 	tx._RequireNotFrozen()
 	tx.stakedNodeID = &id
+	tx.stakedAccountID = nil
 	return tx
 }
 

--- a/account_create_transaction_e2e_test.go
+++ b/account_create_transaction_e2e_test.go
@@ -607,3 +607,30 @@ func TestIntegrationSerializeTransactionWithoutNodeAccountIdDeserialiseAndExecut
 
 	require.NoError(t, err)
 }
+
+func TestIntegrationAccountCreateTransactionSetStakingNodeID(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	newBalance := NewHbar(2)
+
+	assert.Equal(t, 2*HbarUnits.Hbar._NumberOfTinybar(), newBalance.tinybar)
+
+	resp, err := NewAccountCreateTransaction().
+		SetKey(newKey).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetInitialBalance(newBalance).
+		SetStakedAccountID(env.OperatorID).
+		SetStakedNodeID(0).
+		SetMaxAutomaticTokenAssociations(100).
+		Execute(env.Client)
+
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+}

--- a/account_create_transaction_unit_test.go
+++ b/account_create_transaction_unit_test.go
@@ -353,3 +353,28 @@ func TestUnitAccountCreateTransactionCoverage(t *testing.T) {
 		b.AddSignature(key.PublicKey(), sig)
 	}
 }
+
+func TestUnitAccountCreateSetStakedNodeID(t *testing.T) {
+	t.Parallel()
+
+	checksum := "dmqui"
+	account := AccountID{Account: 3, checksum: &checksum}
+	tx := NewAccountCreateTransaction().
+		SetStakedAccountID(account).
+		SetStakedNodeID(4)
+
+	require.Equal(t, AccountID{}, tx.GetStakedAccountID())
+	require.Equal(t, int64(4), tx.GetStakedNodeID())
+}
+func TestUnitAccountCreateSetStakedAccountID(t *testing.T) {
+	t.Parallel()
+
+	checksum := "dmqui"
+	account := AccountID{Account: 3, checksum: &checksum}
+	tx := NewAccountCreateTransaction().
+		SetStakedNodeID(4).
+		SetStakedAccountID(account)
+
+	require.Equal(t, int64(0), tx.GetStakedNodeID())
+	require.Equal(t, account, tx.GetStakedAccountID())
+}


### PR DESCRIPTION
**Description**:

`SetStakedNodeID` should reset `stakedAccountID` and vice versa.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
