### PR TITLE
refactor: use strings.Builder

### DIFF
--- a/sdk/abi_decode.go
+++ b/sdk/abi_decode.go
@@ -176,19 +176,20 @@ func (a Address) checksumEncode() string {
 
 	hash := hex.EncodeToString(Keccak256Hash([]byte(address)).Bytes())
 
-	ret := "0x"
+	var ret strings.Builder
+	ret.WriteString("0x")
 	for i := 0; i < len(address); i++ {
 		character := string(address[i])
 
 		num, _ := strconv.ParseInt(string(hash[i]), 16, 64)
 		if num > 7 {
-			ret += strings.ToUpper(character)
+			ret.WriteString(strings.ToUpper(character))
 		} else {
-			ret += character
+			ret.WriteString(character)
 		}
 	}
 
-	return ret
+	return ret.String()
 }
 
 func readAddr(b []byte) (Address, error) {

--- a/sdk/custom_fee_limit.go
+++ b/sdk/custom_fee_limit.go
@@ -1,5 +1,7 @@
 package hiero
 
+import "strings"
+
 import "github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 
 // SPDX-License-Identifier: Apache-2.0
@@ -83,13 +85,14 @@ func (feeLimit *CustomFeeLimit) toProtobuf() *services.CustomFeeLimit {
 }
 
 func (feeLimit *CustomFeeLimit) String() string {
-	customFeesStr := "["
+	var customFeesStr strings.Builder
+	customFeesStr.WriteString("[")
 	for i, fee := range feeLimit.CustomFees {
 		if i > 0 {
-			customFeesStr += ", "
+			customFeesStr.WriteString(", ")
 		}
-		customFeesStr += fee.String()
+		customFeesStr.WriteString(fee.String())
 	}
-	customFeesStr += "]"
-	return "CustomFeeLimit{PayerId: " + feeLimit.PayerId.String() + ", CustomFees: " + customFeesStr + "}"
+	customFeesStr.WriteString("]")
+	return "CustomFeeLimit{PayerId: " + feeLimit.PayerId.String() + ", CustomFees: " + customFeesStr.String() + "}"
 }

--- a/sdk/node_address.go
+++ b/sdk/node_address.go
@@ -4,6 +4,7 @@ package hiero
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 )
@@ -60,9 +61,9 @@ func (nodeAdd *NodeAddress) _ToProtobuf() *services.NodeAddress {
 
 // String returns a string representation of the NodeAddress
 func (nodeAdd NodeAddress) String() string {
-	Addresses := ""
+	var Addresses strings.Builder
 	for _, k := range nodeAdd.Addresses {
-		Addresses += k.String()
+		Addresses.WriteString(k.String())
 	}
-	return "NodeAccountId: " + nodeAdd.AccountID.String() + " " + Addresses + "\n" + "CertHash: " + string(nodeAdd.CertHash) + "\n" + "NodeId: " + strconv.FormatInt(nodeAdd.NodeID, 10) + "\n" + "PubKey: " + nodeAdd.PublicKey
+	return "NodeAccountId: " + nodeAdd.AccountID.String() + " " + Addresses.String() + "\n" + "CertHash: " + string(nodeAdd.CertHash) + "\n" + "NodeId: " + strconv.FormatInt(nodeAdd.NodeID, 10) + "\n" + "PubKey: " + nodeAdd.PublicKey
 }

--- a/sdk/token_nft_allowance.go
+++ b/sdk/token_nft_allowance.go
@@ -4,6 +4,7 @@ package hiero
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -118,7 +119,7 @@ func (approval *TokenNftAllowance) String() string {
 	var owner string
 	var spender string
 	var token string
-	var serials string
+	var serials strings.Builder
 
 	if approval.OwnerAccountID != nil {
 		owner = approval.OwnerAccountID.String()
@@ -133,8 +134,8 @@ func (approval *TokenNftAllowance) String() string {
 	}
 
 	for _, serial := range approval.SerialNumbers {
-		serials += fmt.Sprintf("%d, ", serial)
+		serials.WriteString(fmt.Sprintf("%d, ", serial))
 	}
 
-	return fmt.Sprintf("OwnerAccountID: %s, SpenderAccountID: %s, TokenID: %s, Serials: %s, ApprovedForAll: %t", owner, spender, token, serials, approval.AllSerials)
+	return fmt.Sprintf("OwnerAccountID: %s, SpenderAccountID: %s, TokenID: %s, Serials: %s, ApprovedForAll: %t", owner, spender, token, serials.String(), approval.AllSerials)
 }


### PR DESCRIPTION
**Description**:

The new pr for https://github.com/hiero-ledger/hiero-sdk-go/pull/1488 and signed.

strings.Builder has fewer memory allocations and better performance.
More info: https://github.com/golang/go/issues/75190


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
