### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/sdk/mnemonic.go
+++ b/sdk/mnemonic.go
@@ -131,7 +131,7 @@ func (m Mnemonic) _Indices() ([]int, error) {
 	var check bool
 	temp := strings.Split(m.words, " ")
 	if len(temp) == 22 { // nolint
-		for _, mnemonicString := range strings.Split(m.words, " ") {
+		for mnemonicString := range strings.SplitSeq(m.words, " ") {
 			check = false
 			for i, stringCheck := range legacy {
 				if mnemonicString == stringCheck {
@@ -144,7 +144,7 @@ func (m Mnemonic) _Indices() ([]int, error) {
 			}
 		}
 	} else if len(temp) == 24 {
-		for _, mnemonicString := range strings.Split(m.words, " ") {
+		for mnemonicString := range strings.SplitSeq(m.words, " ") {
 			t, check := GetWordIndex(mnemonicString)
 			if !check {
 				return make([]int, 0), ErrInvalidMnemonic


### PR DESCRIPTION
**Description**:


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901





**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
