### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/sdk/abi.go
+++ b/sdk/abi.go
@@ -235,7 +235,7 @@ func (m *Method) ID() []byte {
 }
 
 // Encode encodes the inputs with this function
-func (m *Method) Encode(args interface{}) ([]byte, error) {
+func (m *Method) Encode(args any) ([]byte, error) {
 	data, err := Encode(args, m.Inputs)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ func (m *Method) Encode(args interface{}) ([]byte, error) {
 }
 
 // Decode decodes the output with this function
-func (m *Method) Decode(data []byte) (map[string]interface{}, error) {
+func (m *Method) Decode(data []byte) (map[string]any, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("empty response")
 	}
@@ -253,7 +253,7 @@ func (m *Method) Decode(data []byte) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp := respInterface.(map[string]interface{})
+	resp := respInterface.(map[string]any)
 	return resp, nil
 }
 
@@ -317,7 +317,7 @@ type ArgumentStr struct {
 }
 
 var keccakPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return sha3.NewLegacyKeccak256()
 	},
 }

--- a/sdk/abi_decode.go
+++ b/sdk/abi_decode.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Decode decodes the input with a given type
-func Decode(t *Type, input []byte) (interface{}, error) {
+func Decode(t *Type, input []byte) (any, error) {
 	if len(input) == 0 {
 		return nil, fmt.Errorf("empty input")
 	}
@@ -24,7 +24,7 @@ func Decode(t *Type, input []byte) (interface{}, error) {
 }
 
 // DecodeStruct decodes the input with a type to a struct
-func DecodeStruct(t *Type, input []byte, out interface{}) error {
+func DecodeStruct(t *Type, input []byte, out any) error {
 	val, err := Decode(t, input)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func DecodeStruct(t *Type, input []byte, out interface{}) error {
 	return nil
 }
 
-func decode(t *Type, input []byte) (interface{}, []byte, error) {
+func decode(t *Type, input []byte) (any, []byte, error) {
 	var data []byte
 	var length int
 	var err error
@@ -75,7 +75,7 @@ func decode(t *Type, input []byte) (interface{}, []byte, error) {
 		return decodeArraySlice(t, input, t.size)
 	}
 
-	var val interface{}
+	var val any
 	switch t.kind {
 	case KindBool:
 		val, err = decodeBool(data)
@@ -201,7 +201,7 @@ func readAddr(b []byte) (Address, error) {
 	return res, nil
 }
 
-func readInteger(t *Type, b []byte) interface{} {
+func readInteger(t *Type, b []byte) any {
 	switch t.t.Kind() {
 	case reflect.Uint8:
 		return b[len(b)-1]
@@ -253,14 +253,14 @@ func readFunctionType(t *Type, word []byte) ([24]byte, error) {
 }
 
 // nolint
-func readFixedBytes(t *Type, word []byte) (interface{}, error) {
+func readFixedBytes(t *Type, word []byte) (any, error) {
 	array := reflect.New(t.t).Elem()
 	reflect.Copy(array, reflect.ValueOf(word[0:t.size]))
 	return array.Interface(), nil
 }
 
-func decodeTuple(t *Type, data []byte) (interface{}, []byte, error) {
-	res := make(map[string]interface{})
+func decodeTuple(t *Type, data []byte) (any, []byte, error) {
+	res := make(map[string]any)
 
 	orig := data
 	origLen := len(orig)
@@ -302,7 +302,7 @@ func decodeTuple(t *Type, data []byte) (interface{}, []byte, error) {
 	return res, data, nil
 }
 
-func decodeArraySlice(t *Type, data []byte, size int) (interface{}, []byte, error) {
+func decodeArraySlice(t *Type, data []byte, size int) (any, []byte, error) {
 	if size < 0 {
 		return nil, nil, fmt.Errorf("size is lower than zero")
 	}
@@ -351,7 +351,7 @@ func decodeArraySlice(t *Type, data []byte, size int) (interface{}, []byte, erro
 	return res.Interface(), data, nil
 }
 
-func decodeBool(data []byte) (interface{}, error) {
+func decodeBool(data []byte) (any, error) {
 	switch data[31] {
 	case 0:
 		return false, nil

--- a/sdk/abi_encode.go
+++ b/sdk/abi_encode.go
@@ -17,7 +17,7 @@ var (
 )
 
 // Encode encodes a value
-func Encode(v interface{}, t *Type) ([]byte, error) {
+func Encode(v any, t *Type) ([]byte, error) {
 	return encode(reflect.ValueOf(v), t)
 }
 
@@ -282,7 +282,7 @@ func encodeErr(v reflect.Value, t string) error {
 
 // nolint
 func mapFromStruct(v reflect.Value) (reflect.Value, error) {
-	res := map[string]interface{}{}
+	res := map[string]any{}
 	typ := v.Type()
 	for i := 0; i < v.NumField(); i++ {
 		f := typ.Field(i)

--- a/sdk/abi_type.go
+++ b/sdk/abi_type.go
@@ -26,7 +26,7 @@ var (
 	stringT       = reflect.TypeOf("")
 	dynamicBytesT = reflect.SliceOf(reflect.TypeOf(byte(0)))
 	functionT     = reflect.ArrayOf(24, reflect.TypeOf(byte(0)))
-	tupleT        = reflect.TypeOf(map[string]interface{}{})
+	tupleT        = reflect.TypeOf(map[string]any{})
 	bigIntT       = reflect.TypeOf(new(big.Int))
 )
 
@@ -132,12 +132,12 @@ func NewTupleTypeFromArgs(inputs []*ArgumentStr) (*Type, error) {
 }
 
 // Decode decodes an object using this type
-func (t *Type) Decode(input []byte) (interface{}, error) {
+func (t *Type) Decode(input []byte) (any, error) {
 	return Decode(t, input)
 }
 
 // DecodeStruct decodes an object using this type to the out param
-func (t *Type) DecodeStruct(input []byte, out interface{}) error {
+func (t *Type) DecodeStruct(input []byte, out any) error {
 	return DecodeStruct(t, input, out)
 }
 
@@ -147,7 +147,7 @@ func (t *Type) InternalType() string {
 }
 
 // Encode encodes an object using this type
-func (t *Type) Encode(v interface{}) ([]byte, error) {
+func (t *Type) Encode(v any) ([]byte, error) {
 	return Encode(v, t)
 }
 

--- a/sdk/account_id.go
+++ b/sdk/account_id.go
@@ -339,7 +339,7 @@ const (
 	EvmAddress
 )
 
-func (id *AccountID) _MirrorNodeRequest(client *Client, populateType string) (map[string]interface{}, error) {
+func (id *AccountID) _MirrorNodeRequest(client *Client, populateType string) (map[string]any, error) {
 	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
 		return nil, errors.New("mirror node is not set")
 	}
@@ -361,7 +361,7 @@ func (id *AccountID) _MirrorNodeRequest(client *Client, populateType string) (ma
 	}
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
 	}

--- a/sdk/bip39_test.go
+++ b/sdk/bip39_test.go
@@ -423,13 +423,13 @@ func badMnemonicSentences() []vector {
 	}
 }
 
-func assertNil(t *testing.T, object interface{}) {
+func assertNil(t *testing.T, object any) {
 	if object != nil {
 		t.Errorf("Expected nil, got %v", object)
 	}
 }
 
-func assertNotNil(t *testing.T, object interface{}) {
+func assertNotNil(t *testing.T, object any) {
 	if object == nil {
 		t.Error("Expected not nil")
 	}
@@ -447,7 +447,7 @@ func assertFalse(t *testing.T, a bool) {
 	}
 }
 
-func assertEqual(t *testing.T, a, b interface{}) {
+func assertEqual(t *testing.T, a, b any) {
 	if a != b {
 		t.Errorf("Objects not equal, expected `%s` and got `%s`", a, b)
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -271,8 +271,8 @@ type _ConfigOperator struct {
 
 // TODO: Implement complete spec: https://gitlab.com/launchbadge/hedera/sdk/python/-/issues/45
 type _ClientConfig struct {
-	Network       interface{}      `json:"network"`
-	MirrorNetwork interface{}      `json:"mirrorNetwork"`
+	Network       any              `json:"network"`
+	MirrorNetwork any              `json:"mirrorNetwork"`
 	Shard         uint64           `json:"shard"`
 	Realm         uint64           `json:"realm"`
 	Operator      *_ConfigOperator `json:"operator"`
@@ -305,7 +305,7 @@ func clientFromConfig(jsonBytes []byte, shouldScheduleNetworkUpdate bool) (*Clie
 	networkAddresses := make(map[string]AccountID)
 
 	switch net := clientConfig.Network.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for url, inter := range net {
 			switch id := inter.(type) {
 			case string:
@@ -338,7 +338,7 @@ func clientFromConfig(jsonBytes []byte, shouldScheduleNetworkUpdate bool) (*Clie
 	}
 
 	switch mirror := clientConfig.MirrorNetwork.(type) {
-	case []interface{}:
+	case []any:
 		arr := make([]string, len(mirror))
 		for i, inter := range mirror {
 			switch str := inter.(type) {

--- a/sdk/contract_function_parameters.go
+++ b/sdk/contract_function_parameters.go
@@ -1840,7 +1840,7 @@ func _NewArgument() Argument {
 	}
 }
 
-func _NewIntArgument(value interface{}) Argument {
+func _NewIntArgument(value any) Argument {
 	var val int64
 	switch v := value.(type) {
 	case int64:

--- a/sdk/contract_function_result.go
+++ b/sdk/contract_function_result.go
@@ -415,7 +415,7 @@ func (result ContractFunctionResult) AsBytes() []byte {
 // allowing flexibility to handle various types of contract call results.
 // For correct usage, the caller should perform a type assertion on the returned interface{}
 // to convert it into the appropriate go type.
-func (result ContractFunctionResult) GetResult(types string) (interface{}, error) {
+func (result ContractFunctionResult) GetResult(types string) (any, error) {
 	def := fmt.Sprintf(`[{ "name" : "method", "type": "function", "outputs": [{ "type": "%s" }]}]`, types)
 	abi := ABI{}
 	err := abi.UnmarshalJSON([]byte(def))

--- a/sdk/contract_id.go
+++ b/sdk/contract_id.go
@@ -184,7 +184,7 @@ func (id *ContractID) PopulateContract(client *Client) error {
 	}
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return err
 	}

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -91,7 +91,7 @@ type ErrBadKey struct {
 	message string
 }
 
-func _NewErrBadKeyf(format string, a ...interface{}) ErrBadKey {
+func _NewErrBadKeyf(format string, a ...any) ErrBadKey {
 	return ErrBadKey{fmt.Sprintf(format, a...)}
 }
 

--- a/sdk/executable.go
+++ b/sdk/executable.go
@@ -40,13 +40,13 @@ type Executable interface {
 	GetNodeAccountIDs() []AccountID
 	GetLogLevel() *LogLevel
 
-	shouldRetry(Executable, interface{}) _ExecutionState
-	makeRequest() interface{}
+	shouldRetry(Executable, any) _ExecutionState
+	makeRequest() any
 	advanceRequest()
 	getNodeAccountID() AccountID
 	getMethod(*_Channel) _Method
-	mapStatusError(Executable, interface{}) error
-	mapResponse(interface{}, AccountID, interface{}) (interface{}, error)
+	mapStatusError(Executable, any) error
+	mapResponse(any, AccountID, any) (any, error)
 	getName() string
 	validateNetworkOnIDs(client *Client) error
 	isTransaction() bool
@@ -190,7 +190,7 @@ func (e *executable) getNodeAccountID() AccountID {
 }
 
 // nolint
-func _Execute(client *Client, e Executable) (interface{}, error) {
+func _Execute(client *Client, e Executable) (any, error) {
 	var maxAttempts int
 
 	if client.maxAttempts != nil {
@@ -220,7 +220,7 @@ func _Execute(client *Client, e Executable) (interface{}, error) {
 			return TransactionResponse{}, fmt.Errorf("request timed out after %s", requestTimeout)
 		}
 
-		var protoRequest interface{}
+		var protoRequest any
 		var node *_Node
 		var ok bool
 
@@ -269,7 +269,7 @@ func _Execute(client *Client, e Executable) (interface{}, error) {
 
 		method := e.getMethod(channel)
 
-		var resp interface{}
+		var resp any
 
 		var grpcDeadline time.Duration
 		if e.GetGrpcDeadline() != nil {

--- a/sdk/lockable_slice.go
+++ b/sdk/lockable_slice.go
@@ -3,14 +3,14 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 type _LockableSlice struct {
-	slice  []interface{}
+	slice  []any
 	locked bool
 	index  int
 }
 
 func _NewLockableSlice() *_LockableSlice {
 	return &_LockableSlice{
-		slice: []interface{}{},
+		slice: []any{},
 	}
 }
 
@@ -25,14 +25,14 @@ func (ls *_LockableSlice) _SetLocked(locked bool) *_LockableSlice { // nolint
 	return ls
 }
 
-func (ls *_LockableSlice) _SetSlice(slice []interface{}) *_LockableSlice { //nolint
+func (ls *_LockableSlice) _SetSlice(slice []any) *_LockableSlice { //nolint
 	ls._RequireNotLocked()
 	ls.slice = slice
 	ls.index = 0
 	return ls
 }
 
-func (ls *_LockableSlice) _Push(items ...interface{}) *_LockableSlice {
+func (ls *_LockableSlice) _Push(items ...any) *_LockableSlice {
 	ls._RequireNotLocked()
 	ls.slice = append(ls.slice, items...)
 	return ls
@@ -40,15 +40,15 @@ func (ls *_LockableSlice) _Push(items ...interface{}) *_LockableSlice {
 
 func (ls *_LockableSlice) _Clear() *_LockableSlice { //nolint
 	ls._RequireNotLocked()
-	ls.slice = []interface{}{}
+	ls.slice = []any{}
 	return ls
 }
 
-func (ls *_LockableSlice) _Get(index int) interface{} { //nolint
+func (ls *_LockableSlice) _Get(index int) any { //nolint
 	return ls.slice[index]
 }
 
-func (ls *_LockableSlice) _Set(index int, item interface{}) *_LockableSlice { //nolint
+func (ls *_LockableSlice) _Set(index int, item any) *_LockableSlice { //nolint
 	ls._RequireNotLocked()
 
 	if len(ls.slice) == index {
@@ -60,7 +60,7 @@ func (ls *_LockableSlice) _Set(index int, item interface{}) *_LockableSlice { //
 	return ls
 }
 
-func (ls *_LockableSlice) _SetIfAbsent(index int, item interface{}) *_LockableSlice { //nolint
+func (ls *_LockableSlice) _SetIfAbsent(index int, item any) *_LockableSlice { //nolint
 	ls._RequireNotLocked()
 	if len(ls.slice) == index || ls.slice[index] == nil {
 		ls._Set(index, item)
@@ -68,11 +68,11 @@ func (ls *_LockableSlice) _SetIfAbsent(index int, item interface{}) *_LockableSl
 	return ls
 }
 
-func (ls *_LockableSlice) _GetNext() interface{} { //nolint
+func (ls *_LockableSlice) _GetNext() any { //nolint
 	return ls._Get(ls._Advance())
 }
 
-func (ls *_LockableSlice) _GetCurrent() interface{} { //nolint
+func (ls *_LockableSlice) _GetCurrent() any { //nolint
 	return ls._Get(ls.index)
 }
 

--- a/sdk/logger.go
+++ b/sdk/logger.go
@@ -25,11 +25,11 @@ type Logger interface {
 	SetSilent(isSilent bool)
 	SetLevel(level LogLevel)
 	SubLoggerWithLevel(level LogLevel) Logger
-	Error(msg string, keysAndValues ...interface{})
-	Warn(msg string, keysAndValues ...interface{})
-	Info(msg string, keysAndValues ...interface{})
-	Debug(msg string, keysAndValues ...interface{})
-	Trace(msg string, keysAndValues ...interface{})
+	Error(msg string, keysAndValues ...any)
+	Warn(msg string, keysAndValues ...any)
+	Info(msg string, keysAndValues ...any)
+	Debug(msg string, keysAndValues ...any)
+	Trace(msg string, keysAndValues ...any)
 }
 
 type DefaultLogger struct {
@@ -96,35 +96,35 @@ func (l *DefaultLogger) SubLoggerWithLevel(level LogLevel) Logger {
 	}
 }
 
-func (l *DefaultLogger) Warn(msg string, keysAndValues ...interface{}) {
+func (l *DefaultLogger) Warn(msg string, keysAndValues ...any) {
 	addFields(l.logger.Warn(), msg, keysAndValues...)
 }
 
-func (l *DefaultLogger) Error(msg string, keysAndValues ...interface{}) {
+func (l *DefaultLogger) Error(msg string, keysAndValues ...any) {
 	addFields(l.logger.Error(), msg, keysAndValues...)
 }
 
-func (l *DefaultLogger) Trace(msg string, keysAndValues ...interface{}) {
+func (l *DefaultLogger) Trace(msg string, keysAndValues ...any) {
 	addFields(l.logger.Trace(), msg, keysAndValues...)
 }
 
-func (l *DefaultLogger) Debug(msg string, keysAndValues ...interface{}) {
+func (l *DefaultLogger) Debug(msg string, keysAndValues ...any) {
 	addFields(l.logger.Debug(), msg, keysAndValues...)
 }
 
-func (l *DefaultLogger) Info(msg string, keysAndValues ...interface{}) {
+func (l *DefaultLogger) Info(msg string, keysAndValues ...any) {
 	addFields(l.logger.Info(), msg, keysAndValues...)
 }
 
-func argsToFields(keysAndValues ...interface{}) map[string]interface{} {
-	fields := make(map[string]interface{})
+func argsToFields(keysAndValues ...any) map[string]any {
+	fields := make(map[string]any)
 	for i := 0; i < len(keysAndValues); i += 2 {
 		fields[fmt.Sprint(keysAndValues[i])] = keysAndValues[i+1]
 	}
 	return fields
 }
 
-func addFields(event *zerolog.Event, msg string, keysAndValues ...interface{}) {
+func addFields(event *zerolog.Event, msg string, keysAndValues ...any) {
 	for key, value := range argsToFields(keysAndValues...) {
 		switch v := value.(type) {
 		case string:

--- a/sdk/node.go
+++ b/sdk/node.go
@@ -256,7 +256,7 @@ func unaryInterceptor(md metadata.MD) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
-		req, reply interface{},
+		req, reply any,
 		cc *grpc.ClientConn,
 		invoker grpc.UnaryInvoker,
 		opts ...grpc.CallOption,

--- a/sdk/query.go
+++ b/sdk/query.go
@@ -236,7 +236,7 @@ func (q *Query) isBatchedAndNotBatchTransaction() bool {
 	return false
 }
 
-func (q *Query) shouldRetry(e Executable, response interface{}) _ExecutionState {
+func (q *Query) shouldRetry(e Executable, response any) _ExecutionState {
 	queryResp := e.(QueryInterface).getQueryResponse(response.(*services.Response))
 
 	status := Status(queryResp.GetHeader().NodeTransactionPrecheckCode)
@@ -281,7 +281,7 @@ func (q *Query) advanceRequest() {
 	q.nodeAccountIDs._Advance()
 }
 
-func (q *Query) makeRequest() interface{} {
+func (q *Query) makeRequest() any {
 	if q.client != nil && q.isPaymentRequired {
 		tx, err := q.generatePayments(q.client, q.queryPayment)
 		if err != nil {
@@ -293,7 +293,7 @@ func (q *Query) makeRequest() interface{} {
 	return q.pb
 }
 
-func (q *Query) mapResponse(response interface{}, _ AccountID, _ interface{}) (interface{}, error) { // nolint
+func (q *Query) mapResponse(response any, _ AccountID, _ any) (any, error) { // nolint
 	return response.(*services.Response), nil
 }
 
@@ -301,7 +301,7 @@ func (q *Query) isTransaction() bool {
 	return false
 }
 
-func (q *Query) mapStatusError(e Executable, response interface{}) error {
+func (q *Query) mapStatusError(e Executable, response any) error {
 	queryResp := e.(QueryInterface).getQueryResponse(response.(*services.Response))
 	return ErrHederaPreCheckStatus{
 		Status: Status(queryResp.GetHeader().NodeTransactionPrecheckCode),

--- a/sdk/topic_message_submit_transaction.go
+++ b/sdk/topic_message_submit_transaction.go
@@ -71,7 +71,7 @@ func (tx *TopicMessageSubmitTransaction) GetTopicID() TopicID {
 // SetMessage Sets the message to be submitted.
 // The message should be a byte array or a string
 // If other types are provided, it will not set the value
-func (tx *TopicMessageSubmitTransaction) SetMessage(message interface{}) *TopicMessageSubmitTransaction {
+func (tx *TopicMessageSubmitTransaction) SetMessage(message any) *TopicMessageSubmitTransaction {
 	tx._RequireNotFrozen()
 	switch m := message.(type) {
 	case string:

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -1329,7 +1329,7 @@ func (tx *Transaction[T]) getLogID(transactionInterface Executable) string {
 }
 
 // ------------ Executable Functions ------------
-func (tx *Transaction[T]) shouldRetry(_ Executable, response interface{}) _ExecutionState {
+func (tx *Transaction[T]) shouldRetry(_ Executable, response any) _ExecutionState {
 	status := Status(response.(*services.TransactionResponse).NodeTransactionPrecheckCode)
 
 	retryableStatuses := map[Status]bool{
@@ -1357,7 +1357,7 @@ func (tx *Transaction[T]) shouldRetry(_ Executable, response interface{}) _Execu
 	return executionStateError
 }
 
-func (tx *Transaction[T]) makeRequest() interface{} {
+func (tx *Transaction[T]) makeRequest() any {
 	index := tx.nodeAccountIDs._Length()*tx.transactionIDs.index + tx.nodeAccountIDs.index
 	built, _ := tx._BuildTransaction(index)
 
@@ -1375,7 +1375,7 @@ func (tx *Transaction[T]) getNodeAccountID() AccountID {
 
 func (tx *Transaction[T]) mapStatusError(
 	_ Executable,
-	response interface{},
+	response any,
 ) error {
 	return ErrHederaPreCheckStatus{
 		Status: Status(response.(*services.TransactionResponse).NodeTransactionPrecheckCode),
@@ -1383,7 +1383,7 @@ func (tx *Transaction[T]) mapStatusError(
 	}
 }
 
-func (tx *Transaction[T]) mapResponse(_ interface{}, nodeID AccountID, protoRequest interface{}) (interface{}, error) {
+func (tx *Transaction[T]) mapResponse(_ any, nodeID AccountID, protoRequest any) (any, error) {
 	hash := sha512.New384()
 	_, err := hash.Write(protoRequest.(*services.Transaction).SignedTransactionBytes)
 	if err != nil {

--- a/sdk/transaction_receipt.go
+++ b/sdk/transaction_receipt.go
@@ -36,8 +36,8 @@ type TransactionReceipt struct {
 	TransactionID           *TransactionID
 }
 
-func (receipt *TransactionReceipt) _ToMap() map[string]interface{} {
-	m := map[string]interface{}{
+func (receipt *TransactionReceipt) _ToMap() map[string]any {
+	m := map[string]any{
 		"status":                  receipt.Status.String(),
 		"topicSequenceNumber":     receipt.TopicSequenceNumber,
 		"topicRunningHash":        hex.EncodeToString(receipt.TopicRunningHash),
@@ -77,7 +77,7 @@ func (receipt *TransactionReceipt) _ToMap() map[string]interface{} {
 	}
 
 	// Handling fields with possible nil values
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"topicId":                receipt.TopicID,
 		"fileId":                 receipt.FileID,
 		"contractId":             receipt.ContractID,

--- a/sdk/transaction_receipt_query.go
+++ b/sdk/transaction_receipt_query.go
@@ -167,7 +167,7 @@ func (q *TransactionReceiptQuery) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (q *TransactionReceiptQuery) mapStatusError(_ Executable, response interface{}) error {
+func (q *TransactionReceiptQuery) mapStatusError(_ Executable, response any) error {
 	status := Status(response.(*services.Response).GetTransactionGetReceipt().GetHeader().GetNodeTransactionPrecheckCode())
 	switch status {
 	case StatusPlatformTransactionNotCreated, StatusBusy, StatusUnknown, StatusOk:
@@ -223,7 +223,7 @@ func (q *TransactionReceiptQuery) validateNetworkOnIDs(client *Client) error {
 	return nil
 }
 
-func (q *TransactionReceiptQuery) shouldRetry(_ Executable, response interface{}) _ExecutionState {
+func (q *TransactionReceiptQuery) shouldRetry(_ Executable, response any) _ExecutionState {
 	status := Status(response.(*services.Response).GetTransactionGetReceipt().GetHeader().GetNodeTransactionPrecheckCode())
 
 	switch status {

--- a/sdk/transaction_record.go
+++ b/sdk/transaction_record.go
@@ -53,11 +53,11 @@ type TransactionRecord struct {
 // MarshalJSON returns the JSON representation of the TransactionRecord
 func (record TransactionRecord) MarshalJSON() ([]byte, error) {
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	type TransferJSON struct {
-		AccountID  string      `json:"accountId"`
-		Amount     interface{} `json:"amount"`
-		IsApproved bool        `json:"isApproved"`
+		AccountID  string `json:"accountId"`
+		Amount     any    `json:"amount"`
+		IsApproved bool   `json:"isApproved"`
 	}
 	var transfersJSON []TransferJSON
 	for _, t := range record.Transfers {
@@ -225,7 +225,7 @@ func (record TransactionRecord) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var receiptInterface interface{}
+	var receiptInterface any
 	err = json.Unmarshal(receiptBytes, &receiptInterface)
 	if err != nil {
 		return nil, err

--- a/sdk/transaction_record_query.go
+++ b/sdk/transaction_record_query.go
@@ -170,7 +170,7 @@ func (q *TransactionRecordQuery) getMethod(channel *_Channel) _Method {
 	}
 }
 
-func (q *TransactionRecordQuery) mapStatusError(_ Executable, response interface{}) error {
+func (q *TransactionRecordQuery) mapStatusError(_ Executable, response any) error {
 	query := response.(*services.Response)
 	switch Status(query.GetTransactionGetRecord().GetHeader().GetNodeTransactionPrecheckCode()) {
 	case StatusPlatformTransactionNotCreated, StatusBusy, StatusUnknown, StatusReceiptNotFound, StatusRecordNotFound, StatusOk:
@@ -228,7 +228,7 @@ func (q *TransactionRecordQuery) validateNetworkOnIDs(client *Client) error {
 	return nil
 }
 
-func (q *TransactionRecordQuery) shouldRetry(_ Executable, response interface{}) _ExecutionState {
+func (q *TransactionRecordQuery) shouldRetry(_ Executable, response any) _ExecutionState {
 	status := Status(response.(*services.Response).GetTransactionGetRecord().GetHeader().GetNodeTransactionPrecheckCode())
 
 	switch status {

--- a/sdk/transaction_response.go
+++ b/sdk/transaction_response.go
@@ -28,7 +28,7 @@ type TransactionResponse struct {
 // This should yield the same result in all SDK's.
 func (response TransactionResponse) MarshalJSON() ([]byte, error) {
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 	obj["nodeID"] = response.NodeID.String()
 	obj["hash"] = hex.EncodeToString(response.Hash)
 	obj["transactionID"] = response.TransactionID.String()


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
