### PR TITLE
fix: Retry in case of throttle when calling `getRecord`

### DIFF
--- a/transaction_response.go
+++ b/transaction_response.go
@@ -91,6 +91,10 @@ func (response TransactionResponse) GetRecord(client *Client) (TransactionRecord
 		SetNodeAccountIDs([]AccountID{response.NodeID}).
 		Execute(client)
 
+	for receipt.Status == StatusThrottledAtConsensus {
+		receipt, err = retryTransaction(client, response.Transaction)
+	}
+
 	if err != nil {
 		// Manually add the receipt, because an empty TransactionRecord will have an empty receipt and empty receipt has no status and no status defaults to 0, which means success
 		return TransactionRecord{Receipt: receipt}, err


### PR DESCRIPTION
**Description**:

**Related issue(s)**:

Fixes #1125

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
