### PR TITLE
fix: resolve gosec security warnings (G122, G402, G118)

### DIFF
--- a/scripts/generators/proto/generator.go
+++ b/scripts/generators/proto/generator.go
@@ -207,7 +207,9 @@ func removeFilesWithExtension(rootDir, module, ext string) {
 		}
 
 		if strings.HasSuffix(filename, ext) {
-			if err := os.Remove(filename); err != nil {
+			// G122: This is a build-time code generator script, not production code.
+			// The TOCTOU risk from symlink traversal is acceptable in this context.
+			if err := os.Remove(filename); err != nil { //nolint:gosec
 				return err
 			}
 		}

--- a/sdk/node.go
+++ b/sdk/node.go
@@ -170,6 +170,46 @@ func (node *_Node) _GetChannel(logger Logger) (*_Channel, error) {
 					Detail: "",
 				}
 			},
+			// VerifyConnection is called after VerifyPeerCertificate and also during
+			// session resumption when VerifyPeerCertificate may be skipped (gosec G402)
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				if node.addressBook == nil {
+					return nil
+				}
+
+				if !node.verifyCertificate {
+					return nil
+				}
+
+				for _, cert := range cs.PeerCertificates {
+					var certHash []byte
+
+					block := &pem.Block{
+						Type:  "CERTIFICATE",
+						Bytes: cert.Raw,
+					}
+
+					var encodedBuf bytes.Buffer
+					_ = pem.Encode(&encodedBuf, block)
+					digest := sha512.New384()
+
+					if _, err = digest.Write(encodedBuf.Bytes()); err != nil {
+						return err
+					}
+
+					certHash = digest.Sum(nil)
+
+					if string(node.addressBook.CertHash) == hex.EncodeToString(certHash) {
+						return nil
+					}
+				}
+
+				return x509.CertificateInvalidError{
+					Cert:   nil,
+					Reason: x509.Expired,
+					Detail: "",
+				}
+			},
 		}))
 	}
 

--- a/sdk/topic_message_query.go
+++ b/sdk/topic_message_query.go
@@ -184,7 +184,7 @@ func (query *TopicMessageQuery) Subscribe(client *Client, onNext func(TopicMessa
 		return handle, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is stored in handle.onUnsubscribe and called on unsubscribe
 	handle.onUnsubscribe = cancel
 
 	stream, err := channel.SubscribeTopic(ctx, pbBody)


### PR DESCRIPTION
**Description**:
fix: resolve gosec security warnings (G122, G402, G118)
- generator.go: Add nolint for filepath.Walk TOCTOU in build-time script
- node.go: Add VerifyConnection callback for TLS session resumption
- topic_message_query.go: Add nolint for false positive (cancel stored in handle)

**Related issue(s)**:

Fixes #1637

**Notes for reviewer**:
See failed CI run: https://github.com/hiero-ledger/hiero-sdk-go/actions/runs/22788528189

The `VerifyConnection` callback in `node.go` mirrors the existing `VerifyPeerCertificate` logic to ensure certificate validation also runs during TLS session resumption (when `VerifyPeerCertificate` may be skipped).

**Checklist**

- [x] Documented (Code comments, README, etc.) - primarily CI fixes
- [x] Tested (unit, integration, etc.)
