### PR TITLE
ci: Remove redundant local-node workflow steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,10 +127,6 @@ jobs:
                 token: ${{ secrets.CODECOV_TOKEN }}
                 files: ./e2e.out
 
-            - name: Stop the local node
-              if: matrix.test-type == 'e2e'
-              run: npx @hashgraph/hedera-local stop
-
     run-examples:
         name: Run Examples
         if: success()
@@ -181,9 +177,6 @@ jobs:
             - name: Run Examples
               if: success()
               run: task run-examples
-
-            - name: Stop the local node
-              run: npx @hashgraph/hedera-local stop
 
     build-test-tck:
         name: Build and Test TCK


### PR DESCRIPTION
**Description**:

Remove local-node stop steps as they are increasing CI pass time.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-go/issues/1422

**Notes for reviewer**:
Merge after `v2.65.0` rel.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
