### PR TITLE
HIP-1137: Block Node discoverability via on-chain registry

### DIFF
--- a/examples/registered_node/main.go
+++ b/examples/registered_node/main.go
@@ -22,20 +22,55 @@ import (
 // Environment:
 //
 //	HEDERA_NETWORK          — e.g. "previewnet", "testnet", or "mainnet"
-//	OPERATOR_ID             — e.g. "0.0.2"
-//	OPERATOR_KEY            — DER-encoded private key
+//	GENESIS_OPERATOR_ID     — optional override (defaults to "0.0.2")
+//	GENESIS_OPERATOR_KEY    — optional override (defaults to the genesis Ed25519 key)
 //	CONSENSUS_NODE_ID       — numeric consensus node ID to associate (optional; step 5 is skipped if unset)
 //	CONSENSUS_NODE_ADMIN_KEY — DER-encoded admin key for that consensus node (optional; required if CONSENSUS_NODE_ID is set)
 func main() {
+	client := setupClient()
+
+	// Step 1 — generate the registered node admin key.
+	adminKey, err := hiero.PrivateKeyGenerateEd25519()
+	if err != nil {
+		panic(fmt.Sprintf("%v : error generating admin key", err))
+	}
+	fmt.Printf("Generated registered-node admin key: %s\n", adminKey.PublicKey().String())
+
+	// Steps 2-4 — create a new registered node.
+	registeredNodeId := createRegisteredNode(client, adminKey)
+	fmt.Printf("Created registered node with id: %d\n", registeredNodeId)
+
+	// Wait for the mirror node to ingest the new entry.
+	time.Sleep(time.Second * 5)
+
+	// Step 5 — query the address book and confirm the new node is present.
+	verifyInAddressBook(client, registeredNodeId)
+
+	// Steps 6-7 — update the registered node with a new description and both endpoints.
+	updateRegisteredNode(client, adminKey, registeredNodeId)
+
+	// Step 8 — associate with an existing consensus node (optional).
+	associateWithConsensusNode(client, registeredNodeId)
+
+	// Step 9 — delete the registered node.
+	deleteRegisteredNode(client, adminKey, registeredNodeId)
+
+	if err := client.Close(); err != nil {
+		panic(fmt.Sprintf("%v : error closing client", err))
+	}
+}
+
+// setupClient builds a Hiero client from HEDERA_NETWORK and configures the
+// operator. The operator defaults to account 0.0.2 + genesis Ed25519 key (the
+// standard local hedera-services bootstrap, also what the HIP-1137 e2e tests
+// use); override via GENESIS_OPERATOR_ID / GENESIS_OPERATOR_KEY if your
+// network has a different system account.
+func setupClient() *hiero.Client {
 	client, err := hiero.ClientForName(os.Getenv("HEDERA_NETWORK"))
 	if err != nil {
 		panic(fmt.Sprintf("%v : error creating client", err))
 	}
 
-	// Operator: defaults to account 0.0.2 + genesis Ed25519 key (the standard
-	// local hedera-services bootstrap, also what the HIP-1137 e2e tests use).
-	// Override either via GENESIS_OPERATOR_ID / GENESIS_OPERATOR_KEY if your
-	// network has a different system account.
 	operatorIDStr := os.Getenv("GENESIS_OPERATOR_ID")
 	if operatorIDStr == "" {
 		operatorIDStr = "0.0.2"
@@ -55,15 +90,12 @@ func main() {
 	}
 
 	client.SetOperator(operatorAccountID, operatorKey)
+	return client
+}
 
-	// Step 1 — generate the registered node admin key.
-	adminKey, err := hiero.PrivateKeyGenerateEd25519()
-	if err != nil {
-		panic(fmt.Sprintf("%v : error generating admin key", err))
-	}
-	fmt.Printf("Generated registered-node admin key: %s\n", adminKey.PublicKey().String())
-
-	// Step 2 — build the initial block node service endpoint (IP + TLS + two APIs).
+// createRegisteredNode submits a RegisteredNodeCreateTransaction with a single
+// block-node endpoint and returns the assigned registeredNodeId.
+func createRegisteredNode(client *hiero.Client, adminKey hiero.PrivateKey) uint64 {
 	primaryEndpoint := &hiero.BlockNodeServiceEndpoint{}
 	primaryEndpoint.
 		SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).
@@ -74,7 +106,6 @@ func main() {
 			hiero.BlockNodeApiStatus,
 		})
 
-	// Step 3 — submit the create transaction.
 	createTx, err := hiero.NewRegisteredNodeCreateTransaction().
 		SetAdminKey(adminKey).
 		SetDescription("My Block Node").
@@ -94,17 +125,15 @@ func main() {
 		panic(fmt.Sprintf("%v : error fetching create receipt", err))
 	}
 
-	// Step 4 — verify the assigned registeredNodeId.
 	if createReceipt.RegisteredNodeId == nil || *createReceipt.RegisteredNodeId == 0 {
 		panic("expected a non-zero registeredNodeId on the receipt")
 	}
-	registeredNodeId := *createReceipt.RegisteredNodeId
-	fmt.Printf("Created registered node with id: %d\n", registeredNodeId)
+	return *createReceipt.RegisteredNodeId
+}
 
-	// Wait for it
-	time.Sleep(time.Second * 5)
-
-	// Step 5 — query the address book and confirm the new node is present.
+// verifyInAddressBook queries the mirror node and panics if the given
+// registered node id is missing.
+func verifyInAddressBook(client *hiero.Client, registeredNodeId uint64) {
 	book, err := hiero.NewRegisteredNodeAddressBookQuery().
 		SetRegisteredNodeId(registeredNodeId).
 		Execute(client)
@@ -112,20 +141,29 @@ func main() {
 		panic(fmt.Sprintf("%v : error executing address book query", err))
 	}
 
-	found := false
 	for _, n := range book.RegisteredNodes {
 		if n.RegisteredNodeID == registeredNodeId {
-			found = true
 			fmt.Printf("Address book returned registered node: id=%d description=%q\n",
 				n.RegisteredNodeID, n.Description)
-			break
+			return
 		}
 	}
-	if !found {
-		panic("registered node was not found in the address book")
-	}
+	panic("registered node was not found in the address book")
+}
 
-	// Step 6 — build the second endpoint (domain name, TLS, STATUS only).
+// updateRegisteredNode submits a RegisteredNodeUpdateTransaction with a new
+// description and adds a second (domain-name) endpoint alongside the original.
+func updateRegisteredNode(client *hiero.Client, adminKey hiero.PrivateKey, registeredNodeId uint64) {
+	primaryEndpoint := &hiero.BlockNodeServiceEndpoint{}
+	primaryEndpoint.
+		SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).
+		SetPort(50211).
+		SetRequiresTls(true).
+		SetEndpointApis([]hiero.BlockNodeApi{
+			hiero.BlockNodeApiSubscribeStream,
+			hiero.BlockNodeApiStatus,
+		})
+
 	secondaryEndpoint := &hiero.BlockNodeServiceEndpoint{}
 	secondaryEndpoint.
 		SetDomainName("block.example.com").
@@ -133,7 +171,6 @@ func main() {
 		SetRequiresTls(true).
 		SetEndpointApis([]hiero.BlockNodeApi{hiero.BlockNodeApiStatus})
 
-	// Step 7 — update the registered node with a new description and both endpoints.
 	updateTx, err := hiero.NewRegisteredNodeUpdateTransaction().
 		SetRegisteredNodeId(registeredNodeId).
 		SetDescription("My Updated Block Node").
@@ -153,43 +190,52 @@ func main() {
 		panic(fmt.Sprintf("%v : error fetching update receipt", err))
 	}
 	fmt.Printf("Update receipt status: %s\n", updateReceipt.Status)
+}
 
-	// Step 8 — associate with an existing consensus node (optional).
-	if consensusNodeIDStr := os.Getenv("CONSENSUS_NODE_ID"); consensusNodeIDStr != "" {
-		var consensusNodeID uint64
-		if _, err := fmt.Sscanf(consensusNodeIDStr, "%d", &consensusNodeID); err != nil {
-			panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ID", err))
-		}
-
-		consensusAdminKey, err := hiero.PrivateKeyFromString(os.Getenv("CONSENSUS_NODE_ADMIN_KEY"))
-		if err != nil {
-			panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ADMIN_KEY", err))
-		}
-
-		nodeUpdateTx, err := hiero.NewNodeUpdateTransaction().
-			SetNodeID(consensusNodeID).
-			AddAssociatedRegisteredNode(registeredNodeId).
-			FreezeWith(client)
-		if err != nil {
-			panic(fmt.Sprintf("%v : error freezing node update tx", err))
-		}
-
-		nodeUpdateResp, err := nodeUpdateTx.Sign(consensusAdminKey).Execute(client)
-		if err != nil {
-			panic(fmt.Sprintf("%v : error executing node update tx", err))
-		}
-
-		nodeUpdateReceipt, err := nodeUpdateResp.SetValidateStatus(true).GetReceipt(client)
-		if err != nil {
-			panic(fmt.Sprintf("%v : error fetching node update receipt", err))
-		}
-		fmt.Printf("Consensus node %d updated with associated registered node %d: %s\n",
-			consensusNodeID, registeredNodeId, nodeUpdateReceipt.Status)
-	} else {
+// associateWithConsensusNode runs step 8 of the lifecycle. Skipped when
+// CONSENSUS_NODE_ID is unset, since most operators don't hold a consensus
+// node's admin key.
+func associateWithConsensusNode(client *hiero.Client, registeredNodeId uint64) {
+	consensusNodeIDStr := os.Getenv("CONSENSUS_NODE_ID")
+	if consensusNodeIDStr == "" {
 		fmt.Println("CONSENSUS_NODE_ID not set — skipping consensus-node association step")
+		return
 	}
 
-	// Step 9 — delete the registered node.
+	var consensusNodeID uint64
+	if _, err := fmt.Sscanf(consensusNodeIDStr, "%d", &consensusNodeID); err != nil {
+		panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ID", err))
+	}
+
+	consensusAdminKey, err := hiero.PrivateKeyFromString(os.Getenv("CONSENSUS_NODE_ADMIN_KEY"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ADMIN_KEY", err))
+	}
+
+	nodeUpdateTx, err := hiero.NewNodeUpdateTransaction().
+		SetNodeID(consensusNodeID).
+		AddAssociatedRegisteredNode(registeredNodeId).
+		FreezeWith(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error freezing node update tx", err))
+	}
+
+	nodeUpdateResp, err := nodeUpdateTx.Sign(consensusAdminKey).Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing node update tx", err))
+	}
+
+	nodeUpdateReceipt, err := nodeUpdateResp.SetValidateStatus(true).GetReceipt(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error fetching node update receipt", err))
+	}
+	fmt.Printf("Consensus node %d updated with associated registered node %d: %s\n",
+		consensusNodeID, registeredNodeId, nodeUpdateReceipt.Status)
+}
+
+// deleteRegisteredNode submits a RegisteredNodeDeleteTransaction and waits for
+// the receipt.
+func deleteRegisteredNode(client *hiero.Client, adminKey hiero.PrivateKey, registeredNodeId uint64) {
 	deleteTx, err := hiero.NewRegisteredNodeDeleteTransaction().
 		SetRegisteredNodeId(registeredNodeId).
 		FreezeWith(client)
@@ -207,8 +253,4 @@ func main() {
 		panic(fmt.Sprintf("%v : error fetching delete receipt", err))
 	}
 	fmt.Printf("Delete receipt status: %s\n", deleteReceipt.Status)
-
-	if err := client.Close(); err != nil {
-		panic(fmt.Sprintf("%v : error closing client", err))
-	}
 }

--- a/examples/registered_node/main.go
+++ b/examples/registered_node/main.go
@@ -83,10 +83,10 @@ func main() {
 	}
 
 	// Step 4 — verify the assigned registeredNodeId.
-	registeredNodeId := createReceipt.RegisteredNodeId
-	if registeredNodeId == 0 {
-		panic("expected a non-zero registeredNodeId in the receipt")
+	if createReceipt.RegisteredNodeId == nil || *createReceipt.RegisteredNodeId == 0 {
+		panic("expected a non-zero registeredNodeId on the receipt")
 	}
+	registeredNodeId := *createReceipt.RegisteredNodeId
 	fmt.Printf("Created registered node with id: %d\n", registeredNodeId)
 
 	// Wait for it

--- a/examples/registered_node/main.go
+++ b/examples/registered_node/main.go
@@ -32,14 +32,26 @@ func main() {
 		panic(fmt.Sprintf("%v : error creating client", err))
 	}
 
-	operatorAccountID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+	// Operator: defaults to account 0.0.2 + genesis Ed25519 key (the standard
+	// local hedera-services bootstrap, also what the HIP-1137 e2e tests use).
+	// Override either via GENESIS_OPERATOR_ID / GENESIS_OPERATOR_KEY if your
+	// network has a different system account.
+	operatorIDStr := os.Getenv("GENESIS_OPERATOR_ID")
+	if operatorIDStr == "" {
+		operatorIDStr = "0.0.2"
+	}
+	operatorAccountID, err := hiero.AccountIDFromString(operatorIDStr)
 	if err != nil {
-		panic(fmt.Sprintf("%v : error parsing OPERATOR_ID", err))
+		panic(fmt.Sprintf("%v : error parsing operator ID", err))
 	}
 
-	operatorKey, err := hiero.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+	operatorKeyStr := os.Getenv("GENESIS_OPERATOR_KEY")
+	if operatorKeyStr == "" {
+		operatorKeyStr = "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"
+	}
+	operatorKey, err := hiero.PrivateKeyFromString(operatorKeyStr)
 	if err != nil {
-		panic(fmt.Sprintf("%v : error parsing OPERATOR_KEY", err))
+		panic(fmt.Sprintf("%v : error parsing operator key", err))
 	}
 
 	client.SetOperator(operatorAccountID, operatorKey)

--- a/examples/registered_node/main.go
+++ b/examples/registered_node/main.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+)
+
+// Registered Node Lifecycle
+//
+// Walks through the full lifecycle of a registered node:
+//  1. Generate an admin key.
+//  2. Create a registered node with a block node service endpoint.
+//  3. Query the RegisteredNodeAddressBook to confirm it appears.
+//  4. Update the registered node with a new description and a second endpoint.
+//  5. Associate the registered node with an existing consensus node.
+//  6. Delete the registered node.
+//
+// Environment:
+//
+//	HEDERA_NETWORK          — e.g. "previewnet", "testnet", or "mainnet"
+//	OPERATOR_ID             — e.g. "0.0.2"
+//	OPERATOR_KEY            — DER-encoded private key
+//	CONSENSUS_NODE_ID       — numeric consensus node ID to associate (optional; step 5 is skipped if unset)
+//	CONSENSUS_NODE_ADMIN_KEY — DER-encoded admin key for that consensus node (optional; required if CONSENSUS_NODE_ID is set)
+func main() {
+	client, err := hiero.ClientForName(os.Getenv("HEDERA_NETWORK"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error creating client", err))
+	}
+
+	operatorAccountID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error parsing OPERATOR_ID", err))
+	}
+
+	operatorKey, err := hiero.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error parsing OPERATOR_KEY", err))
+	}
+
+	client.SetOperator(operatorAccountID, operatorKey)
+
+	// Step 1 — generate the registered node admin key.
+	adminKey, err := hiero.PrivateKeyGenerateEd25519()
+	if err != nil {
+		panic(fmt.Sprintf("%v : error generating admin key", err))
+	}
+	fmt.Printf("Generated registered-node admin key: %s\n", adminKey.PublicKey().String())
+
+	// Step 2 — build the initial block node service endpoint (IP + TLS + two APIs).
+	primaryEndpoint := &hiero.BlockNodeServiceEndpoint{}
+	primaryEndpoint.
+		SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).
+		SetPort(50211).
+		SetRequiresTls(true).
+		SetEndpointApis([]hiero.BlockNodeApi{
+			hiero.BlockNodeApiSubscribeStream,
+			hiero.BlockNodeApiStatus,
+		})
+
+	// Step 3 — submit the create transaction.
+	createTx, err := hiero.NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription("My Block Node").
+		SetServiceEndpoints([]hiero.RegisteredServiceEndpoint{primaryEndpoint}).
+		FreezeWith(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error freezing create tx", err))
+	}
+
+	createResp, err := createTx.Sign(adminKey).Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing create tx", err))
+	}
+
+	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error fetching create receipt", err))
+	}
+
+	// Step 4 — verify the assigned registeredNodeId.
+	registeredNodeId := createReceipt.RegisteredNodeId
+	if registeredNodeId == 0 {
+		panic("expected a non-zero registeredNodeId in the receipt")
+	}
+	fmt.Printf("Created registered node with id: %d\n", registeredNodeId)
+
+	// Wait for it
+	time.Sleep(time.Second * 5)
+
+	// Step 5 — query the address book and confirm the new node is present.
+	book, err := hiero.NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing address book query", err))
+	}
+
+	found := false
+	for _, n := range book.RegisteredNodes {
+		if n.RegisteredNodeID == registeredNodeId {
+			found = true
+			fmt.Printf("Address book returned registered node: id=%d description=%q\n",
+				n.RegisteredNodeID, n.Description)
+			break
+		}
+	}
+	if !found {
+		panic("registered node was not found in the address book")
+	}
+
+	// Step 6 — build the second endpoint (domain name, TLS, STATUS only).
+	secondaryEndpoint := &hiero.BlockNodeServiceEndpoint{}
+	secondaryEndpoint.
+		SetDomainName("block.example.com").
+		SetPort(50212).
+		SetRequiresTls(true).
+		SetEndpointApis([]hiero.BlockNodeApi{hiero.BlockNodeApiStatus})
+
+	// Step 7 — update the registered node with a new description and both endpoints.
+	updateTx, err := hiero.NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetDescription("My Updated Block Node").
+		SetServiceEndpoints([]hiero.RegisteredServiceEndpoint{primaryEndpoint, secondaryEndpoint}).
+		FreezeWith(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error freezing update tx", err))
+	}
+
+	updateResp, err := updateTx.Sign(adminKey).Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing update tx", err))
+	}
+
+	updateReceipt, err := updateResp.SetValidateStatus(true).GetReceipt(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error fetching update receipt", err))
+	}
+	fmt.Printf("Update receipt status: %s\n", updateReceipt.Status)
+
+	// Step 8 — associate with an existing consensus node (optional).
+	if consensusNodeIDStr := os.Getenv("CONSENSUS_NODE_ID"); consensusNodeIDStr != "" {
+		var consensusNodeID uint64
+		if _, err := fmt.Sscanf(consensusNodeIDStr, "%d", &consensusNodeID); err != nil {
+			panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ID", err))
+		}
+
+		consensusAdminKey, err := hiero.PrivateKeyFromString(os.Getenv("CONSENSUS_NODE_ADMIN_KEY"))
+		if err != nil {
+			panic(fmt.Sprintf("%v : error parsing CONSENSUS_NODE_ADMIN_KEY", err))
+		}
+
+		nodeUpdateTx, err := hiero.NewNodeUpdateTransaction().
+			SetNodeID(consensusNodeID).
+			AddAssociatedRegisteredNode(registeredNodeId).
+			FreezeWith(client)
+		if err != nil {
+			panic(fmt.Sprintf("%v : error freezing node update tx", err))
+		}
+
+		nodeUpdateResp, err := nodeUpdateTx.Sign(consensusAdminKey).Execute(client)
+		if err != nil {
+			panic(fmt.Sprintf("%v : error executing node update tx", err))
+		}
+
+		nodeUpdateReceipt, err := nodeUpdateResp.SetValidateStatus(true).GetReceipt(client)
+		if err != nil {
+			panic(fmt.Sprintf("%v : error fetching node update receipt", err))
+		}
+		fmt.Printf("Consensus node %d updated with associated registered node %d: %s\n",
+			consensusNodeID, registeredNodeId, nodeUpdateReceipt.Status)
+	} else {
+		fmt.Println("CONSENSUS_NODE_ID not set — skipping consensus-node association step")
+	}
+
+	// Step 9 — delete the registered node.
+	deleteTx, err := hiero.NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		FreezeWith(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error freezing delete tx", err))
+	}
+
+	deleteResp, err := deleteTx.Sign(adminKey).Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing delete tx", err))
+	}
+
+	deleteReceipt, err := deleteResp.SetValidateStatus(true).GetReceipt(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error fetching delete receipt", err))
+	}
+	fmt.Printf("Delete receipt status: %s\n", deleteReceipt.Status)
+
+	if err := client.Close(); err != nil {
+		panic(fmt.Sprintf("%v : error closing client", err))
+	}
+}

--- a/proto/services/transaction_receipt.pb.go
+++ b/proto/services/transaction_receipt.pb.go
@@ -21,6 +21,7 @@ package services
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -189,8 +190,16 @@ type TransactionReceipt struct {
 	// This value SHALL NOT be set following any other transaction.<br/>
 	// This value SHALL be unique within a given network.
 	RegisteredNodeId uint64 `protobuf:"varint,16,opt,name=registered_node_id,json=registeredNodeId,proto3" json:"registered_node_id,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// *
+	// The block number containing this transaction.
+	// <p>
+	// This value SHALL be unset or default if consensus has not been reached
+	// or the block assignment is not yet known.<br/>
+	// Once known, this value SHALL identify the block containing the
+	// transaction represented by this receipt.
+	BlockNumber   *wrapperspb.UInt64Value `protobuf:"bytes,17,opt,name=block_number,json=blockNumber,proto3" json:"block_number,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TransactionReceipt) Reset() {
@@ -335,11 +344,18 @@ func (x *TransactionReceipt) GetRegisteredNodeId() uint64 {
 	return 0
 }
 
+func (x *TransactionReceipt) GetBlockNumber() *wrapperspb.UInt64Value {
+	if x != nil {
+		return x.BlockNumber
+	}
+	return nil
+}
+
 var File_transaction_receipt_proto protoreflect.FileDescriptor
 
 const file_transaction_receipt_proto_rawDesc = "" +
 	"\n" +
-	"\x19transaction_receipt.proto\x12\x05proto\x1a\x11basic_types.proto\x1a\x13response_code.proto\x1a\x13exchange_rate.proto\"\x8d\x06\n" +
+	"\x19transaction_receipt.proto\x12\x05proto\x1a\x11basic_types.proto\x1a\x13response_code.proto\x1a\x13exchange_rate.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xce\x06\n" +
 	"\x12TransactionReceipt\x12/\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x17.proto.ResponseCodeEnumR\x06status\x12.\n" +
 	"\taccountID\x18\x02 \x01(\v2\x10.proto.AccountIDR\taccountID\x12%\n" +
@@ -361,7 +377,8 @@ const file_transaction_receipt_proto_rawDesc = "" +
 	"\x16scheduledTransactionID\x18\r \x01(\v2\x14.proto.TransactionIDR\x16scheduledTransactionID\x12$\n" +
 	"\rserialNumbers\x18\x0e \x03(\x03R\rserialNumbers\x12\x17\n" +
 	"\anode_id\x18\x0f \x01(\x04R\x06nodeId\x12,\n" +
-	"\x12registered_node_id\x18\x10 \x01(\x04R\x10registeredNodeIdB&\n" +
+	"\x12registered_node_id\x18\x10 \x01(\x04R\x10registeredNodeId\x12?\n" +
+	"\fblock_number\x18\x11 \x01(\v2\x1c.google.protobuf.UInt64ValueR\vblockNumberB&\n" +
 	"\"com.hederahashgraph.api.proto.javaP\x01b\x06proto3"
 
 var (
@@ -378,32 +395,34 @@ func file_transaction_receipt_proto_rawDescGZIP() []byte {
 
 var file_transaction_receipt_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_transaction_receipt_proto_goTypes = []any{
-	(*TransactionReceipt)(nil), // 0: proto.TransactionReceipt
-	(ResponseCodeEnum)(0),      // 1: proto.ResponseCodeEnum
-	(*AccountID)(nil),          // 2: proto.AccountID
-	(*FileID)(nil),             // 3: proto.FileID
-	(*ContractID)(nil),         // 4: proto.ContractID
-	(*ExchangeRateSet)(nil),    // 5: proto.ExchangeRateSet
-	(*TopicID)(nil),            // 6: proto.TopicID
-	(*TokenID)(nil),            // 7: proto.TokenID
-	(*ScheduleID)(nil),         // 8: proto.ScheduleID
-	(*TransactionID)(nil),      // 9: proto.TransactionID
+	(*TransactionReceipt)(nil),     // 0: proto.TransactionReceipt
+	(ResponseCodeEnum)(0),          // 1: proto.ResponseCodeEnum
+	(*AccountID)(nil),              // 2: proto.AccountID
+	(*FileID)(nil),                 // 3: proto.FileID
+	(*ContractID)(nil),             // 4: proto.ContractID
+	(*ExchangeRateSet)(nil),        // 5: proto.ExchangeRateSet
+	(*TopicID)(nil),                // 6: proto.TopicID
+	(*TokenID)(nil),                // 7: proto.TokenID
+	(*ScheduleID)(nil),             // 8: proto.ScheduleID
+	(*TransactionID)(nil),          // 9: proto.TransactionID
+	(*wrapperspb.UInt64Value)(nil), // 10: google.protobuf.UInt64Value
 }
 var file_transaction_receipt_proto_depIdxs = []int32{
-	1, // 0: proto.TransactionReceipt.status:type_name -> proto.ResponseCodeEnum
-	2, // 1: proto.TransactionReceipt.accountID:type_name -> proto.AccountID
-	3, // 2: proto.TransactionReceipt.fileID:type_name -> proto.FileID
-	4, // 3: proto.TransactionReceipt.contractID:type_name -> proto.ContractID
-	5, // 4: proto.TransactionReceipt.exchangeRate:type_name -> proto.ExchangeRateSet
-	6, // 5: proto.TransactionReceipt.topicID:type_name -> proto.TopicID
-	7, // 6: proto.TransactionReceipt.tokenID:type_name -> proto.TokenID
-	8, // 7: proto.TransactionReceipt.scheduleID:type_name -> proto.ScheduleID
-	9, // 8: proto.TransactionReceipt.scheduledTransactionID:type_name -> proto.TransactionID
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	1,  // 0: proto.TransactionReceipt.status:type_name -> proto.ResponseCodeEnum
+	2,  // 1: proto.TransactionReceipt.accountID:type_name -> proto.AccountID
+	3,  // 2: proto.TransactionReceipt.fileID:type_name -> proto.FileID
+	4,  // 3: proto.TransactionReceipt.contractID:type_name -> proto.ContractID
+	5,  // 4: proto.TransactionReceipt.exchangeRate:type_name -> proto.ExchangeRateSet
+	6,  // 5: proto.TransactionReceipt.topicID:type_name -> proto.TopicID
+	7,  // 6: proto.TransactionReceipt.tokenID:type_name -> proto.TokenID
+	8,  // 7: proto.TransactionReceipt.scheduleID:type_name -> proto.ScheduleID
+	9,  // 8: proto.TransactionReceipt.scheduledTransactionID:type_name -> proto.TransactionID
+	10, // 9: proto.TransactionReceipt.block_number:type_name -> google.protobuf.UInt64Value
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_transaction_receipt_proto_init() }

--- a/sdk/block_node_api.go
+++ b/sdk/block_node_api.go
@@ -33,5 +33,5 @@ func (api BlockNodeApi) String() string {
 		return "STATE_PROOF"
 	}
 
-	return "UNKNOWN"
+	return unknownString
 }

--- a/sdk/block_node_api.go
+++ b/sdk/block_node_api.go
@@ -1,0 +1,37 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+// BlockNodeApi is an enumeration of well-known block node endpoint APIs.
+type BlockNodeApi int32
+
+const (
+	// BlockNodeApiOther represents an unknown or custom block node API type.
+	BlockNodeApiOther BlockNodeApi = 0
+	// BlockNodeApiStatus represents the Block Node Status API.
+	BlockNodeApiStatus BlockNodeApi = 1
+	// BlockNodeApiPublish represents the Block Node Publish API.
+	BlockNodeApiPublish BlockNodeApi = 2
+	// BlockNodeApiSubscribeStream represents the Block Node Subscribe Stream API.
+	BlockNodeApiSubscribeStream BlockNodeApi = 3
+	// BlockNodeApiStateProof represents the Block Node State Proof API.
+	BlockNodeApiStateProof BlockNodeApi = 4
+)
+
+// String returns the string representation of the BlockNodeApi.
+func (api BlockNodeApi) String() string {
+	switch api {
+	case BlockNodeApiOther:
+		return "OTHER"
+	case BlockNodeApiStatus:
+		return "STATUS"
+	case BlockNodeApiPublish:
+		return "PUBLISH"
+	case BlockNodeApiSubscribeStream:
+		return "SUBSCRIBE_STREAM"
+	case BlockNodeApiStateProof:
+		return "STATE_PROOF"
+	}
+
+	return "UNKNOWN"
+}

--- a/sdk/block_node_api.go
+++ b/sdk/block_node_api.go
@@ -2,6 +2,11 @@ package hiero
 
 // SPDX-License-Identifier: Apache-2.0
 
+import (
+	"fmt"
+	"strings"
+)
+
 // BlockNodeApi is an enumeration of well-known block node endpoint APIs.
 type BlockNodeApi int32
 
@@ -34,4 +39,23 @@ func (api BlockNodeApi) String() string {
 	}
 
 	return unknownString
+}
+
+// blockNodeApiFromString parses a BlockNodeApi enum name. Returns an error
+// for anything outside the known set, including "UNKNOWN".
+func blockNodeApiFromString(s string) (BlockNodeApi, error) {
+	switch strings.ToUpper(s) {
+	case "OTHER":
+		return BlockNodeApiOther, nil
+	case "STATUS":
+		return BlockNodeApiStatus, nil
+	case "PUBLISH":
+		return BlockNodeApiPublish, nil
+	case "SUBSCRIBE_STREAM":
+		return BlockNodeApiSubscribeStream, nil
+	case "STATE_PROOF":
+		return BlockNodeApiStateProof, nil
+	default:
+		return BlockNodeApiOther, fmt.Errorf("unknown block node API: %q", s)
+	}
 }

--- a/sdk/block_node_service_endpoint.go
+++ b/sdk/block_node_service_endpoint.go
@@ -14,6 +14,30 @@ type BlockNodeServiceEndpoint struct {
 	endpointApi BlockNodeApi
 }
 
+// SetIPAddress sets the IP address for this endpoint.
+func (e *BlockNodeServiceEndpoint) SetIPAddress(ip []byte) *BlockNodeServiceEndpoint {
+	e.registeredEndpointBase.SetIPAddress(ip)
+	return e
+}
+
+// SetDomainName sets the domain name for this endpoint.
+func (e *BlockNodeServiceEndpoint) SetDomainName(name string) *BlockNodeServiceEndpoint {
+	e.registeredEndpointBase.SetDomainName(name)
+	return e
+}
+
+// SetPort sets the port number for this endpoint.
+func (e *BlockNodeServiceEndpoint) SetPort(port uint32) *BlockNodeServiceEndpoint {
+	e.registeredEndpointBase.SetPort(port)
+	return e
+}
+
+// SetRequiresTls sets whether this endpoint requires TLS.
+func (e *BlockNodeServiceEndpoint) SetRequiresTls(tls bool) *BlockNodeServiceEndpoint {
+	e.registeredEndpointBase.SetRequiresTls(tls)
+	return e
+}
+
 // SetEndpointApi sets the block node API kind for this endpoint.
 func (e *BlockNodeServiceEndpoint) SetEndpointApi(api BlockNodeApi) *BlockNodeServiceEndpoint {
 	e.endpointApi = api

--- a/sdk/block_node_service_endpoint.go
+++ b/sdk/block_node_service_endpoint.go
@@ -1,0 +1,54 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// BlockNodeServiceEndpoint a registered service endpoint for a block node.
+// Extends the base registered endpoint with the specific block node API
+// that the endpoint exposes.
+type BlockNodeServiceEndpoint struct {
+	registeredEndpointBase
+	endpointApi BlockNodeApi
+}
+
+// SetEndpointApi sets the block node API kind for this endpoint.
+func (e *BlockNodeServiceEndpoint) SetEndpointApi(api BlockNodeApi) *BlockNodeServiceEndpoint {
+	e.endpointApi = api
+	return e
+}
+
+// GetEndpointApi returns the block node API kind for this endpoint.
+func (e *BlockNodeServiceEndpoint) GetEndpointApi() BlockNodeApi {
+	return e.endpointApi
+}
+
+// _ToProtobuf converts this BlockNodeServiceEndpoint to its protobuf representation.
+func (e *BlockNodeServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
+	pb := &services.RegisteredServiceEndpoint{
+		Port:        e.port,
+		RequiresTls: e.requiresTls,
+		EndpointType: &services.RegisteredServiceEndpoint_BlockNode{
+			BlockNode: &services.RegisteredServiceEndpoint_BlockNodeEndpoint{
+				EndpointApi: services.RegisteredServiceEndpoint_BlockNodeEndpoint_BlockNodeApi(e.endpointApi),
+			},
+		},
+	}
+	e.addressToProtobuf(pb)
+	return pb
+}
+
+// _BlockNodeServiceEndpointFromProtobuf converts a protobuf RegisteredServiceEndpoint to a BlockNodeServiceEndpoint.
+func _BlockNodeServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoint) *BlockNodeServiceEndpoint {
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: baseFromProtobuf(pb),
+	}
+
+	if bn, ok := pb.EndpointType.(*services.RegisteredServiceEndpoint_BlockNode); ok && bn.BlockNode != nil {
+		endpoint.endpointApi = BlockNodeApi(bn.BlockNode.GetEndpointApi())
+	}
+
+	return endpoint
+}

--- a/sdk/block_node_service_endpoint.go
+++ b/sdk/block_node_service_endpoint.go
@@ -11,7 +11,7 @@ import (
 // that the endpoint exposes.
 type BlockNodeServiceEndpoint struct {
 	registeredEndpointBase
-	endpointApi BlockNodeApi
+	endpointApis []BlockNodeApi
 }
 
 // SetIPAddress sets the IP address for this endpoint.
@@ -38,25 +38,36 @@ func (e *BlockNodeServiceEndpoint) SetRequiresTls(tls bool) *BlockNodeServiceEnd
 	return e
 }
 
-// SetEndpointApi sets the block node API kind for this endpoint.
-func (e *BlockNodeServiceEndpoint) SetEndpointApi(api BlockNodeApi) *BlockNodeServiceEndpoint {
-	e.endpointApi = api
+// SetEndpointApis sets the block node API kinds for this endpoint.
+func (e *BlockNodeServiceEndpoint) SetEndpointApis(apis []BlockNodeApi) *BlockNodeServiceEndpoint {
+	e.endpointApis = apis
+	return e
+}
+
+// AddEndpointApi adds a block node API kind to this endpoint.
+func (e *BlockNodeServiceEndpoint) AddEndpointApi(api BlockNodeApi) *BlockNodeServiceEndpoint {
+	e.endpointApis = append(e.endpointApis,api)
 	return e
 }
 
 // GetEndpointApi returns the block node API kind for this endpoint.
-func (e *BlockNodeServiceEndpoint) GetEndpointApi() BlockNodeApi {
-	return e.endpointApi
+func (e *BlockNodeServiceEndpoint) GetEndpointApis() []BlockNodeApi {
+	return e.endpointApis
 }
 
 // _ToProtobuf converts this BlockNodeServiceEndpoint to its protobuf representation.
 func (e *BlockNodeServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
+	apis := make([]services.RegisteredServiceEndpoint_BlockNodeEndpoint_BlockNodeApi, len(e.endpointApis))
+	for i, api := range e.endpointApis {
+		apis[i] = services.RegisteredServiceEndpoint_BlockNodeEndpoint_BlockNodeApi(api)
+	}
+
 	pb := &services.RegisteredServiceEndpoint{
 		Port:        e.port,
 		RequiresTls: e.requiresTls,
 		EndpointType: &services.RegisteredServiceEndpoint_BlockNode{
 			BlockNode: &services.RegisteredServiceEndpoint_BlockNodeEndpoint{
-				EndpointApi: services.RegisteredServiceEndpoint_BlockNodeEndpoint_BlockNodeApi(e.endpointApi),
+				EndpointApi: apis,
 			},
 		},
 	}
@@ -71,7 +82,11 @@ func _BlockNodeServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoin
 	}
 
 	if bn, ok := pb.EndpointType.(*services.RegisteredServiceEndpoint_BlockNode); ok && bn.BlockNode != nil {
-		endpoint.endpointApi = BlockNodeApi(bn.BlockNode.GetEndpointApi())
+		pbApis := bn.BlockNode.GetEndpointApi()
+		endpoint.endpointApis = make([]BlockNodeApi, len(pbApis))
+		for i, api := range pbApis {
+			endpoint.endpointApis[i] = BlockNodeApi(api)
+		}
 	}
 
 	return endpoint

--- a/sdk/constants.go
+++ b/sdk/constants.go
@@ -1,0 +1,5 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+const unknownString = "UNKNOWN"

--- a/sdk/fee_estimate_types.go
+++ b/sdk/fee_estimate_types.go
@@ -20,7 +20,7 @@ func (m FeeEstimateMode) String() string {
 	case FeeEstimateModeState:
 		return "STATE"
 	default:
-		return "UNKNOWN"
+		return unknownString
 	}
 }
 

--- a/sdk/general_service_endpoint.go
+++ b/sdk/general_service_endpoint.go
@@ -1,0 +1,76 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// GeneralServiceEndpoint a registered service endpoint for a general-purpose service.
+type GeneralServiceEndpoint struct {
+	registeredEndpointBase
+	description string
+}
+
+// SetIPAddress sets the IP address for this endpoint.
+func (e *GeneralServiceEndpoint) SetIPAddress(ip []byte) *GeneralServiceEndpoint {
+	e.registeredEndpointBase.SetIPAddress(ip)
+	return e
+}
+
+// SetDomainName sets the domain name for this endpoint.
+func (e *GeneralServiceEndpoint) SetDomainName(name string) *GeneralServiceEndpoint {
+	e.registeredEndpointBase.SetDomainName(name)
+	return e
+}
+
+// SetPort sets the port number for this endpoint.
+func (e *GeneralServiceEndpoint) SetPort(port uint32) *GeneralServiceEndpoint {
+	e.registeredEndpointBase.SetPort(port)
+	return e
+}
+
+// SetRequiresTls sets whether this endpoint requires TLS.
+func (e *GeneralServiceEndpoint) SetRequiresTls(tls bool) *GeneralServiceEndpoint {
+	e.registeredEndpointBase.SetRequiresTls(tls)
+	return e
+}
+
+// SetDescription sets a short description of the service provided by this endpoint.
+func (e *GeneralServiceEndpoint) SetDescription(description string) *GeneralServiceEndpoint {
+	e.description = description
+	return e
+}
+
+// GetDescription returns the short description of the service provided by this endpoint.
+func (e *GeneralServiceEndpoint) GetDescription() string {
+	return e.description
+}
+
+// _ToProtobuf converts this GeneralServiceEndpoint to its protobuf representation.
+func (e *GeneralServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
+	pb := &services.RegisteredServiceEndpoint{
+		Port:        e.port,
+		RequiresTls: e.requiresTls,
+		EndpointType: &services.RegisteredServiceEndpoint_GeneralService{
+			GeneralService: &services.RegisteredServiceEndpoint_GeneralServiceEndpoint{
+				Description: e.description,
+			},
+		},
+	}
+	e.addressToProtobuf(pb)
+	return pb
+}
+
+// _GeneralServiceEndpointFromProtobuf converts a protobuf RegisteredServiceEndpoint to a GeneralServiceEndpoint.
+func _GeneralServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoint) *GeneralServiceEndpoint {
+	endpoint := &GeneralServiceEndpoint{
+		registeredEndpointBase: baseFromProtobuf(pb),
+	}
+
+	if gs, ok := pb.EndpointType.(*services.RegisteredServiceEndpoint_GeneralService); ok && gs.GeneralService != nil {
+		endpoint.description = gs.GeneralService.GetDescription()
+	}
+
+	return endpoint
+}

--- a/sdk/mirror_node_service_endpoint.go
+++ b/sdk/mirror_node_service_endpoint.go
@@ -1,0 +1,32 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// MirrorNodeServiceEndpoint a registered service endpoint for a mirror node.
+type MirrorNodeServiceEndpoint struct {
+	registeredEndpointBase
+}
+
+// _ToProtobuf converts this MirrorNodeServiceEndpoint to its protobuf representation.
+func (e *MirrorNodeServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
+	pb := &services.RegisteredServiceEndpoint{
+		Port:        e.port,
+		RequiresTls: e.requiresTls,
+		EndpointType: &services.RegisteredServiceEndpoint_MirrorNode{
+			MirrorNode: &services.RegisteredServiceEndpoint_MirrorNodeEndpoint{},
+		},
+	}
+	e.addressToProtobuf(pb)
+	return pb
+}
+
+// _MirrorNodeServiceEndpointFromProtobuf converts a protobuf RegisteredServiceEndpoint to a MirrorNodeServiceEndpoint.
+func _MirrorNodeServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoint) *MirrorNodeServiceEndpoint {
+	return &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: baseFromProtobuf(pb),
+	}
+}

--- a/sdk/mirror_node_service_endpoint.go
+++ b/sdk/mirror_node_service_endpoint.go
@@ -11,6 +11,30 @@ type MirrorNodeServiceEndpoint struct {
 	registeredEndpointBase
 }
 
+// SetIPAddress sets the IP address for this endpoint.
+func (e *MirrorNodeServiceEndpoint) SetIPAddress(ip []byte) *MirrorNodeServiceEndpoint {
+	e.registeredEndpointBase.SetIPAddress(ip)
+	return e
+}
+
+// SetDomainName sets the domain name for this endpoint.
+func (e *MirrorNodeServiceEndpoint) SetDomainName(name string) *MirrorNodeServiceEndpoint {
+	e.registeredEndpointBase.SetDomainName(name)
+	return e
+}
+
+// SetPort sets the port number for this endpoint.
+func (e *MirrorNodeServiceEndpoint) SetPort(port uint32) *MirrorNodeServiceEndpoint {
+	e.registeredEndpointBase.SetPort(port)
+	return e
+}
+
+// SetRequiresTls sets whether this endpoint requires TLS.
+func (e *MirrorNodeServiceEndpoint) SetRequiresTls(tls bool) *MirrorNodeServiceEndpoint {
+	e.registeredEndpointBase.SetRequiresTls(tls)
+	return e
+}
+
 // _ToProtobuf converts this MirrorNodeServiceEndpoint to its protobuf representation.
 func (e *MirrorNodeServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
 	pb := &services.RegisteredServiceEndpoint{

--- a/sdk/node_create_transaction.go
+++ b/sdk/node_create_transaction.go
@@ -32,15 +32,16 @@ import (
  */
 type NodeCreateTransaction struct {
 	*Transaction[*NodeCreateTransaction]
-	accountID            *AccountID
-	description          string
-	gossipEndpoints      []Endpoint
-	serviceEndpoints     []Endpoint
-	gossipCaCertificate  []byte
-	grpcCertificateHash  []byte
-	adminKey             Key
-	declineReward        *bool
-	grpcWebProxyEndpoint *Endpoint
+	accountID                 *AccountID
+	description               string
+	gossipEndpoints           []Endpoint
+	serviceEndpoints          []Endpoint
+	gossipCaCertificate       []byte
+	grpcCertificateHash       []byte
+	adminKey                  Key
+	declineReward             *bool
+	grpcWebProxyEndpoint      *Endpoint
+	associatedRegisteredNodes []uint64
 }
 
 func NewNodeCreateTransaction() *NodeCreateTransaction {
@@ -76,15 +77,16 @@ func _NodeCreateTransactionFromProtobuf(tx Transaction[*NodeCreateTransaction], 
 	gossipCaCertificate := pb.GetNodeCreate().GetGossipCaCertificate()
 
 	nodeCreateTransaction := NodeCreateTransaction{
-		accountID:            accountID,
-		description:          pb.GetNodeCreate().GetDescription(),
-		gossipEndpoints:      gossipEndpoints,
-		serviceEndpoints:     serviceEndpoints,
-		gossipCaCertificate:  gossipCaCertificate,
-		grpcCertificateHash:  pb.GetNodeCreate().GetGrpcCertificateHash(),
-		adminKey:             adminKey,
-		declineReward:        &declineReward,
-		grpcWebProxyEndpoint: grpcProxyEndpoint,
+		accountID:                 accountID,
+		description:               pb.GetNodeCreate().GetDescription(),
+		gossipEndpoints:           gossipEndpoints,
+		serviceEndpoints:          serviceEndpoints,
+		gossipCaCertificate:       gossipCaCertificate,
+		grpcCertificateHash:       pb.GetNodeCreate().GetGrpcCertificateHash(),
+		adminKey:                  adminKey,
+		declineReward:             &declineReward,
+		grpcWebProxyEndpoint:      grpcProxyEndpoint,
+		associatedRegisteredNodes: pb.GetNodeCreate().GetAssociatedRegisteredNode(),
 	}
 
 	tx.childTransaction = &nodeCreateTransaction
@@ -220,6 +222,25 @@ func (tx *NodeCreateTransaction) SetGrpcWebProxyEndpoint(grpcWebProxyEndpoint En
 	return tx
 }
 
+// GetAssociatedRegisteredNodes returns the list of associated registered node IDs.
+func (tx *NodeCreateTransaction) GetAssociatedRegisteredNodes() []uint64 {
+	return tx.associatedRegisteredNodes
+}
+
+// SetAssociatedRegisteredNodes sets the list of associated registered node IDs.
+func (tx *NodeCreateTransaction) SetAssociatedRegisteredNodes(ids []uint64) *NodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.associatedRegisteredNodes = ids
+	return tx
+}
+
+// AddAssociatedRegisteredNode adds a registered node ID to the association list.
+func (tx *NodeCreateTransaction) AddAssociatedRegisteredNode(id uint64) *NodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.associatedRegisteredNodes = append(tx.associatedRegisteredNodes, id)
+	return tx
+}
+
 // ----------- Overridden functions ----------------
 
 func (tx NodeCreateTransaction) getName() string {
@@ -293,6 +314,10 @@ func (tx NodeCreateTransaction) buildProtoBody() *services.NodeCreateTransaction
 
 	if tx.declineReward != nil {
 		body.DeclineReward = *tx.declineReward
+	}
+
+	if len(tx.associatedRegisteredNodes) > 0 {
+		body.AssociatedRegisteredNode = tx.associatedRegisteredNodes
 	}
 
 	return body

--- a/sdk/node_create_transaction_e2e_test.go
+++ b/sdk/node_create_transaction_e2e_test.go
@@ -96,8 +96,9 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 	t.Parallel()
 
 	// Set the network
+	nodeAccountID := AccountID{Account: 3}
 	network := make(map[string]AccountID)
-	network["localhost:50211"] = AccountID{Account: 3}
+	network["localhost:50211"] = nodeAccountID
 	client, err := ClientForNetworkV2(network)
 	require.NoError(t, err)
 	mirror := []string{"localhost:5600"}
@@ -130,19 +131,8 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 
 	registeredNodeId := regReceipt.RegisteredNodeId
 
-	// Create an account for the consensus node
-	newKey, err := PrivateKeyGenerateEd25519()
+	accountId, _, err := createAccount(&IntegrationTestEnv{Client: client, NodeAccountIDs: []AccountID{nodeAccountID}})
 	require.NoError(t, err)
-
-	resp, err := NewAccountCreateTransaction().
-		SetKeyWithoutAlias(newKey).
-		SetInitialBalance(NewHbar(1)).
-		Execute(client)
-	require.NoError(t, err)
-
-	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
-	require.NoError(t, err)
-	accountId := *receipt.AccountID
 
 	// DER gossip certificate
 	validGossipCertDER := "3082052830820310a003020102020101300d06092a864886f70d01010c05003010310e300c060355040313056e6f6465333024170d3234313030383134333233395a181332313234313030383134333233392e3337395a3010310e300c060355040313056e6f64653330820222300d06092a864886f70d01010105000382020f003082020a0282020100af111cff0c4ad8125d2f4b8691ce87332fecc867f7a94ddc0f3f96514cc4224d44af516394f7384c1ef0a515d29aa6116b65bc7e4d7e2d848cf79fbfffedae3a6583b3957a438bdd780c4981b800676ea509bc8c619ae04093b5fc642c4484152f0e8bcaabf19eae025b630028d183a2f47caf6d9f1075efb30a4248679d871beef1b7e9115382270cbdb68682fae4b1fd592cadb414d918c0a8c23795c7c5a91e22b3e90c410825a2bc1a840efc5bf9976a7f474c7ed7dc047e4ddd2db631b68bb4475f173baa3edc234c4bed79c83e2f826f79e07d0aade2d984da447a8514135bfa4145274a7f62959a23c4f0fae5adc6855974e7c04164951d052beb5d45cb1f3cdfd005da894dea9151cb62ba43f4731c6bb0c83e10fd842763ba6844ef499f71bc67fa13e4917fb39f2ad18112170d31cdcb3c61c9e3253accf703dbd8427fdcb87ece78b787b6cfdc091e8fedea8ad95dc64074e1fc6d0e42ea2337e18a5e54e4aaab3791a98dfcef282e2ae1caec9cf986fabe8f36e6a21c8711647177e492d264415e765a86c58599cd97b103cb4f6a01d2edd06e3b60470cf64daca7aecf831197b466cae04baeeac19840a05394bef628aed04b611cfa13677724b08ddfd662b02fd0ef0af17eb7f4fb8c1c17fbe9324f6dc7bcc02449622636cc45ec04909b3120ab4df4726b21bf79e955fe8f832699d2196dcd7a58bfeafb170203010001a38186308183300f0603551d130101ff04053003020100300e0603551d0f0101ff0404030204b030200603551d250101ff0416301406082b0601050507030106082b06010505070302301d0603551d0e04160414643118e05209035edd83d44a0c368de2fb2fe4c0301f0603551d23041830168014643118e05209035edd83d44a0c368de2fb2fe4c0300d06092a864886f70d01010c05000382020100ad41c32bb52650eb4b76fce439c9404e84e4538a94916b3dc7983e8b5c58890556e7384601ca7440dde68233bb07b97bf879b64487b447df510897d2a0a4e789c409a9b237a6ad240ad5464f2ce80c58ddc4d07a29a74eb25e1223db6c00e334d7a27d32bfa6183a82f5e35bccf497c2445a526eabb0c068aba9b94cc092ea4756b0dcfb574f6179f0089e52b174ccdbd04123eeb6d70daeabd8513fcba6be0bc2b45ca9a69802dae11cc4d9ff6053b3a87fd8b0c6bf72fffc3b81167f73cca2b3fd656c5d353c8defca8a76e2ad535f984870a590af4e28fed5c5a125bf360747c5e7742e7813d1bd39b5498c8eb6ba72f267eda034314fdbc596f6b967a0ef8be5231d364e634444c84e64bd7919425171016fcd9bb05f01c58a303dee28241f6e860fc3aac3d92aad7dac2801ce79a3b41a0e1f1509fc0d86e96d94edb18616c000152490f64561713102128990fedd3a5fa642f2ff22dc11bc4dc5b209986a0c3e4eb2bdfdd40e9fdf246f702441cac058dd8d0d51eb0796e2bea2ce1b37b2a2f468505e1f8980a9f66d719df034a6fbbd2f9585991d259678fb9a4aebdc465d22c240351ed44abffbdd11b79a706fdf7c40158d3da87f68d7bd557191a8016b5b899c07bf1b87590feb4fa4203feea9a2a7a73ec224813a12b7a21e5dc93fcde4f0a7620f570d31fe27e9b8d65b74db7dc18a5e51adc42d7805d4661938"
@@ -152,22 +142,19 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 	nodeAdminKey, err := PrivateKeyGenerateEd25519()
 	require.NoError(t, err)
 
-	gossipEndpoint := Endpoint{domainName: "gossip.test.com", port: 50111}
-	serviceEndpoint := Endpoint{domainName: "service.test.com", port: 50211}
-
 	// Create consensus node with the associatedRegisteredNode
 	nodeTx, err := NewNodeCreateTransaction().
 		SetAccountID(accountId).
 		SetDescription("node with associated registered node").
-		SetGossipEndpoints([]Endpoint{gossipEndpoint}).
-		SetServiceEndpoints([]Endpoint{serviceEndpoint}).
+		SetGossipEndpoints([]Endpoint{{domainName: "gossip.test.com", port: 50111}}).
+		SetServiceEndpoints([]Endpoint{{domainName: "service.test.com", port: 50211}}).
 		SetGossipCaCertificate(validGossipCert).
 		SetAdminKey(nodeAdminKey).
 		AddAssociatedRegisteredNode(registeredNodeId).
 		FreezeWith(client)
 	require.NoError(t, err)
 
-	resp, err = nodeTx.Sign(nodeAdminKey).Execute(client)
+	resp, err := nodeTx.Sign(nodeAdminKey).Execute(client)
 	require.NoError(t, err)
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(client)

--- a/sdk/node_create_transaction_e2e_test.go
+++ b/sdk/node_create_transaction_e2e_test.go
@@ -88,8 +88,10 @@ func TestIntegrationNodeCreateTransactionCanExecute(t *testing.T) {
 	resp, err = tx.Sign(adminKey).Execute(client)
 	require.NoError(t, err)
 
-	_, err = resp.GetReceipt(client)
+	
+	receipt, err = resp.GetReceipt(client)
 	require.NoError(t, err)
+	t.Log(receipt.NodeID)
 }
 
 func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing.T) {
@@ -114,7 +116,7 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 
 	regEndpoint := &BlockNodeServiceEndpoint{}
 	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	regEndpoint.SetEndpointApi(BlockNodeApiStatus)
+	regEndpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	regTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(regAdminKey).

--- a/sdk/node_create_transaction_e2e_test.go
+++ b/sdk/node_create_transaction_e2e_test.go
@@ -6,6 +6,7 @@ package hiero
 
 import (
 	"encoding/hex"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,5 +89,87 @@ func TestIntegrationNodeCreateTransactionCanExecute(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = resp.GetReceipt(client)
+	require.NoError(t, err)
+}
+
+func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Create a registered node to get a registeredNodeId
+	regAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	regEndpoint := &BlockNodeServiceEndpoint{}
+	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
+	regEndpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	regTx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(regAdminKey).
+		SetDescription("registered node for association test").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{regEndpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	regResp, err := regTx.Sign(regAdminKey).Execute(client)
+	require.NoError(t, err)
+
+	regReceipt, err := regResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	registeredNodeId := regReceipt.RegisteredNodeId
+
+	// Create an account for the consensus node
+	newKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	resp, err := NewAccountCreateTransaction().
+		SetKeyWithoutAlias(newKey).
+		SetInitialBalance(NewHbar(1)).
+		Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+	accountId := *receipt.AccountID
+
+	// DER gossip certificate
+	validGossipCertDER := "3082052830820310a003020102020101300d06092a864886f70d01010c05003010310e300c060355040313056e6f6465333024170d3234313030383134333233395a181332313234313030383134333233392e3337395a3010310e300c060355040313056e6f64653330820222300d06092a864886f70d01010105000382020f003082020a0282020100af111cff0c4ad8125d2f4b8691ce87332fecc867f7a94ddc0f3f96514cc4224d44af516394f7384c1ef0a515d29aa6116b65bc7e4d7e2d848cf79fbfffedae3a6583b3957a438bdd780c4981b800676ea509bc8c619ae04093b5fc642c4484152f0e8bcaabf19eae025b630028d183a2f47caf6d9f1075efb30a4248679d871beef1b7e9115382270cbdb68682fae4b1fd592cadb414d918c0a8c23795c7c5a91e22b3e90c410825a2bc1a840efc5bf9976a7f474c7ed7dc047e4ddd2db631b68bb4475f173baa3edc234c4bed79c83e2f826f79e07d0aade2d984da447a8514135bfa4145274a7f62959a23c4f0fae5adc6855974e7c04164951d052beb5d45cb1f3cdfd005da894dea9151cb62ba43f4731c6bb0c83e10fd842763ba6844ef499f71bc67fa13e4917fb39f2ad18112170d31cdcb3c61c9e3253accf703dbd8427fdcb87ece78b787b6cfdc091e8fedea8ad95dc64074e1fc6d0e42ea2337e18a5e54e4aaab3791a98dfcef282e2ae1caec9cf986fabe8f36e6a21c8711647177e492d264415e765a86c58599cd97b103cb4f6a01d2edd06e3b60470cf64daca7aecf831197b466cae04baeeac19840a05394bef628aed04b611cfa13677724b08ddfd662b02fd0ef0af17eb7f4fb8c1c17fbe9324f6dc7bcc02449622636cc45ec04909b3120ab4df4726b21bf79e955fe8f832699d2196dcd7a58bfeafb170203010001a38186308183300f0603551d130101ff04053003020100300e0603551d0f0101ff0404030204b030200603551d250101ff0416301406082b0601050507030106082b06010505070302301d0603551d0e04160414643118e05209035edd83d44a0c368de2fb2fe4c0301f0603551d23041830168014643118e05209035edd83d44a0c368de2fb2fe4c0300d06092a864886f70d01010c05000382020100ad41c32bb52650eb4b76fce439c9404e84e4538a94916b3dc7983e8b5c58890556e7384601ca7440dde68233bb07b97bf879b64487b447df510897d2a0a4e789c409a9b237a6ad240ad5464f2ce80c58ddc4d07a29a74eb25e1223db6c00e334d7a27d32bfa6183a82f5e35bccf497c2445a526eabb0c068aba9b94cc092ea4756b0dcfb574f6179f0089e52b174ccdbd04123eeb6d70daeabd8513fcba6be0bc2b45ca9a69802dae11cc4d9ff6053b3a87fd8b0c6bf72fffc3b81167f73cca2b3fd656c5d353c8defca8a76e2ad535f984870a590af4e28fed5c5a125bf360747c5e7742e7813d1bd39b5498c8eb6ba72f267eda034314fdbc596f6b967a0ef8be5231d364e634444c84e64bd7919425171016fcd9bb05f01c58a303dee28241f6e860fc3aac3d92aad7dac2801ce79a3b41a0e1f1509fc0d86e96d94edb18616c000152490f64561713102128990fedd3a5fa642f2ff22dc11bc4dc5b209986a0c3e4eb2bdfdd40e9fdf246f702441cac058dd8d0d51eb0796e2bea2ce1b37b2a2f468505e1f8980a9f66d719df034a6fbbd2f9585991d259678fb9a4aebdc465d22c240351ed44abffbdd11b79a706fdf7c40158d3da87f68d7bd557191a8016b5b899c07bf1b87590feb4fa4203feea9a2a7a73ec224813a12b7a21e5dc93fcde4f0a7620f570d31fe27e9b8d65b74db7dc18a5e51adc42d7805d4661938"
+	validGossipCert, err := hex.DecodeString(validGossipCertDER)
+	require.NoError(t, err)
+
+	nodeAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	gossipEndpoint := Endpoint{domainName: "gossip.test.com", port: 50111}
+	serviceEndpoint := Endpoint{domainName: "service.test.com", port: 50211}
+
+	// Create consensus node with the associatedRegisteredNode
+	nodeTx, err := NewNodeCreateTransaction().
+		SetAccountID(accountId).
+		SetDescription("node with associated registered node").
+		SetGossipEndpoints([]Endpoint{gossipEndpoint}).
+		SetServiceEndpoints([]Endpoint{serviceEndpoint}).
+		SetGossipCaCertificate(validGossipCert).
+		SetAdminKey(nodeAdminKey).
+		AddAssociatedRegisteredNode(registeredNodeId).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err = nodeTx.Sign(nodeAdminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 }

--- a/sdk/node_create_transaction_e2e_test.go
+++ b/sdk/node_create_transaction_e2e_test.go
@@ -115,8 +115,7 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 	require.NoError(t, err)
 
 	regEndpoint := &BlockNodeServiceEndpoint{}
-	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	regEndpoint.AddEndpointApi(BlockNodeApiStatus)
+	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080).AddEndpointApi(BlockNodeApiStatus)
 
 	regTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(regAdminKey).

--- a/sdk/node_create_transaction_e2e_test.go
+++ b/sdk/node_create_transaction_e2e_test.go
@@ -131,7 +131,8 @@ func TestIntegrationNodeCreateTransactionWithAssociatedRegisteredNode(t *testing
 	regReceipt, err := regResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	registeredNodeId := regReceipt.RegisteredNodeId
+	require.NotNil(t, regReceipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
+	registeredNodeId := *regReceipt.RegisteredNodeId
 
 	accountId, _, err := createAccount(&IntegrationTestEnv{Client: client, NodeAccountIDs: []AccountID{nodeAccountID}})
 	require.NoError(t, err)

--- a/sdk/node_create_transaction_unit_test.go
+++ b/sdk/node_create_transaction_unit_test.go
@@ -189,6 +189,7 @@ func TestUnitNodeCreateTransactionGet(t *testing.T) {
 	transaction.GetGossipCaCertificate()
 	transaction.GetGrpcCertificateHash()
 	transaction.GetAdminKey()
+	transaction.GetAssociatedRegisteredNodes()
 }
 
 func TestUnitNodeCreateTransactionSetNothing(t *testing.T) {
@@ -252,6 +253,8 @@ func TestUnitNodeCreateTransactionProtoCheck(t *testing.T) {
 		SetServiceEndpoints(serviceEndpoints).
 		SetGossipCaCertificate([]byte{111}).
 		SetGrpcCertificateHash([]byte{222}).
+		AddAssociatedRegisteredNode(1).
+		AddAssociatedRegisteredNode(2).
 		SetTransactionValidDuration(60 * time.Second).
 		Freeze()
 	require.NoError(t, err)
@@ -267,6 +270,7 @@ func TestUnitNodeCreateTransactionProtoCheck(t *testing.T) {
 	require.Equal(t, proto.GossipCaCertificate, []byte{111})
 	require.Equal(t, proto.GrpcCertificateHash, []byte{222})
 	require.Equal(t, proto.AdminKey, key._ToProtoKey())
+	require.Equal(t, []uint64{1, 2}, proto.AssociatedRegisteredNode)
 }
 
 func TestUnitNodeCreateTransactionCoverage(t *testing.T) {
@@ -329,6 +333,7 @@ func TestUnitNodeCreateTransactionCoverage(t *testing.T) {
 	trx.GetGossipCaCertificate()
 	trx.GetGrpcCertificateHash()
 	trx.GetAdminKey()
+	trx.GetAssociatedRegisteredNodes()
 	_, err = trx.GetSignatures()
 	require.NoError(t, err)
 	trx.getName()

--- a/sdk/node_update_transaction.go
+++ b/sdk/node_update_transaction.go
@@ -30,16 +30,17 @@ import (
  */
 type NodeUpdateTransaction struct {
 	*Transaction[*NodeUpdateTransaction]
-	nodeID               *uint64
-	accountID            *AccountID
-	description          string
-	gossipEndpoints      []Endpoint
-	serviceEndpoints     []Endpoint
-	gossipCaCertificate  []byte
-	grpcCertificateHash  []byte
-	adminKey             Key
-	declineReward        *bool
-	grpcWebProxyEndpoint *Endpoint
+	nodeID                    *uint64
+	accountID                 *AccountID
+	description               string
+	gossipEndpoints           []Endpoint
+	serviceEndpoints          []Endpoint
+	gossipCaCertificate       []byte
+	grpcCertificateHash       []byte
+	adminKey                  Key
+	declineReward             *bool
+	grpcWebProxyEndpoint      *Endpoint
+	associatedRegisteredNodes *[]uint64 // nil=unchanged, empty=clear, non-empty=replace
 }
 
 func NewNodeUpdateTransaction() *NodeUpdateTransaction {
@@ -92,18 +93,28 @@ func _NodeUpdateTransactionFromProtobuf(tx Transaction[*NodeUpdateTransaction], 
 		declineReward = &declineRewardValue
 	}
 
+	var associatedRegisteredNodes *[]uint64
+	if pb.GetNodeUpdate().GetAssociatedRegisteredNodeList() != nil {
+		ids := pb.GetNodeUpdate().GetAssociatedRegisteredNodeList().GetAssociatedRegisteredNode()
+		if ids == nil {
+			ids = []uint64{}
+		}
+		associatedRegisteredNodes = &ids
+	}
+
 	nodeID := pb.GetNodeUpdate().GetNodeId()
 	nodeUpdateTransaction := NodeUpdateTransaction{
-		nodeID:               &nodeID,
-		accountID:            accountID,
-		description:          description,
-		gossipEndpoints:      gossipEndpoints,
-		serviceEndpoints:     serviceEndpoints,
-		gossipCaCertificate:  certificate,
-		grpcCertificateHash:  certificateHash,
-		adminKey:             adminKey,
-		grpcWebProxyEndpoint: grpcProxyEndpoint,
-		declineReward:        declineReward,
+		nodeID:                    &nodeID,
+		accountID:                 accountID,
+		description:               description,
+		gossipEndpoints:           gossipEndpoints,
+		serviceEndpoints:          serviceEndpoints,
+		gossipCaCertificate:       certificate,
+		grpcCertificateHash:       certificateHash,
+		adminKey:                  adminKey,
+		grpcWebProxyEndpoint:      grpcProxyEndpoint,
+		declineReward:             declineReward,
+		associatedRegisteredNodes: associatedRegisteredNodes,
 	}
 
 	tx.childTransaction = &nodeUpdateTransaction
@@ -270,6 +281,41 @@ func (tx *NodeUpdateTransaction) DeleteGrpcWebProxyEndpoint() *NodeUpdateTransac
 	return tx
 }
 
+// GetAssociatedRegisteredNodes returns the associated registered node IDs.
+// Returns nil if the field was never set (preserve existing), a pointer to an empty
+// slice if cleared, or a pointer to a populated slice if replaced.
+func (tx *NodeUpdateTransaction) GetAssociatedRegisteredNodes() *[]uint64 {
+	return tx.associatedRegisteredNodes
+}
+
+// SetAssociatedRegisteredNodes sets the associated registered node IDs, replacing any existing ones.
+// Pass a non-empty slice to replace, or use ClearAssociatedRegisteredNodes to clear.
+func (tx *NodeUpdateTransaction) SetAssociatedRegisteredNodes(ids []uint64) *NodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.associatedRegisteredNodes = &ids
+	return tx
+}
+
+// AddAssociatedRegisteredNode adds a registered node ID to the association list.
+func (tx *NodeUpdateTransaction) AddAssociatedRegisteredNode(id uint64) *NodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	if tx.associatedRegisteredNodes == nil {
+		ids := []uint64{id}
+		tx.associatedRegisteredNodes = &ids
+	} else {
+		*tx.associatedRegisteredNodes = append(*tx.associatedRegisteredNodes, id)
+	}
+	return tx
+}
+
+// ClearAssociatedRegisteredNodes clears all associated registered nodes.
+func (tx *NodeUpdateTransaction) ClearAssociatedRegisteredNodes() *NodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	ids := []uint64{}
+	tx.associatedRegisteredNodes = &ids
+	return tx
+}
+
 // ----------- Overridden functions ----------------
 
 func (tx NodeUpdateTransaction) getName() string {
@@ -349,6 +395,12 @@ func (tx NodeUpdateTransaction) buildProtoBody() *services.NodeUpdateTransaction
 
 	if tx.declineReward != nil {
 		body.DeclineReward = wrapperspb.Bool(*tx.declineReward)
+	}
+
+	if tx.associatedRegisteredNodes != nil {
+		body.AssociatedRegisteredNodeList = &services.AssociatedRegisteredNodeList{
+			AssociatedRegisteredNode: *tx.associatedRegisteredNodes,
+		}
 	}
 
 	return body

--- a/sdk/node_update_transaction_e2e_test.go
+++ b/sdk/node_update_transaction_e2e_test.go
@@ -3,6 +3,7 @@
 package hiero
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -451,6 +452,63 @@ func TestIntegrationNodeUpdateTransactionCanChangeNodeAccountWithoutMirrorNodeSe
 		Execute(client)
 
 	require.NoError(t, err)
+	_, err = resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+}
+
+func TestIntegrationNodeUpdateTransactionWithAssociatedRegisteredNode(t *testing.T) {
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Create a registered node to get a registeredNodeId
+	regAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	regEndpoint := &BlockNodeServiceEndpoint{}
+	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
+	regEndpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	regTx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(regAdminKey).
+		SetDescription("registered node for node update association test").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{regEndpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	regResp, err := regTx.Sign(regAdminKey).Execute(client)
+	require.NoError(t, err)
+
+	regReceipt, err := regResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	registeredNodeId := regReceipt.RegisteredNodeId
+
+	// Update existing consensus node 0 with the associated registered node
+	resp, err := NewNodeUpdateTransaction().
+		SetNodeID(nodeIDToUpdate).
+		SetAssociatedRegisteredNodes([]uint64{registeredNodeId}).
+		Execute(client)
+	require.NoError(t, err)
+
+	_, err = resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Clear the association to restore state
+	resp, err = NewNodeUpdateTransaction().
+		SetNodeID(nodeIDToUpdate).
+		ClearAssociatedRegisteredNodes().
+		Execute(client)
+	require.NoError(t, err)
+
 	_, err = resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 }

--- a/sdk/node_update_transaction_e2e_test.go
+++ b/sdk/node_update_transaction_e2e_test.go
@@ -475,7 +475,7 @@ func TestIntegrationNodeUpdateTransactionWithAssociatedRegisteredNode(t *testing
 
 	regEndpoint := &BlockNodeServiceEndpoint{}
 	regEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	regEndpoint.SetEndpointApi(BlockNodeApiStatus)
+	regEndpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	regTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(regAdminKey).

--- a/sdk/node_update_transaction_e2e_test.go
+++ b/sdk/node_update_transaction_e2e_test.go
@@ -490,7 +490,8 @@ func TestIntegrationNodeUpdateTransactionWithAssociatedRegisteredNode(t *testing
 	regReceipt, err := regResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	registeredNodeId := regReceipt.RegisteredNodeId
+	require.NotNil(t, regReceipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
+	registeredNodeId := *regReceipt.RegisteredNodeId
 
 	// Update existing consensus node 0 with the associated registered node
 	resp, err := NewNodeUpdateTransaction().

--- a/sdk/node_update_transaction_unit_test.go
+++ b/sdk/node_update_transaction_unit_test.go
@@ -160,6 +160,7 @@ func TestUnitNodeUpdateTransactionGet(t *testing.T) {
 	transaction.GetGrpcCertificateHash()
 	transaction.GetAdminKey()
 	transaction.GetNodeID()
+	transaction.GetAssociatedRegisteredNodes()
 }
 
 func TestUnitNodeUpdateTransactionSetNothing(t *testing.T) {
@@ -226,6 +227,7 @@ func TestUnitNodeUpdateTransactionProtoCheck(t *testing.T) {
 		SetServiceEndpoints(serviceEndpoints).
 		SetGossipCaCertificate([]byte{111}).
 		SetGrpcCertificateHash([]byte{222}).
+		SetAssociatedRegisteredNodes([]uint64{1, 2}).
 		SetTransactionValidDuration(60 * time.Second).
 		Freeze()
 	require.NoError(t, err)
@@ -242,6 +244,8 @@ func TestUnitNodeUpdateTransactionProtoCheck(t *testing.T) {
 	require.Equal(t, proto.GrpcCertificateHash.Value, []byte{222})
 	require.Equal(t, proto.AdminKey, key._ToProtoKey())
 	require.Equal(t, proto.NodeId, uint64(1))
+	require.NotNil(t, proto.AssociatedRegisteredNodeList)
+	require.Equal(t, []uint64{1, 2}, proto.AssociatedRegisteredNodeList.AssociatedRegisteredNode)
 }
 
 func TestUnitNodeUpdateTransactionCoverage(t *testing.T) {
@@ -306,6 +310,7 @@ func TestUnitNodeUpdateTransactionCoverage(t *testing.T) {
 	trx.GetGrpcCertificateHash()
 	trx.GetAdminKey()
 	trx.GetNodeID()
+	trx.GetAssociatedRegisteredNodes()
 	_, err = trx.GetSignatures()
 	require.NoError(t, err)
 	trx.getName()
@@ -437,4 +442,48 @@ func TestUnitNodeUpdateTransactionFailsWenNodeIDIsNotSet(t *testing.T) {
 
 	require.Error(t, err)
 	assert.ErrorIs(t, errNodeIdIsRequired, err)
+}
+
+func TestUnitNodeUpdateTransactionAssociatedRegisteredNodesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Populated state
+	tx := NewNodeUpdateTransaction().
+		SetNodeID(1).
+		SetAssociatedRegisteredNodes([]uint64{3, 4, 5})
+
+	body := tx.buildProtoBody()
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_NodeUpdate{
+			NodeUpdate: body,
+		},
+	}
+	restored := _NodeUpdateTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.NotNil(t, restored.GetAssociatedRegisteredNodes())
+	assert.Equal(t, []uint64{3, 4, 5}, *restored.GetAssociatedRegisteredNodes())
+
+	// Empty state (clear)
+	tx2 := NewNodeUpdateTransaction().SetNodeID(1)
+	tx2.ClearAssociatedRegisteredNodes()
+
+	body2 := tx2.buildProtoBody()
+	pbBody2 := &services.TransactionBody{
+		Data: &services.TransactionBody_NodeUpdate{
+			NodeUpdate: body2,
+		},
+	}
+	restored2 := _NodeUpdateTransactionFromProtobuf(*tx2.Transaction, pbBody2)
+	assert.NotNil(t, restored2.GetAssociatedRegisteredNodes())
+	assert.Empty(t, *restored2.GetAssociatedRegisteredNodes())
+
+	// Nil state (preserve)
+	tx3 := NewNodeUpdateTransaction().SetNodeID(1)
+	body3 := tx3.buildProtoBody()
+	pbBody3 := &services.TransactionBody{
+		Data: &services.TransactionBody_NodeUpdate{
+			NodeUpdate: body3,
+		},
+	}
+	restored3 := _NodeUpdateTransactionFromProtobuf(*tx3.Transaction, pbBody3)
+	assert.Nil(t, restored3.GetAssociatedRegisteredNodes())
 }

--- a/sdk/registered_node_address_book_query.go
+++ b/sdk/registered_node_address_book_query.go
@@ -1,0 +1,390 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	registeredNodeQueryRetryDelay = 200 * time.Millisecond
+	registeredNodeMaxPages        = 1000
+)
+
+type RegisteredNode struct {
+	AdminKey         Key
+	Description      string
+	RegisteredNodeID uint64
+	ServiceEndpoints []RegisteredServiceEndpoint
+	CreatedTimestamp string
+}
+
+type RegisteredNodeAddressBook struct {
+	RegisteredNodes []RegisteredNode
+}
+
+// RegisteredNodeAddressBookQuery defines the contract for querying registered nodes.
+type RegisteredNodeAddressBookQuery struct {
+	registeredNodeId *uint64
+	maxAttempts      uint64
+	limit            int32
+}
+
+func NewRegisteredNodeAddressBookQuery() *RegisteredNodeAddressBookQuery {
+	return &RegisteredNodeAddressBookQuery{}
+}
+
+// SetRegisteredNodeId filters the query to a specific registered node ID.
+func (q *RegisteredNodeAddressBookQuery) SetRegisteredNodeId(id uint64) *RegisteredNodeAddressBookQuery {
+	q.registeredNodeId = &id
+	return q
+}
+
+// GetRegisteredNodeId returns the registered node ID filter, or 0 if not set.
+func (q *RegisteredNodeAddressBookQuery) GetRegisteredNodeId() uint64 {
+	if q.registeredNodeId == nil {
+		return 0
+	}
+	return *q.registeredNodeId
+}
+
+// SetLimit sets the maximum number of registered nodes to return.
+// Zero (the default) leaves the limit up to the mirror node.
+func (q *RegisteredNodeAddressBookQuery) SetLimit(limit int32) *RegisteredNodeAddressBookQuery {
+	q.limit = limit
+	return q
+}
+
+// GetLimit returns the current limit, or 0 if unset.
+func (q *RegisteredNodeAddressBookQuery) GetLimit() int32 {
+	return q.limit
+}
+
+// SetMaxAttempts sets the total number of attempts (initial try + retries).
+// Zero (the default) is treated as a single attempt with no retries.
+func (q *RegisteredNodeAddressBookQuery) SetMaxAttempts(maxAttempts uint64) *RegisteredNodeAddressBookQuery {
+	q.maxAttempts = maxAttempts
+	return q
+}
+
+// GetMaxAttempts returns the configured retry budget.
+func (q *RegisteredNodeAddressBookQuery) GetMaxAttempts() uint64 {
+	return q.maxAttempts
+}
+
+func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNodeAddressBook, error) {
+	if client == nil {
+		return RegisteredNodeAddressBook{}, errNoClientProvided
+	}
+
+	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
+		return RegisteredNodeAddressBook{}, fmt.Errorf("mirror node is not set")
+	}
+
+	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
+	if err != nil {
+		return RegisteredNodeAddressBook{}, fmt.Errorf("failed to get mirror REST API base URL: %w", err)
+	}
+
+	if strings.Contains(mirrorUrl, "localhost") || strings.Contains(mirrorUrl, "127.0.0.1") {
+		mirrorUrl = "http://localhost:8084/api/v1"
+	}
+
+	mirrorBase, err := url.Parse(mirrorUrl)
+	if err != nil {
+		return RegisteredNodeAddressBook{}, fmt.Errorf("invalid mirror REST API base URL %q: %w", mirrorUrl, err)
+	}
+
+	attempts := q.maxAttempts
+	if attempts == 0 {
+		if clientMax := client.GetMaxAttempts(); clientMax > 0 {
+			attempts = uint64(clientMax)
+		} else {
+			attempts = 1
+		}
+	}
+
+	endpoint := q.buildURL(mirrorUrl)
+	allNodes := make([]RegisteredNode, 0)
+
+	for range registeredNodeMaxPages {
+		body, err := fetchRegisteredNodesPage(endpoint, attempts)
+		if err != nil {
+			return RegisteredNodeAddressBook{}, err
+		}
+
+		nodes, next, err := parseRegisteredNodes(body)
+		if err != nil {
+			return RegisteredNodeAddressBook{}, err
+		}
+		allNodes = append(allNodes, nodes...)
+
+		if next == nil || *next == "" {
+			return RegisteredNodeAddressBook{RegisteredNodes: allNodes}, nil
+		}
+
+		resolved, err := resolveNextURL(mirrorBase, *next)
+		if err != nil {
+			return RegisteredNodeAddressBook{}, fmt.Errorf("invalid pagination next link %q: %w", *next, err)
+		}
+		endpoint = resolved
+	}
+
+	return RegisteredNodeAddressBook{}, fmt.Errorf("exceeded pagination cap of %d pages", registeredNodeMaxPages)
+}
+
+// buildURL composes the mirror node REST URL together with any query
+// parameters configured on the query.
+func (q *RegisteredNodeAddressBookQuery) buildURL(mirrorBaseURL string) string {
+	endpoint := fmt.Sprintf("%s/network/registered-nodes", mirrorBaseURL)
+
+	params := url.Values{}
+	if q.registeredNodeId != nil {
+		params.Set("registerednode.id", strconv.FormatUint(*q.registeredNodeId, 10))
+	}
+	if q.limit > 0 {
+		params.Set("limit", strconv.FormatInt(int64(q.limit), 10))
+	}
+
+	if encoded := params.Encode(); encoded != "" {
+		endpoint = endpoint + "?" + encoded
+	}
+	return endpoint
+}
+
+// fetchRegisteredNodes issues a single GET against the mirror node and
+// returns the response body together with the HTTP status code.
+func fetchRegisteredNodes(endpoint string) ([]byte, int, error) {
+	resp, err := http.Get(endpoint) // #nosec
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("failed to read response body: %w", err)
+	}
+	return body, resp.StatusCode, nil
+}
+
+// fetchRegisteredNodesPage wraps fetchRegisteredNodes with the per-page retry.
+func fetchRegisteredNodesPage(endpoint string, attempts uint64) ([]byte, error) {
+	var lastErr error
+	for attempt := range attempts {
+		if attempt > 0 {
+			time.Sleep(registeredNodeQueryRetryDelay)
+		}
+
+		body, status, err := fetchRegisteredNodes(endpoint)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if status >= 500 {
+			lastErr = fmt.Errorf("received non-200 response from mirror node: %d, details: %s", status, body)
+			continue
+		}
+
+		if status != http.StatusOK {
+			return nil, fmt.Errorf("received non-200 response from mirror node: %d, details: %s", status, body)
+		}
+
+		return body, nil
+	}
+	return nil, fmt.Errorf("failed after %d attempt(s): %w", attempts, lastErr)
+}
+
+// resolveNextURL resolves a pagination next link against the mirror base URL.
+func resolveNextURL(base *url.URL, next string) (string, error) {
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(parsed).String(), nil
+}
+
+func parseRegisteredNodes(body []byte) ([]RegisteredNode, *string, error) {
+	var raw registeredNodesResponseJSON
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	nodes := make([]RegisteredNode, 0, len(raw.RegisteredNodes))
+	for _, rn := range raw.RegisteredNodes {
+		node, err := registeredNodeFromJSON(rn)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert registered node %d: %w", rn.RegisteredNodeID, err)
+		}
+		nodes = append(nodes, node)
+	}
+
+	var next *string
+	if raw.Links != nil {
+		next = raw.Links.Next
+	}
+	return nodes, next, nil
+}
+
+type registeredNodesResponseJSON struct {
+	RegisteredNodes []registeredNodeJSON `json:"registered_nodes"`
+	Links           *linksJSON           `json:"links"`
+}
+
+type linksJSON struct {
+	Next *string `json:"next"`
+}
+
+type registeredNodeJSON struct {
+	AdminKey         *adminKeyJSON         `json:"admin_key"`
+	CreatedTimestamp string                `json:"created_timestamp"`
+	Description      string                `json:"description"`
+	RegisteredNodeID uint64                `json:"registered_node_id"`
+	ServiceEndpoints []serviceEndpointJSON `json:"service_endpoints"`
+}
+
+type adminKeyJSON struct {
+	Type string `json:"_type"`
+	Key  string `json:"key"`
+}
+
+type serviceEndpointJSON struct {
+	BlockNode      *blockNodeJSON      `json:"block_node"`
+	GeneralService *generalServiceJSON `json:"general_service"`
+	DomainName     *string             `json:"domain_name"`
+	IPAddress      *string             `json:"ip_address"`
+	Port           uint32              `json:"port"`
+	RequiresTls    bool                `json:"requires_tls"`
+	Type           string              `json:"type"`
+}
+
+type blockNodeJSON struct {
+	EndpointApis []string `json:"endpoint_apis"`
+}
+
+type generalServiceJSON struct {
+	Description string `json:"description"`
+}
+
+func registeredNodeFromJSON(raw registeredNodeJSON) (RegisteredNode, error) {
+	node := RegisteredNode{
+		Description:      raw.Description,
+		RegisteredNodeID: raw.RegisteredNodeID,
+		CreatedTimestamp: raw.CreatedTimestamp,
+	}
+
+	if raw.AdminKey != nil {
+		key, err := adminKeyFromJSON(*raw.AdminKey)
+		if err != nil {
+			return RegisteredNode{}, fmt.Errorf("failed to parse admin key: %w", err)
+		}
+		node.AdminKey = key
+	}
+
+	endpoints := make([]RegisteredServiceEndpoint, 0, len(raw.ServiceEndpoints))
+	for i, ep := range raw.ServiceEndpoints {
+		endpoint, err := serviceEndpointFromJSON(ep)
+		if err != nil {
+			return RegisteredNode{}, fmt.Errorf("failed to parse service endpoint %d: %w", i, err)
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	node.ServiceEndpoints = endpoints
+
+	return node, nil
+}
+
+func adminKeyFromJSON(raw adminKeyJSON) (Key, error) {
+	switch strings.ToUpper(raw.Type) {
+	case "ED25519":
+		return PublicKeyFromStringEd25519(raw.Key)
+	case "ECDSA_SECP256K1":
+		return PublicKeyFromStringECDSA(raw.Key)
+	default:
+		return PublicKeyFromString(raw.Key)
+	}
+}
+
+func serviceEndpointFromJSON(raw serviceEndpointJSON) (RegisteredServiceEndpoint, error) {
+	base := registeredEndpointBase{
+		port:        raw.Port,
+		requiresTls: raw.RequiresTls,
+	}
+
+	if raw.IPAddress != nil && *raw.IPAddress != "" {
+		ip := net.ParseIP(*raw.IPAddress)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IP address: %s", *raw.IPAddress)
+		}
+		if v4 := ip.To4(); v4 != nil {
+			base.ipAddress = v4
+		} else {
+			base.ipAddress = ip.To16()
+		}
+	}
+
+	if raw.DomainName != nil && *raw.DomainName != "" {
+		base.domainName = *raw.DomainName
+	}
+
+	switch strings.ToUpper(raw.Type) {
+	case "BLOCK_NODE":
+		endpoint := &BlockNodeServiceEndpoint{
+			registeredEndpointBase: base,
+		}
+		if raw.BlockNode != nil {
+			apis := make([]BlockNodeApi, 0, len(raw.BlockNode.EndpointApis))
+			for _, apiStr := range raw.BlockNode.EndpointApis {
+				apis = append(apis, blockNodeApiFromString(apiStr))
+			}
+			endpoint.endpointApis = apis
+		}
+		return endpoint, nil
+
+	case "MIRROR_NODE":
+		return &MirrorNodeServiceEndpoint{
+			registeredEndpointBase: base,
+		}, nil
+
+	case "RPC_RELAY":
+		return &RpcRelayServiceEndpoint{
+			registeredEndpointBase: base,
+		}, nil
+
+	case "GENERAL_SERVICE":
+		endpoint := &GeneralServiceEndpoint{
+			registeredEndpointBase: base,
+		}
+		if raw.GeneralService != nil {
+			endpoint.description = raw.GeneralService.Description
+		}
+		return endpoint, nil
+
+	default:
+		return nil, fmt.Errorf("unknown endpoint type: %s", raw.Type)
+	}
+}
+
+func blockNodeApiFromString(s string) BlockNodeApi {
+	switch strings.ToUpper(s) {
+	case "STATUS":
+		return BlockNodeApiStatus
+	case "PUBLISH":
+		return BlockNodeApiPublish
+	case "SUBSCRIBE_STREAM":
+		return BlockNodeApiSubscribeStream
+	case "STATE_PROOF":
+		return BlockNodeApiStateProof
+	default:
+		return BlockNodeApiOther
+	}
+}

--- a/sdk/registered_node_address_book_query.go
+++ b/sdk/registered_node_address_book_query.go
@@ -340,7 +340,7 @@ func serviceEndpointFromJSON(raw serviceEndpointJSON) (RegisteredServiceEndpoint
 
 	switch strings.ToUpper(raw.Type) {
 	case "BLOCK_NODE":
-		return blockNodeEndpointFromJSON(base, raw.BlockNode), nil
+		return blockNodeEndpointFromJSON(base, raw.BlockNode)
 	case "MIRROR_NODE":
 		return &MirrorNodeServiceEndpoint{registeredEndpointBase: base}, nil
 	case "RPC_RELAY":
@@ -379,17 +379,21 @@ func endpointBaseFromJSON(raw serviceEndpointJSON) (registeredEndpointBase, erro
 	return base, nil
 }
 
-func blockNodeEndpointFromJSON(base registeredEndpointBase, raw *blockNodeJSON) *BlockNodeServiceEndpoint {
+func blockNodeEndpointFromJSON(base registeredEndpointBase, raw *blockNodeJSON) (*BlockNodeServiceEndpoint, error) {
 	endpoint := &BlockNodeServiceEndpoint{registeredEndpointBase: base}
 	if raw == nil {
-		return endpoint
+		return endpoint, nil
 	}
 
 	endpoint.endpointApis = make([]BlockNodeApi, 0, len(raw.EndpointApis))
 	for _, apiStr := range raw.EndpointApis {
-		endpoint.endpointApis = append(endpoint.endpointApis, blockNodeApiFromString(apiStr))
+		api, err := blockNodeApiFromString(apiStr)
+		if err != nil {
+			return nil, err
+		}
+		endpoint.endpointApis = append(endpoint.endpointApis, api)
 	}
-	return endpoint
+	return endpoint, nil
 }
 
 func generalServiceEndpointFromJSON(base registeredEndpointBase, raw *generalServiceJSON) *GeneralServiceEndpoint {
@@ -400,17 +404,3 @@ func generalServiceEndpointFromJSON(base registeredEndpointBase, raw *generalSer
 	return endpoint
 }
 
-func blockNodeApiFromString(s string) BlockNodeApi {
-	switch strings.ToUpper(s) {
-	case "STATUS":
-		return BlockNodeApiStatus
-	case "PUBLISH":
-		return BlockNodeApiPublish
-	case "SUBSCRIBE_STREAM":
-		return BlockNodeApiSubscribeStream
-	case "STATE_PROOF":
-		return BlockNodeApiStateProof
-	default:
-		return BlockNodeApiOther
-	}
-}

--- a/sdk/registered_node_address_book_query.go
+++ b/sdk/registered_node_address_book_query.go
@@ -85,13 +85,24 @@ func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNode
 		return RegisteredNodeAddressBook{}, errNoClientProvided
 	}
 
+	mirrorBase, endpoint, err := q.resolveEndpoint(client)
+	if err != nil {
+		return RegisteredNodeAddressBook{}, err
+	}
+
+	return q.walkPages(mirrorBase, endpoint, q.resolveAttempts(client))
+}
+
+// resolveEndpoint discovers the mirror node REST base URL on the client,
+// parses it, and returns it together with the initial query URL.
+func (q *RegisteredNodeAddressBookQuery) resolveEndpoint(client *Client) (*url.URL, string, error) {
 	if client.mirrorNetwork == nil || len(client.GetMirrorNetwork()) == 0 {
-		return RegisteredNodeAddressBook{}, fmt.Errorf("mirror node is not set")
+		return nil, "", fmt.Errorf("mirror node is not set")
 	}
 
 	mirrorUrl, err := client.GetMirrorRestApiBaseUrl()
 	if err != nil {
-		return RegisteredNodeAddressBook{}, fmt.Errorf("failed to get mirror REST API base URL: %w", err)
+		return nil, "", fmt.Errorf("failed to get mirror REST API base URL: %w", err)
 	}
 
 	if strings.Contains(mirrorUrl, "localhost") || strings.Contains(mirrorUrl, "127.0.0.1") {
@@ -100,19 +111,26 @@ func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNode
 
 	mirrorBase, err := url.Parse(mirrorUrl)
 	if err != nil {
-		return RegisteredNodeAddressBook{}, fmt.Errorf("invalid mirror REST API base URL %q: %w", mirrorUrl, err)
+		return nil, "", fmt.Errorf("invalid mirror REST API base URL %q: %w", mirrorUrl, err)
 	}
 
-	attempts := q.maxAttempts
-	if attempts == 0 {
-		if clientMax := client.GetMaxAttempts(); clientMax > 0 {
-			attempts = uint64(clientMax)
-		} else {
-			attempts = 1
-		}
-	}
+	return mirrorBase, q.buildURL(mirrorUrl), nil
+}
 
-	endpoint := q.buildURL(mirrorUrl)
+// resolveAttempts picks the per-page retry budget: query setting first,
+// client default second, single attempt as the final fallback.
+func (q *RegisteredNodeAddressBookQuery) resolveAttempts(client *Client) uint64 {
+	if q.maxAttempts > 0 {
+		return q.maxAttempts
+	}
+	if clientMax := client.GetMaxAttempts(); clientMax > 0 {
+		return uint64(clientMax)
+	}
+	return 1
+}
+
+// walkPages follows links.next until exhausted (or the page cap trips).
+func (q *RegisteredNodeAddressBookQuery) walkPages(base *url.URL, endpoint string, attempts uint64) (RegisteredNodeAddressBook, error) {
 	allNodes := make([]RegisteredNode, 0)
 
 	for range registeredNodeMaxPages {
@@ -131,7 +149,7 @@ func (q *RegisteredNodeAddressBookQuery) Execute(client *Client) (RegisteredNode
 			return RegisteredNodeAddressBook{RegisteredNodes: allNodes}, nil
 		}
 
-		resolved, err := resolveNextURL(mirrorBase, *next)
+		resolved, err := resolveNextURL(base, *next)
 		if err != nil {
 			return RegisteredNodeAddressBook{}, fmt.Errorf("invalid pagination next link %q: %w", *next, err)
 		}
@@ -315,6 +333,28 @@ func adminKeyFromJSON(raw adminKeyJSON) (Key, error) {
 }
 
 func serviceEndpointFromJSON(raw serviceEndpointJSON) (RegisteredServiceEndpoint, error) {
+	base, err := endpointBaseFromJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	switch strings.ToUpper(raw.Type) {
+	case "BLOCK_NODE":
+		return blockNodeEndpointFromJSON(base, raw.BlockNode), nil
+	case "MIRROR_NODE":
+		return &MirrorNodeServiceEndpoint{registeredEndpointBase: base}, nil
+	case "RPC_RELAY":
+		return &RpcRelayServiceEndpoint{registeredEndpointBase: base}, nil
+	case "GENERAL_SERVICE":
+		return generalServiceEndpointFromJSON(base, raw.GeneralService), nil
+	default:
+		return nil, fmt.Errorf("unknown endpoint type: %s", raw.Type)
+	}
+}
+
+// endpointBaseFromJSON extracts the IP / domain / port / TLS fields shared by
+// every endpoint subtype.
+func endpointBaseFromJSON(raw serviceEndpointJSON) (registeredEndpointBase, error) {
 	base := registeredEndpointBase{
 		port:        raw.Port,
 		requiresTls: raw.RequiresTls,
@@ -323,7 +363,7 @@ func serviceEndpointFromJSON(raw serviceEndpointJSON) (RegisteredServiceEndpoint
 	if raw.IPAddress != nil && *raw.IPAddress != "" {
 		ip := net.ParseIP(*raw.IPAddress)
 		if ip == nil {
-			return nil, fmt.Errorf("invalid IP address: %s", *raw.IPAddress)
+			return base, fmt.Errorf("invalid IP address: %s", *raw.IPAddress)
 		}
 		if v4 := ip.To4(); v4 != nil {
 			base.ipAddress = v4
@@ -336,42 +376,28 @@ func serviceEndpointFromJSON(raw serviceEndpointJSON) (RegisteredServiceEndpoint
 		base.domainName = *raw.DomainName
 	}
 
-	switch strings.ToUpper(raw.Type) {
-	case "BLOCK_NODE":
-		endpoint := &BlockNodeServiceEndpoint{
-			registeredEndpointBase: base,
-		}
-		if raw.BlockNode != nil {
-			apis := make([]BlockNodeApi, 0, len(raw.BlockNode.EndpointApis))
-			for _, apiStr := range raw.BlockNode.EndpointApis {
-				apis = append(apis, blockNodeApiFromString(apiStr))
-			}
-			endpoint.endpointApis = apis
-		}
-		return endpoint, nil
+	return base, nil
+}
 
-	case "MIRROR_NODE":
-		return &MirrorNodeServiceEndpoint{
-			registeredEndpointBase: base,
-		}, nil
-
-	case "RPC_RELAY":
-		return &RpcRelayServiceEndpoint{
-			registeredEndpointBase: base,
-		}, nil
-
-	case "GENERAL_SERVICE":
-		endpoint := &GeneralServiceEndpoint{
-			registeredEndpointBase: base,
-		}
-		if raw.GeneralService != nil {
-			endpoint.description = raw.GeneralService.Description
-		}
-		return endpoint, nil
-
-	default:
-		return nil, fmt.Errorf("unknown endpoint type: %s", raw.Type)
+func blockNodeEndpointFromJSON(base registeredEndpointBase, raw *blockNodeJSON) *BlockNodeServiceEndpoint {
+	endpoint := &BlockNodeServiceEndpoint{registeredEndpointBase: base}
+	if raw == nil {
+		return endpoint
 	}
+
+	endpoint.endpointApis = make([]BlockNodeApi, 0, len(raw.EndpointApis))
+	for _, apiStr := range raw.EndpointApis {
+		endpoint.endpointApis = append(endpoint.endpointApis, blockNodeApiFromString(apiStr))
+	}
+	return endpoint
+}
+
+func generalServiceEndpointFromJSON(base registeredEndpointBase, raw *generalServiceJSON) *GeneralServiceEndpoint {
+	endpoint := &GeneralServiceEndpoint{registeredEndpointBase: base}
+	if raw != nil {
+		endpoint.description = raw.Description
+	}
+	return endpoint
 }
 
 func blockNodeApiFromString(s string) BlockNodeApi {

--- a/sdk/registered_node_address_book_query_unit_test.go
+++ b/sdk/registered_node_address_book_query_unit_test.go
@@ -1,0 +1,248 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitRegisteredNodeAddressBookQuerySetterChaining(t *testing.T) {
+	t.Parallel()
+
+	q := NewRegisteredNodeAddressBookQuery()
+	require.NotNil(t, q)
+
+	result := q.SetRegisteredNodeId(42)
+	assert.Same(t, q, result, "SetRegisteredNodeId should return the same query for chaining")
+	assert.Equal(t, uint64(42), q.GetRegisteredNodeId())
+}
+
+func TestUnitRegisteredNodeAddressBookQueryGetRegisteredNodeIdDefault(t *testing.T) {
+	t.Parallel()
+
+	q := NewRegisteredNodeAddressBookQuery()
+	assert.Equal(t, uint64(0), q.GetRegisteredNodeId(), "unset ID should default to 0")
+}
+
+func TestUnitRegisteredNodeAddressBookQueryExecuteNilClient(t *testing.T) {
+	t.Parallel()
+
+	book, err := NewRegisteredNodeAddressBookQuery().Execute(nil)
+	assert.Equal(t, errNoClientProvided, err)
+	assert.Equal(t, RegisteredNodeAddressBook{}, book)
+}
+
+func TestUnitBlockNodeApiFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want BlockNodeApi
+	}{
+		{"STATUS", BlockNodeApiStatus},
+		{"PUBLISH", BlockNodeApiPublish},
+		{"SUBSCRIBE_STREAM", BlockNodeApiSubscribeStream},
+		{"STATE_PROOF", BlockNodeApiStateProof},
+		{"OTHER", BlockNodeApiOther},
+		{"unrecognised", BlockNodeApiOther},
+		{"", BlockNodeApiOther},
+		{"status", BlockNodeApiStatus}, // lower-case should still match
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, blockNodeApiFromString(tt.in), "input %q", tt.in)
+	}
+}
+
+func TestUnitAdminKeyFromJSONEd25519(t *testing.T) {
+	t.Parallel()
+
+	priv, err := PrivateKeyFromString(mockPrivateKey)
+	require.NoError(t, err)
+	pub := priv.PublicKey().String()
+
+	key, err := adminKeyFromJSON(adminKeyJSON{Type: "ED25519", Key: pub})
+	require.NoError(t, err)
+	require.NotNil(t, key)
+	assert.Equal(t, pub, key.(PublicKey).String())
+}
+
+func TestUnitAdminKeyFromJSONEcdsa(t *testing.T) {
+	t.Parallel()
+
+	priv, err := PrivateKeyGenerateEcdsa()
+	require.NoError(t, err)
+	pub := priv.PublicKey().StringRaw()
+
+	key, err := adminKeyFromJSON(adminKeyJSON{Type: "ECDSA_SECP256K1", Key: pub})
+	require.NoError(t, err)
+	require.NotNil(t, key)
+}
+
+func TestUnitAdminKeyFromJSONInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := adminKeyFromJSON(adminKeyJSON{Type: "ED25519", Key: "not-a-key"})
+	assert.Error(t, err)
+}
+
+func TestUnitServiceEndpointFromJSONBlockNode(t *testing.T) {
+	t.Parallel()
+
+	ip := "192.168.1.1"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:        "BLOCK_NODE",
+		IPAddress:   &ip,
+		Port:        50211,
+		RequiresTls: true,
+		BlockNode:   &blockNodeJSON{EndpointApis: []string{"PUBLISH", "STATUS"}},
+	})
+	require.NoError(t, err)
+
+	block, ok := ep.(*BlockNodeServiceEndpoint)
+	require.True(t, ok, "expected *BlockNodeServiceEndpoint")
+	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), net.IP(block.GetIPAddress()))
+	assert.Equal(t, uint32(50211), block.GetPort())
+	assert.True(t, block.GetRequiresTls())
+	assert.Equal(t, []BlockNodeApi{BlockNodeApiPublish, BlockNodeApiStatus}, block.GetEndpointApis())
+}
+
+func TestUnitServiceEndpointFromJSONMirrorNode(t *testing.T) {
+	t.Parallel()
+
+	domain := "mirror.example.com"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:       "MIRROR_NODE",
+		DomainName: &domain,
+		Port:       443,
+	})
+	require.NoError(t, err)
+
+	mirror, ok := ep.(*MirrorNodeServiceEndpoint)
+	require.True(t, ok, "expected *MirrorNodeServiceEndpoint")
+	assert.Equal(t, "mirror.example.com", mirror.GetDomainName())
+	assert.Equal(t, uint32(443), mirror.GetPort())
+}
+
+func TestUnitServiceEndpointFromJSONRpcRelay(t *testing.T) {
+	t.Parallel()
+
+	domain := "rpc.example.com"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:       "RPC_RELAY",
+		DomainName: &domain,
+		Port:       8545,
+	})
+	require.NoError(t, err)
+
+	rpc, ok := ep.(*RpcRelayServiceEndpoint)
+	require.True(t, ok, "expected *RpcRelayServiceEndpoint")
+	assert.Equal(t, "rpc.example.com", rpc.GetDomainName())
+	assert.Equal(t, uint32(8545), rpc.GetPort())
+}
+
+func TestUnitServiceEndpointFromJSONUnknownType(t *testing.T) {
+	t.Parallel()
+
+	domain := "x.example.com"
+	_, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:       "SOMETHING_ELSE",
+		DomainName: &domain,
+		Port:       80,
+	})
+	assert.ErrorContains(t, err, "unknown endpoint type")
+}
+
+func TestUnitServiceEndpointFromJSONIPv6(t *testing.T) {
+	t.Parallel()
+
+	ip := "2001:db8::1"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:      "MIRROR_NODE",
+		IPAddress: &ip,
+		Port:      443,
+	})
+	require.NoError(t, err)
+
+	mirror, ok := ep.(*MirrorNodeServiceEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, net.ParseIP(ip).To16(), net.IP(mirror.GetIPAddress()))
+}
+
+func TestUnitServiceEndpointFromJSONInvalidIP(t *testing.T) {
+	t.Parallel()
+
+	ip := "not-an-ip"
+	_, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:      "MIRROR_NODE",
+		IPAddress: &ip,
+		Port:      443,
+	})
+	assert.ErrorContains(t, err, "invalid IP address")
+}
+
+func TestUnitRegisteredNodeFromJSON(t *testing.T) {
+	t.Parallel()
+
+	priv, err := PrivateKeyFromString(mockPrivateKey)
+	require.NoError(t, err)
+	pub := priv.PublicKey().String()
+
+	ip := "10.0.0.1"
+	domain := "rpc.example.com"
+	raw := registeredNodeJSON{
+		AdminKey:         &adminKeyJSON{Type: "ED25519", Key: pub},
+		CreatedTimestamp: "1700000000.000000000",
+		Description:      "node description",
+		RegisteredNodeID: 7,
+		ServiceEndpoints: []serviceEndpointJSON{
+			{
+				Type:      "BLOCK_NODE",
+				IPAddress: &ip,
+				Port:      50211,
+				BlockNode: &blockNodeJSON{EndpointApis: []string{"PUBLISH"}},
+			},
+			{
+				Type:       "RPC_RELAY",
+				DomainName: &domain,
+				Port:       8545,
+			},
+		},
+	}
+
+	node, err := registeredNodeFromJSON(raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, "node description", node.Description)
+	assert.Equal(t, uint64(7), node.RegisteredNodeID)
+	assert.Equal(t, "1700000000.000000000", node.CreatedTimestamp)
+	require.NotNil(t, node.AdminKey)
+	assert.Equal(t, pub, node.AdminKey.(PublicKey).String())
+	require.Len(t, node.ServiceEndpoints, 2)
+
+	_, isBlock := node.ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
+	assert.True(t, isBlock)
+	_, isRpc := node.ServiceEndpoints[1].(*RpcRelayServiceEndpoint)
+	assert.True(t, isRpc)
+}
+
+func TestUnitRegisteredNodeFromJSONPropagatesEndpointError(t *testing.T) {
+	t.Parallel()
+
+	ip := "bad-ip"
+	raw := registeredNodeJSON{
+		RegisteredNodeID: 1,
+		ServiceEndpoints: []serviceEndpointJSON{
+			{Type: "MIRROR_NODE", IPAddress: &ip, Port: 443},
+		},
+	}
+
+	_, err := registeredNodeFromJSON(raw)
+	assert.ErrorContains(t, err, "failed to parse service endpoint")
+}

--- a/sdk/registered_node_address_book_query_unit_test.go
+++ b/sdk/registered_node_address_book_query_unit_test.go
@@ -6,28 +6,38 @@ package hiero
 
 import (
 	"net"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnitRegisteredNodeAddressBookQuerySetterChaining(t *testing.T) {
+// ----- setters / getters -----
+
+func TestUnitRegisteredNodeAddressBookQuerySettersChain(t *testing.T) {
 	t.Parallel()
 
 	q := NewRegisteredNodeAddressBookQuery()
 	require.NotNil(t, q)
 
-	result := q.SetRegisteredNodeId(42)
-	assert.Same(t, q, result, "SetRegisteredNodeId should return the same query for chaining")
+	assert.Same(t, q, q.SetRegisteredNodeId(42))
 	assert.Equal(t, uint64(42), q.GetRegisteredNodeId())
+
+	assert.Same(t, q, q.SetLimit(50))
+	assert.Equal(t, int32(50), q.GetLimit())
+
+	assert.Same(t, q, q.SetMaxAttempts(3))
+	assert.Equal(t, uint64(3), q.GetMaxAttempts())
 }
 
-func TestUnitRegisteredNodeAddressBookQueryGetRegisteredNodeIdDefault(t *testing.T) {
+func TestUnitRegisteredNodeAddressBookQueryDefaults(t *testing.T) {
 	t.Parallel()
 
 	q := NewRegisteredNodeAddressBookQuery()
-	assert.Equal(t, uint64(0), q.GetRegisteredNodeId(), "unset ID should default to 0")
+	assert.Equal(t, uint64(0), q.GetRegisteredNodeId())
+	assert.Equal(t, int32(0), q.GetLimit())
+	assert.Equal(t, uint64(0), q.GetMaxAttempts())
 }
 
 func TestUnitRegisteredNodeAddressBookQueryExecuteNilClient(t *testing.T) {
@@ -37,6 +47,89 @@ func TestUnitRegisteredNodeAddressBookQueryExecuteNilClient(t *testing.T) {
 	assert.Equal(t, errNoClientProvided, err)
 	assert.Equal(t, RegisteredNodeAddressBook{}, book)
 }
+
+// ----- buildURL -----
+
+func TestUnitRegisteredNodeAddressBookQueryBuildURL(t *testing.T) {
+	t.Parallel()
+
+	id := uint64(7)
+	tests := []struct {
+		name string
+		q    *RegisteredNodeAddressBookQuery
+		want string
+	}{
+		{
+			name: "no params",
+			q:    &RegisteredNodeAddressBookQuery{},
+			want: "https://example/api/v1/network/registered-nodes",
+		},
+		{
+			name: "id only",
+			q:    &RegisteredNodeAddressBookQuery{registeredNodeId: &id},
+			want: "https://example/api/v1/network/registered-nodes?registerednode.id=7",
+		},
+		{
+			name: "limit only",
+			q:    &RegisteredNodeAddressBookQuery{limit: 25},
+			want: "https://example/api/v1/network/registered-nodes?limit=25",
+		},
+		{
+			name: "id and limit",
+			q:    &RegisteredNodeAddressBookQuery{registeredNodeId: &id, limit: 25},
+			want: "https://example/api/v1/network/registered-nodes?limit=25&registerednode.id=7",
+		},
+		{
+			name: "limit zero is omitted",
+			q:    &RegisteredNodeAddressBookQuery{registeredNodeId: &id, limit: 0},
+			want: "https://example/api/v1/network/registered-nodes?registerednode.id=7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.q.buildURL("https://example/api/v1"))
+		})
+	}
+}
+
+// ----- resolveNextURL -----
+
+func TestUnitResolveNextURL(t *testing.T) {
+	t.Parallel()
+
+	base, err := url.Parse("https://mirror.example/api/v1")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		next string
+		want string
+	}{
+		{
+			name: "absolute path replaces base path",
+			next: "/api/v1/network/registered-nodes?limit=25&registerednode.id=gt:5",
+			want: "https://mirror.example/api/v1/network/registered-nodes?limit=25&registerednode.id=gt:5",
+		},
+		{
+			name: "absolute URL passes through",
+			next: "https://other.example/api/v1/network/registered-nodes?limit=25",
+			want: "https://other.example/api/v1/network/registered-nodes?limit=25",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveNextURL(base, tt.next)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ----- blockNodeApiFromString -----
 
 func TestUnitBlockNodeApiFromString(t *testing.T) {
 	t.Parallel()
@@ -52,13 +145,15 @@ func TestUnitBlockNodeApiFromString(t *testing.T) {
 		{"OTHER", BlockNodeApiOther},
 		{"unrecognised", BlockNodeApiOther},
 		{"", BlockNodeApiOther},
-		{"status", BlockNodeApiStatus}, // lower-case should still match
+		{"status", BlockNodeApiStatus},
 	}
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, blockNodeApiFromString(tt.in), "input %q", tt.in)
 	}
 }
+
+// ----- adminKeyFromJSON -----
 
 func TestUnitAdminKeyFromJSONEd25519(t *testing.T) {
 	t.Parallel()
@@ -69,7 +164,6 @@ func TestUnitAdminKeyFromJSONEd25519(t *testing.T) {
 
 	key, err := adminKeyFromJSON(adminKeyJSON{Type: "ED25519", Key: pub})
 	require.NoError(t, err)
-	require.NotNil(t, key)
 	assert.Equal(t, pub, key.(PublicKey).String())
 }
 
@@ -85,12 +179,26 @@ func TestUnitAdminKeyFromJSONEcdsa(t *testing.T) {
 	require.NotNil(t, key)
 }
 
-func TestUnitAdminKeyFromJSONInvalid(t *testing.T) {
+func TestUnitAdminKeyFromJSONDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	priv, err := PrivateKeyFromString(mockPrivateKey)
+	require.NoError(t, err)
+	pub := priv.PublicKey().String()
+
+	key, err := adminKeyFromJSON(adminKeyJSON{Type: "MYSTERY", Key: pub})
+	require.NoError(t, err)
+	require.NotNil(t, key)
+}
+
+func TestUnitAdminKeyFromJSONInvalidKey(t *testing.T) {
 	t.Parallel()
 
 	_, err := adminKeyFromJSON(adminKeyJSON{Type: "ED25519", Key: "not-a-key"})
 	assert.Error(t, err)
 }
+
+// ----- serviceEndpointFromJSON -----
 
 func TestUnitServiceEndpointFromJSONBlockNode(t *testing.T) {
 	t.Parallel()
@@ -105,15 +213,33 @@ func TestUnitServiceEndpointFromJSONBlockNode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	block, ok := ep.(*BlockNodeServiceEndpoint)
+	bn, ok := ep.(*BlockNodeServiceEndpoint)
 	require.True(t, ok, "expected *BlockNodeServiceEndpoint")
-	assert.Equal(t, net.IPv4(192, 168, 1, 1).To4(), net.IP(block.GetIPAddress()))
-	assert.Equal(t, uint32(50211), block.GetPort())
-	assert.True(t, block.GetRequiresTls())
-	assert.Equal(t, []BlockNodeApi{BlockNodeApiPublish, BlockNodeApiStatus}, block.GetEndpointApis())
+	assert.Equal(t, []byte(net.ParseIP(ip).To4()), bn.GetIPAddress())
+	assert.Equal(t, uint32(50211), bn.GetPort())
+	assert.True(t, bn.GetRequiresTls())
+	assert.Equal(t, []BlockNodeApi{BlockNodeApiPublish, BlockNodeApiStatus}, bn.GetEndpointApis())
 }
 
-func TestUnitServiceEndpointFromJSONMirrorNode(t *testing.T) {
+func TestUnitServiceEndpointFromJSONMirrorNodeIPv4(t *testing.T) {
+	t.Parallel()
+
+	ip := "10.0.0.1"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:      "MIRROR_NODE",
+		IPAddress: &ip,
+		Port:      443,
+	})
+	require.NoError(t, err)
+
+	mn, ok := ep.(*MirrorNodeServiceEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, []byte(net.ParseIP(ip).To4()), mn.GetIPAddress())
+	assert.Equal(t, uint32(443), mn.GetPort())
+	assert.Empty(t, mn.GetDomainName())
+}
+
+func TestUnitServiceEndpointFromJSONMirrorNodeDomain(t *testing.T) {
 	t.Parallel()
 
 	domain := "mirror.example.com"
@@ -124,39 +250,61 @@ func TestUnitServiceEndpointFromJSONMirrorNode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mirror, ok := ep.(*MirrorNodeServiceEndpoint)
-	require.True(t, ok, "expected *MirrorNodeServiceEndpoint")
-	assert.Equal(t, "mirror.example.com", mirror.GetDomainName())
-	assert.Equal(t, uint32(443), mirror.GetPort())
+	mn, ok := ep.(*MirrorNodeServiceEndpoint)
+	require.True(t, ok)
+	assert.Empty(t, mn.GetIPAddress())
+	assert.Equal(t, domain, mn.GetDomainName())
 }
 
 func TestUnitServiceEndpointFromJSONRpcRelay(t *testing.T) {
 	t.Parallel()
 
-	domain := "rpc.example.com"
+	domain := "relay.example.com"
 	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
 		Type:       "RPC_RELAY",
 		DomainName: &domain,
-		Port:       8545,
+		Port:       7546,
 	})
 	require.NoError(t, err)
 
-	rpc, ok := ep.(*RpcRelayServiceEndpoint)
-	require.True(t, ok, "expected *RpcRelayServiceEndpoint")
-	assert.Equal(t, "rpc.example.com", rpc.GetDomainName())
-	assert.Equal(t, uint32(8545), rpc.GetPort())
+	rr, ok := ep.(*RpcRelayServiceEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, domain, rr.GetDomainName())
+	assert.Equal(t, uint32(7546), rr.GetPort())
 }
 
-func TestUnitServiceEndpointFromJSONUnknownType(t *testing.T) {
+func TestUnitServiceEndpointFromJSONGeneralService(t *testing.T) {
 	t.Parallel()
 
-	domain := "x.example.com"
-	_, err := serviceEndpointFromJSON(serviceEndpointJSON{
-		Type:       "SOMETHING_ELSE",
-		DomainName: &domain,
-		Port:       80,
+	domain := "general.example.com"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:           "GENERAL_SERVICE",
+		DomainName:     &domain,
+		Port:           9000,
+		GeneralService: &generalServiceJSON{Description: "custom-service"},
 	})
-	assert.ErrorContains(t, err, "unknown endpoint type")
+	require.NoError(t, err)
+
+	gs, ok := ep.(*GeneralServiceEndpoint)
+	require.True(t, ok)
+	assert.Equal(t, domain, gs.GetDomainName())
+	assert.Equal(t, "custom-service", gs.GetDescription())
+}
+
+func TestUnitServiceEndpointFromJSONGeneralServiceMissingNested(t *testing.T) {
+	t.Parallel()
+
+	domain := "general.example.com"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:       "GENERAL_SERVICE",
+		DomainName: &domain,
+		Port:       9000,
+	})
+	require.NoError(t, err)
+
+	gs, ok := ep.(*GeneralServiceEndpoint)
+	require.True(t, ok)
+	assert.Empty(t, gs.GetDescription())
 }
 
 func TestUnitServiceEndpointFromJSONIPv6(t *testing.T) {
@@ -170,79 +318,29 @@ func TestUnitServiceEndpointFromJSONIPv6(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mirror, ok := ep.(*MirrorNodeServiceEndpoint)
-	require.True(t, ok)
-	assert.Equal(t, net.ParseIP(ip).To16(), net.IP(mirror.GetIPAddress()))
+	got := ep.GetIPAddress()
+	require.Len(t, got, 16, "IPv6 should be 16 bytes")
+	assert.Equal(t, []byte(net.ParseIP(ip).To16()), got)
 }
 
 func TestUnitServiceEndpointFromJSONInvalidIP(t *testing.T) {
 	t.Parallel()
 
-	ip := "not-an-ip"
+	bad := "not-an-ip"
 	_, err := serviceEndpointFromJSON(serviceEndpointJSON{
 		Type:      "MIRROR_NODE",
-		IPAddress: &ip,
+		IPAddress: &bad,
 		Port:      443,
 	})
-	assert.ErrorContains(t, err, "invalid IP address")
+	assert.Error(t, err)
 }
 
-func TestUnitRegisteredNodeFromJSON(t *testing.T) {
+func TestUnitServiceEndpointFromJSONUnknownType(t *testing.T) {
 	t.Parallel()
 
-	priv, err := PrivateKeyFromString(mockPrivateKey)
-	require.NoError(t, err)
-	pub := priv.PublicKey().String()
-
-	ip := "10.0.0.1"
-	domain := "rpc.example.com"
-	raw := registeredNodeJSON{
-		AdminKey:         &adminKeyJSON{Type: "ED25519", Key: pub},
-		CreatedTimestamp: "1700000000.000000000",
-		Description:      "node description",
-		RegisteredNodeID: 7,
-		ServiceEndpoints: []serviceEndpointJSON{
-			{
-				Type:      "BLOCK_NODE",
-				IPAddress: &ip,
-				Port:      50211,
-				BlockNode: &blockNodeJSON{EndpointApis: []string{"PUBLISH"}},
-			},
-			{
-				Type:       "RPC_RELAY",
-				DomainName: &domain,
-				Port:       8545,
-			},
-		},
-	}
-
-	node, err := registeredNodeFromJSON(raw)
-	require.NoError(t, err)
-
-	assert.Equal(t, "node description", node.Description)
-	assert.Equal(t, uint64(7), node.RegisteredNodeID)
-	assert.Equal(t, "1700000000.000000000", node.CreatedTimestamp)
-	require.NotNil(t, node.AdminKey)
-	assert.Equal(t, pub, node.AdminKey.(PublicKey).String())
-	require.Len(t, node.ServiceEndpoints, 2)
-
-	_, isBlock := node.ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
-	assert.True(t, isBlock)
-	_, isRpc := node.ServiceEndpoints[1].(*RpcRelayServiceEndpoint)
-	assert.True(t, isRpc)
-}
-
-func TestUnitRegisteredNodeFromJSONPropagatesEndpointError(t *testing.T) {
-	t.Parallel()
-
-	ip := "bad-ip"
-	raw := registeredNodeJSON{
-		RegisteredNodeID: 1,
-		ServiceEndpoints: []serviceEndpointJSON{
-			{Type: "MIRROR_NODE", IPAddress: &ip, Port: 443},
-		},
-	}
-
-	_, err := registeredNodeFromJSON(raw)
-	assert.ErrorContains(t, err, "failed to parse service endpoint")
+	_, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type: "MYSTERY",
+		Port: 443,
+	})
+	assert.Error(t, err)
 }

--- a/sdk/registered_node_address_book_query_unit_test.go
+++ b/sdk/registered_node_address_book_query_unit_test.go
@@ -344,3 +344,61 @@ func TestUnitServiceEndpointFromJSONUnknownType(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestUnitServiceEndpointFromJSONBlockNodeMissingNested(t *testing.T) {
+	t.Parallel()
+
+	ip := "10.0.0.1"
+	ep, err := serviceEndpointFromJSON(serviceEndpointJSON{
+		Type:      "BLOCK_NODE",
+		IPAddress: &ip,
+		Port:      50211,
+	})
+	require.NoError(t, err)
+
+	bn, ok := ep.(*BlockNodeServiceEndpoint)
+	require.True(t, ok)
+	assert.Empty(t, bn.GetEndpointApis())
+}
+
+// ----- registeredNodeFromJSON -----
+
+func TestUnitRegisteredNodeFromJSONBadAdminKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := registeredNodeFromJSON(registeredNodeJSON{
+		AdminKey:         &adminKeyJSON{Type: "ED25519", Key: "not-a-key"},
+		RegisteredNodeID: 1,
+	})
+	assert.Error(t, err)
+}
+
+// ----- resolveAttempts / Execute precondition guards -----
+
+func TestUnitResolveAttempts(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	q := NewRegisteredNodeAddressBookQuery()
+	assert.Equal(t, uint64(1), q.resolveAttempts(client), "fallback to 1 when neither is set")
+
+	client.SetMaxAttempts(7)
+	assert.Equal(t, uint64(7), q.resolveAttempts(client), "uses client default when query unset")
+
+	q.SetMaxAttempts(3)
+	assert.Equal(t, uint64(3), q.resolveAttempts(client), "query setting wins over client")
+}
+
+func TestUnitRegisteredNodeAddressBookQueryExecuteNoMirror(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetMirrorNetwork(nil)
+
+	_, err = NewRegisteredNodeAddressBookQuery().Execute(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mirror node is not set")
+}

--- a/sdk/registered_node_address_book_query_unit_test.go
+++ b/sdk/registered_node_address_book_query_unit_test.go
@@ -131,25 +131,44 @@ func TestUnitResolveNextURL(t *testing.T) {
 
 // ----- blockNodeApiFromString -----
 
-func TestUnitBlockNodeApiFromString(t *testing.T) {
+func TestUnitBlockNodeApiFromStringRecognized(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		in   string
 		want BlockNodeApi
 	}{
+		{"OTHER", BlockNodeApiOther},
 		{"STATUS", BlockNodeApiStatus},
 		{"PUBLISH", BlockNodeApiPublish},
 		{"SUBSCRIBE_STREAM", BlockNodeApiSubscribeStream},
 		{"STATE_PROOF", BlockNodeApiStateProof},
-		{"OTHER", BlockNodeApiOther},
-		{"unrecognised", BlockNodeApiOther},
-		{"", BlockNodeApiOther},
 		{"status", BlockNodeApiStatus},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, blockNodeApiFromString(tt.in), "input %q", tt.in)
+		got, err := blockNodeApiFromString(tt.in)
+		require.NoError(t, err, "input %q", tt.in)
+		assert.Equal(t, tt.want, got, "input %q", tt.in)
+	}
+}
+
+func TestUnitBlockNodeApiFromStringRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		// "UNKNOWN" only ever appears when BlockNodeApi.String() was called on
+		// a value the SDK could not name, so seeing it on the way back in
+		// signals a corrupt round-trip.
+		"UNKNOWN",
+		"UNRECOGNIZED",
+		"FUTURE_KIND",
+		"",
+	}
+
+	for _, in := range cases {
+		_, err := blockNodeApiFromString(in)
+		assert.Error(t, err, "input %q should error", in)
 	}
 }
 

--- a/sdk/registered_node_create_transaction.go
+++ b/sdk/registered_node_create_transaction.go
@@ -6,7 +6,16 @@ import (
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 )
 
-// RegisteredNodeCreateTransaction creates a new registered node in the network address book.
+/**
+ * A transaction to create a new registered node in the network
+ * address book.
+ *
+ * This transaction, once complete, SHALL add a new registered node to the
+ * network state.
+ * The new registered node SHALL be visible and discoverable upon
+ * completion of this transaction.
+ *
+ */
 type RegisteredNodeCreateTransaction struct {
 	*Transaction[*RegisteredNodeCreateTransaction]
 	adminKey         Key

--- a/sdk/registered_node_create_transaction.go
+++ b/sdk/registered_node_create_transaction.go
@@ -1,0 +1,145 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// RegisteredNodeCreateTransaction creates a new registered node in the network address book.
+type RegisteredNodeCreateTransaction struct {
+	*Transaction[*RegisteredNodeCreateTransaction]
+	adminKey         Key
+	description      string
+	serviceEndpoints []RegisteredServiceEndpoint
+}
+
+// NewRegisteredNodeCreateTransaction creates a new RegisteredNodeCreateTransaction.
+func NewRegisteredNodeCreateTransaction() *RegisteredNodeCreateTransaction {
+	tx := &RegisteredNodeCreateTransaction{}
+	tx.Transaction = _NewTransaction(tx)
+	return tx
+}
+
+func _RegisteredNodeCreateTransactionFromProtobuf(tx Transaction[*RegisteredNodeCreateTransaction], pb *services.TransactionBody) RegisteredNodeCreateTransaction {
+	var adminKey Key
+	if pb.GetRegisteredNodeCreate().GetAdminKey() != nil {
+		adminKey, _ = _KeyFromProtobuf(pb.GetRegisteredNodeCreate().GetAdminKey())
+	}
+
+	serviceEndpoints := make([]RegisteredServiceEndpoint, 0)
+	for _, endpoint := range pb.GetRegisteredNodeCreate().GetServiceEndpoint() {
+		serviceEndpoints = append(serviceEndpoints, _RegisteredServiceEndpointFromProtobuf(endpoint))
+	}
+
+	registeredNodeCreateTransaction := RegisteredNodeCreateTransaction{
+		adminKey:         adminKey,
+		description:      pb.GetRegisteredNodeCreate().GetDescription(),
+		serviceEndpoints: serviceEndpoints,
+	}
+
+	tx.childTransaction = &registeredNodeCreateTransaction
+	registeredNodeCreateTransaction.Transaction = &tx
+	return registeredNodeCreateTransaction
+}
+
+// SetAdminKey sets the administrative key for the registered node.
+func (tx *RegisteredNodeCreateTransaction) SetAdminKey(key Key) *RegisteredNodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.adminKey = key
+	return tx
+}
+
+// GetAdminKey returns the administrative key for the registered node.
+func (tx *RegisteredNodeCreateTransaction) GetAdminKey() Key {
+	return tx.adminKey
+}
+
+// SetDescription sets the description for the registered node.
+func (tx *RegisteredNodeCreateTransaction) SetDescription(description string) *RegisteredNodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.description = description
+	return tx
+}
+
+// GetDescription returns the description for the registered node.
+func (tx *RegisteredNodeCreateTransaction) GetDescription() string {
+	return tx.description
+}
+
+// SetServiceEndpoints sets the service endpoints for the registered node.
+func (tx *RegisteredNodeCreateTransaction) SetServiceEndpoints(endpoints []RegisteredServiceEndpoint) *RegisteredNodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.serviceEndpoints = endpoints
+	return tx
+}
+
+// GetServiceEndpoints returns the service endpoints for the registered node.
+func (tx *RegisteredNodeCreateTransaction) GetServiceEndpoints() []RegisteredServiceEndpoint {
+	return tx.serviceEndpoints
+}
+
+// AddServiceEndpoint adds a service endpoint to the registered node.
+func (tx *RegisteredNodeCreateTransaction) AddServiceEndpoint(endpoint RegisteredServiceEndpoint) *RegisteredNodeCreateTransaction {
+	tx._RequireNotFrozen()
+	tx.serviceEndpoints = append(tx.serviceEndpoints, endpoint)
+	return tx
+}
+
+// ----------- Overridden functions ----------------
+
+func (tx RegisteredNodeCreateTransaction) getName() string {
+	return "RegisteredNodeCreateTransaction"
+}
+
+func (tx RegisteredNodeCreateTransaction) validateNetworkOnIDs(_ *Client) error {
+	return nil
+}
+
+func (tx RegisteredNodeCreateTransaction) build() *services.TransactionBody {
+	body := tx.buildTransactionBody()
+	body.Data = &services.TransactionBody_RegisteredNodeCreate{
+		RegisteredNodeCreate: tx.buildProtoBody(),
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeCreateTransaction) buildScheduled() (*services.SchedulableTransactionBody, error) {
+	body := tx.buildSchedulableTransactionBody()
+	body.Data = &services.SchedulableTransactionBody_RegisteredNodeCreate{
+		RegisteredNodeCreate: tx.buildProtoBody(),
+	}
+
+	return body, nil
+}
+
+func (tx RegisteredNodeCreateTransaction) buildProtoBody() *services.RegisteredNodeCreateTransactionBody {
+	body := &services.RegisteredNodeCreateTransactionBody{
+		Description: tx.description,
+	}
+
+	if tx.adminKey != nil {
+		body.AdminKey = tx.adminKey._ToProtoKey()
+	}
+
+	for _, endpoint := range tx.serviceEndpoints {
+		body.ServiceEndpoint = append(body.ServiceEndpoint, endpoint._ToProtobuf())
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeCreateTransaction) getMethod(channel *_Channel) _Method {
+	return _Method{
+		transaction: channel._GetAddressBook().CreateRegisteredNode,
+	}
+}
+
+func (tx RegisteredNodeCreateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
+	return tx.buildScheduled()
+}
+
+func (tx RegisteredNodeCreateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
+	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
+}

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -1,0 +1,295 @@
+//go:build all || e2e
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationRegisteredNodeCreateTransactionCanExecute(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build a block node service endpoint with an IPv4 address
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).
+		SetPort(50211)
+	endpoint.SetEndpointApi(BlockNodeApiPublish)
+
+	// Execute the RegisteredNodeCreateTransaction
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription("e2e test registered node").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build a mirror node service endpoint
+	endpoint := &MirrorNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(443)
+
+	// Execute the RegisteredNodeCreateTransaction
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build an RPC relay service endpoint
+	endpoint := &RpcRelayServiceEndpoint{}
+	endpoint.SetDomainName("rpc.example.com").SetPort(8545)
+
+	// Execute the RegisteredNodeCreateTransaction
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build a block node service endpoint
+	blockEndpoint := &BlockNodeServiceEndpoint{}
+	blockEndpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
+	blockEndpoint.SetEndpointApi(BlockNodeApiPublish)
+
+	// Build a mirror node service endpoint
+	mirrorEndpoint := &MirrorNodeServiceEndpoint{}
+	mirrorEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(443)
+
+	// Build an RPC relay service endpoint
+	rpcEndpoint := &RpcRelayServiceEndpoint{}
+	rpcEndpoint.SetDomainName("rpc.example.com").SetPort(8545)
+
+	// Execute the RegisteredNodeCreateTransaction with all three endpoint types
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{blockEndpoint, mirrorEndpoint, rpcEndpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionWithDescriptionSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build a block node service endpoint
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
+	endpoint.SetEndpointApi(BlockNodeApiPublish)
+
+	description := "e2e test registered node with description"
+
+	// Execute the RegisteredNodeCreateTransaction with a description
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription(description).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionFailsIfNoAdminKeySet(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Build a block node service endpoint
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
+	endpoint.SetEndpointApi(BlockNodeApiPublish)
+
+	// Execute the RegisteredNodeCreateTransaction without an admin key
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	_, err = tx.Execute(client)
+	require.ErrorContains(t, err, "KEY_REQUIRED")
+}
+
+func TestIntegrationRegisteredNodeCreateTransactionFailsIfEmptyEndpoints(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Execute the RegisteredNodeCreateTransaction with empty service endpoints
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	_, err = tx.Sign(adminKey).Execute(client)
+	require.ErrorContains(t, err, "INVALID_REGISTERED_ENDPOINT")
+}

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -142,6 +142,50 @@ func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *t
 	t.Log(receipt)
 }
 
+func TestIntegrationRegisteredNodeCreateTransactionGeneralServiceEndpointSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Set the network
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	// Set the operator to be account 0.0.2
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Generate admin key
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	// Build a general service endpoint with a description
+	endpoint := &GeneralServiceEndpoint{}
+	endpoint.SetDomainName("general.example.com").
+		SetPort(9000).
+		SetDescription("custom-service")
+
+	// Execute the RegisteredNodeCreateTransaction
+	tx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	resp, err := tx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Verify the receipt contains a non-zero registeredNodeId
+	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	t.Log(receipt.RegisteredNodeId)
+}
+
 func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *testing.T) {
 	t.Parallel()
 
@@ -175,10 +219,16 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 	rpcEndpoint := &RpcRelayServiceEndpoint{}
 	rpcEndpoint.SetDomainName("rpc.example.com").SetPort(8545)
 
-	// Execute the RegisteredNodeCreateTransaction with all three endpoint types
+	// Build a general service endpoint
+	generalEndpoint := &GeneralServiceEndpoint{}
+	generalEndpoint.SetDomainName("general.example.com").
+		SetPort(9000).
+		SetDescription("custom-service")
+
+	// Execute the RegisteredNodeCreateTransaction with all four endpoint types
 	tx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(adminKey).
-		SetServiceEndpoints([]RegisteredServiceEndpoint{blockEndpoint, mirrorEndpoint, rpcEndpoint}).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{blockEndpoint, mirrorEndpoint, rpcEndpoint, generalEndpoint}).
 		FreezeWith(client)
 	require.NoError(t, err)
 

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -35,7 +35,7 @@ func TestIntegrationRegisteredNodeCreateTransactionCanExecute(t *testing.T) {
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).
 		SetPort(50211)
-	endpoint.SetEndpointApi(BlockNodeApiPublish)
+	endpoint.AddEndpointApi(BlockNodeApiPublish)
 
 	// Execute the RegisteredNodeCreateTransaction
 	tx, err := NewRegisteredNodeCreateTransaction().
@@ -53,6 +53,7 @@ func TestIntegrationRegisteredNodeCreateTransactionCanExecute(t *testing.T) {
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	t.Log(receipt.RegisteredNodeId)
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t *testing.T) {
@@ -94,6 +95,8 @@ func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t 
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	t.Log(receipt.RegisteredNodeId)
+	t.Log(receipt)
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *testing.T) {
@@ -135,6 +138,8 @@ func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *t
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	t.Log(receipt.RegisteredNodeId)
+	t.Log(receipt)
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *testing.T) {
@@ -160,7 +165,7 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 	// Build a block node service endpoint
 	blockEndpoint := &BlockNodeServiceEndpoint{}
 	blockEndpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
-	blockEndpoint.SetEndpointApi(BlockNodeApiPublish)
+	blockEndpoint.AddEndpointApi(BlockNodeApiPublish)
 
 	// Build a mirror node service endpoint
 	mirrorEndpoint := &MirrorNodeServiceEndpoint{}
@@ -210,7 +215,7 @@ func TestIntegrationRegisteredNodeCreateTransactionWithDescriptionSucceeds(t *te
 	// Build a block node service endpoint
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
-	endpoint.SetEndpointApi(BlockNodeApiPublish)
+	endpoint.AddEndpointApi(BlockNodeApiPublish)
 
 	description := "e2e test registered node with description"
 
@@ -251,7 +256,7 @@ func TestIntegrationRegisteredNodeCreateTransactionFailsIfNoAdminKeySet(t *testi
 	// Build a block node service endpoint
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
-	endpoint.SetEndpointApi(BlockNodeApiPublish)
+	endpoint.AddEndpointApi(BlockNodeApiPublish)
 
 	// Execute the RegisteredNodeCreateTransaction without an admin key
 	tx, err := NewRegisteredNodeCreateTransaction().

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -52,19 +52,19 @@ func TestIntegrationRegisteredNodeCreateTransactionCanExecute(t *testing.T) {
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify fields
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
 	require.Equal(t, "e2e test registered node", book.RegisteredNodes[0].Description)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
 
@@ -112,18 +112,18 @@ func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t 
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify the endpoint
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
 
@@ -170,18 +170,18 @@ func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *t
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify the endpoint
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
 
@@ -230,18 +230,18 @@ func TestIntegrationRegisteredNodeCreateTransactionGeneralServiceEndpointSucceed
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify the endpoint
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
 
@@ -304,19 +304,19 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify all four endpoints
 	// come back in the order they were sent.
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 4)
 
@@ -384,18 +384,18 @@ func TestIntegrationRegisteredNodeCreateTransactionWithDescriptionSucceeds(t *te
 	receipt, err := resp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// Verify the receipt contains a non-zero registeredNodeId
-	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	// Verify the receipt contains a registered node ID
+	require.NotNil(t, receipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
 
 	time.Sleep(time.Second * 5)
 
 	// Query the registered node from the mirror node and verify the description
 	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		SetRegisteredNodeId(*receipt.RegisteredNodeId).
 		Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
-	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
 	require.Equal(t, description, book.RegisteredNodes[0].Description)
 	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 }

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -256,12 +256,9 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 	t.Parallel()
 
 	// Set the network
-	network := make(map[string]AccountID)
-	network["localhost:50211"] = AccountID{Account: 3}
-	client, err := ClientForNetworkV2(network)
+	client, err := ClientForNetworkV2(map[string]AccountID{"localhost:50211": {Account: 3}})
 	require.NoError(t, err)
-	mirror := []string{"localhost:5600"}
-	client.SetMirrorNetwork(mirror)
+	client.SetMirrorNetwork([]string{"localhost:5600"})
 
 	// Set the operator to be account 0.0.2
 	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
@@ -272,24 +269,11 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 	adminKey, err := PrivateKeyGenerateEd25519()
 	require.NoError(t, err)
 
-	// Build a block node service endpoint
-	blockEndpoint := &BlockNodeServiceEndpoint{}
-	blockEndpoint.SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211)
-	blockEndpoint.AddEndpointApi(BlockNodeApiPublish)
-
-	// Build a mirror node service endpoint
-	mirrorEndpoint := &MirrorNodeServiceEndpoint{}
-	mirrorEndpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(443)
-
-	// Build an RPC relay service endpoint
-	rpcEndpoint := &RpcRelayServiceEndpoint{}
-	rpcEndpoint.SetDomainName("rpc.example.com").SetPort(8545)
-
-	// Build a general service endpoint
-	generalEndpoint := &GeneralServiceEndpoint{}
-	generalEndpoint.SetDomainName("general.example.com").
-		SetPort(9000).
-		SetDescription("custom-service")
+	// Build one endpoint per kind: block node, mirror node, RPC relay, general service.
+	blockEndpoint := (&BlockNodeServiceEndpoint{}).SetIPAddress(net.IPv4(192, 168, 1, 1).To4()).SetPort(50211).AddEndpointApi(BlockNodeApiPublish)
+	mirrorEndpoint := (&MirrorNodeServiceEndpoint{}).SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(443)
+	rpcEndpoint := (&RpcRelayServiceEndpoint{}).SetDomainName("rpc.example.com").SetPort(8545)
+	generalEndpoint := (&GeneralServiceEndpoint{}).SetDomainName("general.example.com").SetPort(9000).SetDescription("custom-service")
 
 	// Execute the RegisteredNodeCreateTransaction with all four endpoint types
 	tx, err := NewRegisteredNodeCreateTransaction().
@@ -311,9 +295,7 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 
 	// Query the registered node from the mirror node and verify all four endpoints
 	// come back in the order they were sent.
-	book, err := NewRegisteredNodeAddressBookQuery().
-		SetRegisteredNodeId(*receipt.RegisteredNodeId).
-		Execute(client)
+	book, err := NewRegisteredNodeAddressBookQuery().SetRegisteredNodeId(*receipt.RegisteredNodeId).Execute(client)
 	require.NoError(t, err)
 	require.Len(t, book.RegisteredNodes, 1)
 	require.Equal(t, *receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)

--- a/sdk/registered_node_create_transaction_e2e_test.go
+++ b/sdk/registered_node_create_transaction_e2e_test.go
@@ -7,6 +7,7 @@ package hiero
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,25 @@ func TestIntegrationRegisteredNodeCreateTransactionCanExecute(t *testing.T) {
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	t.Log(receipt.RegisteredNodeId)
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify fields
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, "e2e test registered node", book.RegisteredNodes[0].Description)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
+	require.True(t, ok, "expected *BlockNodeServiceEndpoint")
+	require.Equal(t, net.IPv4(192, 168, 1, 1).To4(), net.IP(ep.GetIPAddress()))
+	require.Equal(t, uint32(50211), ep.GetPort())
+	require.Equal(t, []BlockNodeApi{BlockNodeApiPublish}, ep.GetEndpointApis())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t *testing.T) {
@@ -95,8 +114,23 @@ func TestIntegrationRegisteredNodeCreateTransactionMirrorNodeEndpointSucceeds(t 
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	t.Log(receipt.RegisteredNodeId)
-	t.Log(receipt)
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify the endpoint
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*MirrorNodeServiceEndpoint)
+	require.True(t, ok, "expected *MirrorNodeServiceEndpoint")
+	require.Equal(t, net.IPv4(10, 0, 0, 1).To4(), net.IP(ep.GetIPAddress()))
+	require.Equal(t, uint32(443), ep.GetPort())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *testing.T) {
@@ -138,8 +172,23 @@ func TestIntegrationRegisteredNodeCreateTransactionRpcRelayEndpointSucceeds(t *t
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	t.Log(receipt.RegisteredNodeId)
-	t.Log(receipt)
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify the endpoint
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*RpcRelayServiceEndpoint)
+	require.True(t, ok, "expected *RpcRelayServiceEndpoint")
+	require.Equal(t, "rpc.example.com", ep.GetDomainName())
+	require.Equal(t, uint32(8545), ep.GetPort())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionGeneralServiceEndpointSucceeds(t *testing.T) {
@@ -183,7 +232,24 @@ func TestIntegrationRegisteredNodeCreateTransactionGeneralServiceEndpointSucceed
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	t.Log(receipt.RegisteredNodeId)
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify the endpoint
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*GeneralServiceEndpoint)
+	require.True(t, ok, "expected *GeneralServiceEndpoint")
+	require.Equal(t, "general.example.com", ep.GetDomainName())
+	require.Equal(t, uint32(9000), ep.GetPort())
+	require.Equal(t, "custom-service", ep.GetDescription())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *testing.T) {
@@ -240,6 +306,41 @@ func TestIntegrationRegisteredNodeCreateTransactionMixedEndpointsSucceeds(t *tes
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify all four endpoints
+	// come back in the order they were sent.
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 4)
+
+	bn, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
+	require.True(t, ok, "expected *BlockNodeServiceEndpoint at index 0")
+	require.Equal(t, net.IPv4(192, 168, 1, 1).To4(), net.IP(bn.GetIPAddress()))
+	require.Equal(t, uint32(50211), bn.GetPort())
+	require.Equal(t, []BlockNodeApi{BlockNodeApiPublish}, bn.GetEndpointApis())
+
+	mn, ok := book.RegisteredNodes[0].ServiceEndpoints[1].(*MirrorNodeServiceEndpoint)
+	require.True(t, ok, "expected *MirrorNodeServiceEndpoint at index 1")
+	require.Equal(t, net.IPv4(10, 0, 0, 1).To4(), net.IP(mn.GetIPAddress()))
+	require.Equal(t, uint32(443), mn.GetPort())
+
+	rr, ok := book.RegisteredNodes[0].ServiceEndpoints[2].(*RpcRelayServiceEndpoint)
+	require.True(t, ok, "expected *RpcRelayServiceEndpoint at index 2")
+	require.Equal(t, "rpc.example.com", rr.GetDomainName())
+	require.Equal(t, uint32(8545), rr.GetPort())
+
+	gs, ok := book.RegisteredNodes[0].ServiceEndpoints[3].(*GeneralServiceEndpoint)
+	require.True(t, ok, "expected *GeneralServiceEndpoint at index 3")
+	require.Equal(t, "general.example.com", gs.GetDomainName())
+	require.Equal(t, uint32(9000), gs.GetPort())
+	require.Equal(t, "custom-service", gs.GetDescription())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionWithDescriptionSucceeds(t *testing.T) {
@@ -285,6 +386,18 @@ func TestIntegrationRegisteredNodeCreateTransactionWithDescriptionSucceeds(t *te
 
 	// Verify the receipt contains a non-zero registeredNodeId
 	require.Greater(t, receipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+
+	time.Sleep(time.Second * 5)
+
+	// Query the registered node from the mirror node and verify the description
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(receipt.RegisteredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, receipt.RegisteredNodeId, book.RegisteredNodes[0].RegisteredNodeID)
+	require.Equal(t, description, book.RegisteredNodes[0].Description)
+	require.Equal(t, adminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 }
 
 func TestIntegrationRegisteredNodeCreateTransactionFailsIfNoAdminKeySet(t *testing.T) {

--- a/sdk/registered_node_create_transaction_unit_test.go
+++ b/sdk/registered_node_create_transaction_unit_test.go
@@ -21,7 +21,7 @@ func TestUnitRegisteredNodeCreateTransactionBuild(t *testing.T) {
 			port:        8080,
 			requiresTls: true,
 		},
-		endpointApi: BlockNodeApiStatus,
+		endpointApis: []BlockNodeApi{BlockNodeApiStatus},
 	}
 
 	tx := NewRegisteredNodeCreateTransaction().

--- a/sdk/registered_node_create_transaction_unit_test.go
+++ b/sdk/registered_node_create_transaction_unit_test.go
@@ -1,0 +1,97 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitRegisteredNodeCreateTransactionBuild(t *testing.T) {
+	t.Parallel()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress:   []byte{10, 0, 0, 1},
+			port:        8080,
+			requiresTls: true,
+		},
+		endpointApi: BlockNodeApiStatus,
+	}
+
+	tx := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(key.PublicKey()).
+		SetDescription("Test Node").
+		AddServiceEndpoint(endpoint)
+
+	body := tx.buildProtoBody()
+	assert.NotNil(t, body.AdminKey)
+	assert.Equal(t, "Test Node", body.Description)
+	assert.Len(t, body.ServiceEndpoint, 1)
+}
+
+func TestUnitRegisteredNodeCreateTransactionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress:   []byte{192, 168, 1, 1},
+			port:        443,
+			requiresTls: true,
+		},
+	}
+
+	tx := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(key.PublicKey()).
+		SetDescription("My Node").
+		AddServiceEndpoint(endpoint)
+
+	body := tx.buildProtoBody()
+
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_RegisteredNodeCreate{
+			RegisteredNodeCreate: body,
+		},
+	}
+
+	restored := _RegisteredNodeCreateTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.Equal(t, "My Node", restored.GetDescription())
+	assert.Len(t, restored.GetServiceEndpoints(), 1)
+
+	_, ok := restored.GetServiceEndpoints()[0].(*MirrorNodeServiceEndpoint)
+	assert.True(t, ok, "expected *MirrorNodeServiceEndpoint after round-trip")
+}
+
+func TestUnitRegisteredNodeCreateTransactionGetMethod(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeCreateTransaction()
+	assert.Equal(t, "RegisteredNodeCreateTransaction", tx.getName())
+}
+
+func TestUnitRegisteredNodeCreateTransactionGettersSetters(t *testing.T) {
+	t.Parallel()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &RpcRelayServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName: "node.example.com",
+			port:       443,
+		},
+	}
+
+	tx := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(key.PublicKey()).
+		SetDescription("Test").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint})
+
+	assert.Equal(t, key.PublicKey(), tx.GetAdminKey())
+	assert.Equal(t, "Test", tx.GetDescription())
+	assert.Len(t, tx.GetServiceEndpoints(), 1)
+}

--- a/sdk/registered_node_create_transaction_unit_test.go
+++ b/sdk/registered_node_create_transaction_unit_test.go
@@ -156,7 +156,8 @@ func TestUnitRegisteredNodeCreateTransactionMock(t *testing.T) {
 
 	receipt, err := resp.GetReceipt(client)
 	require.NoError(t, err)
-	require.Equal(t, uint64(11), receipt.RegisteredNodeId)
+	require.NotNil(t, receipt.RegisteredNodeId)
+	require.Equal(t, uint64(11), *receipt.RegisteredNodeId)
 }
 
 func TestUnitRegisteredNodeCreateTransactionScheduledBuild(t *testing.T) {

--- a/sdk/registered_node_create_transaction_unit_test.go
+++ b/sdk/registered_node_create_transaction_unit_test.go
@@ -6,9 +6,11 @@ package hiero
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnitRegisteredNodeCreateTransactionBuild(t *testing.T) {
@@ -94,4 +96,165 @@ func TestUnitRegisteredNodeCreateTransactionGettersSetters(t *testing.T) {
 	assert.Equal(t, key.PublicKey(), tx.GetAdminKey())
 	assert.Equal(t, "Test", tx.GetDescription())
 	assert.Len(t, tx.GetServiceEndpoints(), 1)
+}
+
+func registeredNodeCreateMockResponses() [][]interface{} {
+	return [][]interface{}{{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_COST_ANSWER,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status:           services.ResponseCodeEnum_SUCCESS,
+						RegisteredNodeId: 11,
+					},
+				},
+			},
+		},
+	}}
+}
+
+func TestUnitRegisteredNodeCreateTransactionMock(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewMockClientAndServer(registeredNodeCreateMockResponses())
+	defer server.Close()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{10, 0, 0, 1},
+			port:      8080,
+		},
+		endpointApis: []BlockNodeApi{BlockNodeApiPublish},
+	}
+
+	tran := TransactionIDGenerate(AccountID{Account: 3})
+	resp, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(key.PublicKey()).
+		SetDescription("mock node").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		SetTransactionID(tran).
+		Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.GetReceipt(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), receipt.RegisteredNodeId)
+}
+
+func TestUnitRegisteredNodeCreateTransactionScheduledBuild(t *testing.T) {
+	t.Parallel()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{192, 168, 1, 1},
+			port:      443,
+		},
+	}
+
+	tx := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(key.PublicKey()).
+		SetDescription("scheduled").
+		AddServiceEndpoint(endpoint)
+
+	scheduled, err := tx.buildScheduled()
+	require.NoError(t, err)
+	require.NotNil(t, scheduled.GetRegisteredNodeCreate())
+
+	again, err := tx.constructScheduleProtobuf()
+	require.NoError(t, err)
+	require.NotNil(t, again.GetRegisteredNodeCreate())
+}
+
+func buildFrozenRegisteredNodeCreateTransaction(t *testing.T) (*RegisteredNodeCreateTransaction, *Client, PrivateKey) {
+	t.Helper()
+	nodeAccountID := []AccountID{{Account: 10}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	client, err := _NewMockClient()
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	require.NoError(t, err)
+	client.SetAutoValidateChecksums(true)
+
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{10, 0, 0, 1},
+			port:      8080,
+		},
+		endpointApis: []BlockNodeApi{BlockNodeApiStatus},
+	}
+
+	trx, err := NewRegisteredNodeCreateTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetAdminKey(key.PublicKey()).
+		SetDescription("coverage").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		SetTransactionMemo("").
+		SetTransactionValidDuration(60 * time.Second).
+		SetMaxTransactionFee(NewHbar(3)).
+		SetMaxRetry(3).
+		SetMaxBackoff(time.Second * 30).
+		SetMinBackoff(time.Second * 10).
+		SetRegenerateTransactionID(false).
+		Freeze()
+	require.NoError(t, err)
+
+	return trx, client, key
+}
+
+func TestUnitRegisteredNodeCreateTransactionCoverage(t *testing.T) {
+	t.Parallel()
+
+	trx, client, key := buildFrozenRegisteredNodeCreateTransaction(t)
+
+	require.NoError(t, trx.validateNetworkOnIDs(client))
+	_, err := trx.Schedule()
+	require.NoError(t, err)
+	trx.GetTransactionID()
+	trx.GetNodeAccountIDs()
+	trx.GetMaxRetry()
+	trx.GetMaxTransactionFee()
+	trx.GetMaxBackoff()
+	trx.GetMinBackoff()
+	trx.GetRegenerateTransactionID()
+
+	byt, err := trx.ToBytes()
+	require.NoError(t, err)
+	txFromBytes, err := TransactionFromBytes(byt)
+	require.NoError(t, err)
+
+	sig, err := key.SignTransaction(trx)
+	require.NoError(t, err)
+
+	_, err = trx.GetTransactionHash()
+	require.NoError(t, err)
+	_, err = trx.GetSignatures()
+	require.NoError(t, err)
+
+	switch b := txFromBytes.(type) {
+	case RegisteredNodeCreateTransaction:
+		b.AddSignature(key.PublicKey(), sig)
+	}
 }

--- a/sdk/registered_node_delete_transaction.go
+++ b/sdk/registered_node_delete_transaction.go
@@ -1,0 +1,99 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// RegisteredNodeDeleteTransaction removes a registered node from the network address book.
+type RegisteredNodeDeleteTransaction struct {
+	*Transaction[*RegisteredNodeDeleteTransaction]
+	registeredNodeId *uint64
+}
+
+// NewRegisteredNodeDeleteTransaction creates a new RegisteredNodeDeleteTransaction.
+func NewRegisteredNodeDeleteTransaction() *RegisteredNodeDeleteTransaction {
+	tx := &RegisteredNodeDeleteTransaction{}
+	tx.Transaction = _NewTransaction(tx)
+	return tx
+}
+
+func _RegisteredNodeDeleteTransactionFromProtobuf(tx Transaction[*RegisteredNodeDeleteTransaction], pb *services.TransactionBody) RegisteredNodeDeleteTransaction {
+	nodeId := pb.GetRegisteredNodeDelete().GetRegisteredNodeId()
+
+	registeredNodeDeleteTransaction := RegisteredNodeDeleteTransaction{
+		registeredNodeId: &nodeId,
+	}
+
+	tx.childTransaction = &registeredNodeDeleteTransaction
+	registeredNodeDeleteTransaction.Transaction = &tx
+	return registeredNodeDeleteTransaction
+}
+
+// SetRegisteredNodeId sets the registered node ID to delete.
+func (tx *RegisteredNodeDeleteTransaction) SetRegisteredNodeId(id uint64) *RegisteredNodeDeleteTransaction {
+	tx._RequireNotFrozen()
+	tx.registeredNodeId = &id
+	return tx
+}
+
+// GetRegisteredNodeId returns the registered node ID.
+func (tx *RegisteredNodeDeleteTransaction) GetRegisteredNodeId() uint64 {
+	if tx.registeredNodeId == nil {
+		return 0
+	}
+	return *tx.registeredNodeId
+}
+
+// ----------- Overridden functions ----------------
+
+func (tx RegisteredNodeDeleteTransaction) getName() string {
+	return "RegisteredNodeDeleteTransaction"
+}
+
+func (tx RegisteredNodeDeleteTransaction) validateNetworkOnIDs(_ *Client) error {
+	return nil
+}
+
+func (tx RegisteredNodeDeleteTransaction) build() *services.TransactionBody {
+	body := tx.buildTransactionBody()
+	body.Data = &services.TransactionBody_RegisteredNodeDelete{
+		RegisteredNodeDelete: tx.buildProtoBody(),
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeDeleteTransaction) buildScheduled() (*services.SchedulableTransactionBody, error) {
+	body := tx.buildSchedulableTransactionBody()
+	body.Data = &services.SchedulableTransactionBody_RegisteredNodeDelete{
+		RegisteredNodeDelete: tx.buildProtoBody(),
+	}
+
+	return body, nil
+}
+
+func (tx RegisteredNodeDeleteTransaction) buildProtoBody() *services.RegisteredNodeDeleteTransactionBody {
+	body := &services.RegisteredNodeDeleteTransactionBody{}
+
+	if tx.registeredNodeId != nil {
+		body.RegisteredNodeId = *tx.registeredNodeId
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeDeleteTransaction) getMethod(channel *_Channel) _Method {
+	return _Method{
+		transaction: channel._GetAddressBook().DeleteRegisteredNode,
+	}
+}
+
+func (tx RegisteredNodeDeleteTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
+	return tx.buildScheduled()
+}
+
+func (tx RegisteredNodeDeleteTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
+	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
+}

--- a/sdk/registered_node_delete_transaction.go
+++ b/sdk/registered_node_delete_transaction.go
@@ -6,7 +6,16 @@ import (
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 )
 
-// RegisteredNodeDeleteTransaction removes a registered node from the network address book.
+/**
+ * A transaction to delete a registered node from the network
+ * address book.
+ *
+ * This transaction, once complete, SHALL remove the identified registered
+ * node from the network state.
+ * This transaction MUST be signed by the existing entry `admin_key` or
+ * authorized by the Hiero network governance structure.
+ *
+ */
 type RegisteredNodeDeleteTransaction struct {
 	*Transaction[*RegisteredNodeDeleteTransaction]
 	registeredNodeId *uint64

--- a/sdk/registered_node_delete_transaction_e2e_test.go
+++ b/sdk/registered_node_delete_transaction_e2e_test.go
@@ -1,0 +1,146 @@
+//go:build all || e2e
+
+package hiero
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationRegisteredNodeDeleteTransactionCanExecute(t *testing.T) {
+	t.Parallel()
+
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Create a registered node
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
+	endpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	createTx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription("test node for delete").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	createResp, err := createTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	registeredNodeId := createReceipt.RegisteredNodeId
+
+	// Delete the registered node
+	deleteTx, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	deleteResp, err := deleteTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = deleteResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+}
+
+func TestIntegrationRegisteredNodeDeleteTransactionFailsIfAlreadyDeleted(t *testing.T) {
+	t.Parallel()
+
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Create a registered node
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
+	endpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	createTx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription("test node for double delete").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	createResp, err := createTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	registeredNodeId := createReceipt.RegisteredNodeId
+
+	// First delete should succeed
+	deleteTx, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	deleteResp, err := deleteTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = deleteResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// Second delete should fail
+	deleteTx2, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	deleteResp2, err := deleteTx2.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = deleteResp2.SetValidateStatus(true).GetReceipt(client)
+	require.ErrorContains(t, err, "INVALID_REGISTERED_NODE_ID")
+}
+
+func TestIntegrationRegisteredNodeDeleteTransactionFailsIfNonExistentNode(t *testing.T) {
+	t.Parallel()
+
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	// Try to delete a non-existent registered node
+	deleteTx, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(9999999).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	deleteResp, err := deleteTx.Execute(client)
+	require.NoError(t, err)
+
+	_, err = deleteResp.SetValidateStatus(true).GetReceipt(client)
+	require.ErrorContains(t, err, "INVALID_REGISTERED_NODE_ID")
+}

--- a/sdk/registered_node_delete_transaction_e2e_test.go
+++ b/sdk/registered_node_delete_transaction_e2e_test.go
@@ -28,7 +28,7 @@ func TestIntegrationRegisteredNodeDeleteTransactionCanExecute(t *testing.T) {
 
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	endpoint.SetEndpointApi(BlockNodeApiStatus)
+	endpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	createTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(adminKey).
@@ -77,7 +77,7 @@ func TestIntegrationRegisteredNodeDeleteTransactionFailsIfAlreadyDeleted(t *test
 
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	endpoint.SetEndpointApi(BlockNodeApiStatus)
+	endpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	createTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(adminKey).

--- a/sdk/registered_node_delete_transaction_e2e_test.go
+++ b/sdk/registered_node_delete_transaction_e2e_test.go
@@ -44,7 +44,8 @@ func TestIntegrationRegisteredNodeDeleteTransactionCanExecute(t *testing.T) {
 	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	registeredNodeId := createReceipt.RegisteredNodeId
+	require.NotNil(t, createReceipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
+	registeredNodeId := *createReceipt.RegisteredNodeId
 
 	// Delete the registered node
 	deleteTx, err := NewRegisteredNodeDeleteTransaction().
@@ -102,7 +103,8 @@ func TestIntegrationRegisteredNodeDeleteTransactionFailsIfAlreadyDeleted(t *test
 	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	registeredNodeId := createReceipt.RegisteredNodeId
+	require.NotNil(t, createReceipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
+	registeredNodeId := *createReceipt.RegisteredNodeId
 
 	// First delete should succeed
 	deleteTx, err := NewRegisteredNodeDeleteTransaction().

--- a/sdk/registered_node_delete_transaction_e2e_test.go
+++ b/sdk/registered_node_delete_transaction_e2e_test.go
@@ -5,6 +5,7 @@ package hiero
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -56,6 +57,15 @@ func TestIntegrationRegisteredNodeDeleteTransactionCanExecute(t *testing.T) {
 
 	_, err = deleteResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
+
+	// Wait for mirror node propagation, then verify the node is gone from the address book.
+	time.Sleep(time.Second * 5)
+
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Empty(t, book.RegisteredNodes, "deleted node should not appear in the address book")
 }
 
 func TestIntegrationRegisteredNodeDeleteTransactionFailsIfAlreadyDeleted(t *testing.T) {

--- a/sdk/registered_node_delete_transaction_unit_test.go
+++ b/sdk/registered_node_delete_transaction_unit_test.go
@@ -16,10 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnitRegisteredNodeDeleteTransactionMock(t *testing.T) {
-	t.Parallel()
-
-	responses := [][]interface{}{{
+func registeredNodeDeleteMockResponses() [][]interface{} {
+	return [][]interface{}{{
 		grpcStatus.New(codes.Unavailable, "node is UNAVAILABLE").Err(),
 		grpcStatus.New(codes.Internal, "Received RST_STREAM with code 0").Err(),
 		&services.TransactionResponse{
@@ -66,8 +64,12 @@ func TestUnitRegisteredNodeDeleteTransactionMock(t *testing.T) {
 			},
 		},
 	}}
+}
 
-	client, server := NewMockClientAndServer(responses)
+func TestUnitRegisteredNodeDeleteTransactionMock(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewMockClientAndServer(registeredNodeDeleteMockResponses())
 	defer server.Close()
 
 	tran := TransactionIDGenerate(AccountID{Account: 3})
@@ -194,9 +196,8 @@ func TestUnitRegisteredNodeDeleteTransactionProtoCheck(t *testing.T) {
 	require.Equal(t, proto.RegisteredNodeId, uint64(7))
 }
 
-func TestUnitRegisteredNodeDeleteTransactionCoverage(t *testing.T) {
-	t.Parallel()
-
+func buildFrozenRegisteredNodeDeleteTransaction(t *testing.T) (*RegisteredNodeDeleteTransaction, *Client, PrivateKey) {
+	t.Helper()
 	nodeAccountID := []AccountID{{Account: 10}}
 	transactionID := TransactionIDGenerate(AccountID{Account: 324})
 
@@ -224,8 +225,16 @@ func TestUnitRegisteredNodeDeleteTransactionCoverage(t *testing.T) {
 		Freeze()
 	require.NoError(t, err)
 
+	return trx, client, key
+}
+
+func TestUnitRegisteredNodeDeleteTransactionCoverage(t *testing.T) {
+	t.Parallel()
+
+	trx, client, key := buildFrozenRegisteredNodeDeleteTransaction(t)
+
 	trx.validateNetworkOnIDs(client)
-	_, err = trx.Schedule()
+	_, err := trx.Schedule()
 	require.NoError(t, err)
 	trx.GetTransactionID()
 	trx.GetNodeAccountIDs()

--- a/sdk/registered_node_delete_transaction_unit_test.go
+++ b/sdk/registered_node_delete_transaction_unit_test.go
@@ -1,0 +1,271 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitRegisteredNodeDeleteTransactionMock(t *testing.T) {
+	t.Parallel()
+
+	responses := [][]interface{}{{
+		grpcStatus.New(codes.Unavailable, "node is UNAVAILABLE").Err(),
+		grpcStatus.New(codes.Internal, "Received RST_STREAM with code 0").Err(),
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_BUSY,
+		},
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_COST_ANSWER,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_RECEIPT_NOT_FOUND,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status:           services.ResponseCodeEnum_SUCCESS,
+						RegisteredNodeId: 42,
+					},
+				},
+			},
+		},
+	}}
+
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+
+	tran := TransactionIDGenerate(AccountID{Account: 3})
+
+	resp, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(42).
+		SetTransactionID(tran).
+		Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.GetReceipt(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), receipt.RegisteredNodeId)
+}
+
+func TestUnitRegisteredNodeDeleteTransactionBuild(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(5)
+
+	body := tx.buildProtoBody()
+	assert.Equal(t, uint64(5), body.RegisteredNodeId)
+}
+
+func TestUnitRegisteredNodeDeleteTransactionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(42)
+
+	body := tx.buildProtoBody()
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_RegisteredNodeDelete{
+			RegisteredNodeDelete: body,
+		},
+	}
+
+	restored := _RegisteredNodeDeleteTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.Equal(t, uint64(42), restored.GetRegisteredNodeId())
+}
+
+func TestUnitRegisteredNodeDeleteTransactionGetName(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeDeleteTransaction()
+	assert.Equal(t, "RegisteredNodeDeleteTransaction", tx.getName())
+}
+
+func TestUnitRegisteredNodeDeleteTransactionGet(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(1).
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetTransactionMemo("").
+		SetTransactionValidDuration(60 * time.Second).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	_, err = transaction.GetTransactionHash()
+	require.NoError(t, err)
+
+	transaction.GetMaxTransactionFee()
+	transaction.GetTransactionMemo()
+	transaction.GetRegenerateTransactionID()
+	_, err = transaction.GetSignatures()
+	require.NoError(t, err)
+	transaction.GetRegisteredNodeId()
+}
+
+func TestUnitRegisteredNodeDeleteTransactionSetNothing(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(0).
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	_, err = transaction.GetTransactionHash()
+	require.NoError(t, err)
+
+	transaction.GetMaxTransactionFee()
+	transaction.GetTransactionMemo()
+	transaction.GetRegenerateTransactionID()
+	_, err = transaction.GetSignatures()
+	require.NoError(t, err)
+	transaction.GetRegisteredNodeId()
+}
+
+func TestUnitRegisteredNodeDeleteTransactionProtoCheck(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewRegisteredNodeDeleteTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetRegisteredNodeId(7).
+		SetTransactionValidDuration(60 * time.Second).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	proto := transaction.build().GetRegisteredNodeDelete()
+	require.Equal(t, proto.RegisteredNodeId, uint64(7))
+}
+
+func TestUnitRegisteredNodeDeleteTransactionCoverage(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	client, err := _NewMockClient()
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	require.NoError(t, err)
+	client.SetAutoValidateChecksums(true)
+
+	trx, err := NewRegisteredNodeDeleteTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetRegisteredNodeId(1).
+		SetTransactionMemo("").
+		SetTransactionValidDuration(60 * time.Second).
+		SetMaxTransactionFee(NewHbar(3)).
+		SetMaxRetry(3).
+		SetMaxBackoff(time.Second * 30).
+		SetMinBackoff(time.Second * 10).
+		SetTransactionMemo("no").
+		SetTransactionValidDuration(time.Second * 30).
+		SetRegenerateTransactionID(false).
+		Freeze()
+	require.NoError(t, err)
+
+	trx.validateNetworkOnIDs(client)
+	_, err = trx.Schedule()
+	require.NoError(t, err)
+	trx.GetTransactionID()
+	trx.GetNodeAccountIDs()
+	trx.GetMaxRetry()
+	trx.GetMaxTransactionFee()
+	trx.GetMaxBackoff()
+	trx.GetMinBackoff()
+	trx.GetRegenerateTransactionID()
+	byt, err := trx.ToBytes()
+	require.NoError(t, err)
+	txFromBytes, err := TransactionFromBytes(byt)
+	require.NoError(t, err)
+	sig, err := key.SignTransaction(trx)
+	require.NoError(t, err)
+
+	_, err = trx.GetTransactionHash()
+	require.NoError(t, err)
+	trx.GetMaxTransactionFee()
+	trx.GetTransactionMemo()
+	trx.GetRegenerateTransactionID()
+	trx.GetRegisteredNodeId()
+	_, err = trx.GetSignatures()
+	require.NoError(t, err)
+	trx.getName()
+	switch b := txFromBytes.(type) {
+	case RegisteredNodeDeleteTransaction:
+		b.AddSignature(key.PublicKey(), sig)
+	}
+}
+
+func TestUnitRegisteredNodeDeleteTransactionFromToBytes(t *testing.T) {
+	tx := NewRegisteredNodeDeleteTransaction().
+		SetRegisteredNodeId(99)
+
+	txBytes, err := tx.ToBytes()
+	require.NoError(t, err)
+
+	txFromBytes, err := TransactionFromBytes(txBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(RegisteredNodeDeleteTransaction).buildProtoBody())
+}
+

--- a/sdk/registered_node_delete_transaction_unit_test.go
+++ b/sdk/registered_node_delete_transaction_unit_test.go
@@ -82,7 +82,8 @@ func TestUnitRegisteredNodeDeleteTransactionMock(t *testing.T) {
 
 	receipt, err := resp.GetReceipt(client)
 	require.NoError(t, err)
-	require.Equal(t, uint64(42), receipt.RegisteredNodeId)
+	require.NotNil(t, receipt.RegisteredNodeId)
+	require.Equal(t, uint64(42), *receipt.RegisteredNodeId)
 }
 
 func TestUnitRegisteredNodeDeleteTransactionBuild(t *testing.T) {

--- a/sdk/registered_node_delete_transaction_unit_test.go
+++ b/sdk/registered_node_delete_transaction_unit_test.go
@@ -278,3 +278,13 @@ func TestUnitRegisteredNodeDeleteTransactionFromToBytes(t *testing.T) {
 	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(RegisteredNodeDeleteTransaction).buildProtoBody())
 }
 
+func TestUnitRegisteredNodeDeleteTransactionScheduleProtobuf(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeDeleteTransaction().SetRegisteredNodeId(7)
+
+	scheduled, err := tx.constructScheduleProtobuf()
+	require.NoError(t, err)
+	require.NotNil(t, scheduled.GetRegisteredNodeDelete())
+}
+

--- a/sdk/registered_node_update_transaction.go
+++ b/sdk/registered_node_update_transaction.go
@@ -1,0 +1,184 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// RegisteredNodeUpdateTransaction updates an existing registered node in the network address book.
+type RegisteredNodeUpdateTransaction struct {
+	*Transaction[*RegisteredNodeUpdateTransaction]
+	registeredNodeId *uint64
+	adminKey         Key
+	description      *string
+	serviceEndpoints []RegisteredServiceEndpoint
+}
+
+// NewRegisteredNodeUpdateTransaction creates a new RegisteredNodeUpdateTransaction.
+func NewRegisteredNodeUpdateTransaction() *RegisteredNodeUpdateTransaction {
+	tx := &RegisteredNodeUpdateTransaction{}
+	tx.Transaction = _NewTransaction(tx)
+	return tx
+}
+
+func _RegisteredNodeUpdateTransactionFromProtobuf(tx Transaction[*RegisteredNodeUpdateTransaction], pb *services.TransactionBody) RegisteredNodeUpdateTransaction {
+	var adminKey Key
+	if pb.GetRegisteredNodeUpdate().GetAdminKey() != nil {
+		adminKey, _ = _KeyFromProtobuf(pb.GetRegisteredNodeUpdate().GetAdminKey())
+	}
+
+	serviceEndpoints := make([]RegisteredServiceEndpoint, 0)
+	for _, endpoint := range pb.GetRegisteredNodeUpdate().GetServiceEndpoint() {
+		serviceEndpoints = append(serviceEndpoints, _RegisteredServiceEndpointFromProtobuf(endpoint))
+	}
+
+	nodeId := pb.GetRegisteredNodeUpdate().GetRegisteredNodeId()
+
+	var description *string
+	if pb.GetRegisteredNodeUpdate().GetDescription() != nil {
+		description = &pb.GetRegisteredNodeUpdate().GetDescription().Value
+	}
+
+	registeredNodeUpdateTransaction := RegisteredNodeUpdateTransaction{
+		registeredNodeId: &nodeId,
+		adminKey:         adminKey,
+		description:      description,
+		serviceEndpoints: serviceEndpoints,
+	}
+
+	tx.childTransaction = &registeredNodeUpdateTransaction
+	registeredNodeUpdateTransaction.Transaction = &tx
+	return registeredNodeUpdateTransaction
+}
+
+// SetRegisteredNodeId sets the registered node ID to update.
+func (tx *RegisteredNodeUpdateTransaction) SetRegisteredNodeId(id uint64) *RegisteredNodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.registeredNodeId = &id
+	return tx
+}
+
+// GetRegisteredNodeId returns the registered node ID.
+func (tx *RegisteredNodeUpdateTransaction) GetRegisteredNodeId() uint64 {
+	if tx.registeredNodeId == nil {
+		return 0
+	}
+	return *tx.registeredNodeId
+}
+
+// SetAdminKey sets the new admin key for the registered node.
+func (tx *RegisteredNodeUpdateTransaction) SetAdminKey(key Key) *RegisteredNodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.adminKey = key
+	return tx
+}
+
+// GetAdminKey returns the admin key.
+func (tx *RegisteredNodeUpdateTransaction) GetAdminKey() Key {
+	return tx.adminKey
+}
+
+// SetDescription sets the description for the registered node.
+func (tx *RegisteredNodeUpdateTransaction) SetDescription(description string) *RegisteredNodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.description = &description
+	return tx
+}
+
+// GetDescription returns the description.
+func (tx *RegisteredNodeUpdateTransaction) GetDescription() string {
+	if tx.description != nil {
+		return *tx.description
+	}
+
+	return ""
+}
+
+// SetServiceEndpoints sets the service endpoints, replacing any existing ones.
+func (tx *RegisteredNodeUpdateTransaction) SetServiceEndpoints(endpoints []RegisteredServiceEndpoint) *RegisteredNodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.serviceEndpoints = endpoints
+	return tx
+}
+
+// GetServiceEndpoints returns the service endpoints.
+func (tx *RegisteredNodeUpdateTransaction) GetServiceEndpoints() []RegisteredServiceEndpoint {
+	return tx.serviceEndpoints
+}
+
+// AddServiceEndpoint adds a service endpoint.
+func (tx *RegisteredNodeUpdateTransaction) AddServiceEndpoint(endpoint RegisteredServiceEndpoint) *RegisteredNodeUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.serviceEndpoints = append(tx.serviceEndpoints, endpoint)
+	return tx
+}
+
+// ----------- Overridden functions ----------------
+
+func (tx RegisteredNodeUpdateTransaction) getName() string {
+	return "RegisteredNodeUpdateTransaction"
+}
+
+func (tx RegisteredNodeUpdateTransaction) validateNetworkOnIDs(_ *Client) error {
+	return nil
+}
+
+func (tx RegisteredNodeUpdateTransaction) build() *services.TransactionBody {
+	body := tx.buildTransactionBody()
+	body.Data = &services.TransactionBody_RegisteredNodeUpdate{
+		RegisteredNodeUpdate: tx.buildProtoBody(),
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeUpdateTransaction) buildScheduled() (*services.SchedulableTransactionBody, error) {
+	body := tx.buildSchedulableTransactionBody()
+	body.Data = &services.SchedulableTransactionBody_RegisteredNodeUpdate{
+		RegisteredNodeUpdate: tx.buildProtoBody(),
+	}
+
+	return body, nil
+}
+
+func (tx RegisteredNodeUpdateTransaction) buildProtoBody() *services.RegisteredNodeUpdateTransactionBody {
+	body := &services.RegisteredNodeUpdateTransactionBody{}
+
+	if tx.registeredNodeId != nil {
+		body.RegisteredNodeId = *tx.registeredNodeId
+	}
+
+	if tx.adminKey != nil {
+		body.AdminKey = tx.adminKey._ToProtoKey()
+	}
+
+	if tx.description != nil {
+		body.Description = &wrapperspb.StringValue{Value: *tx.description}
+	}
+
+	for _, endpoint := range tx.serviceEndpoints {
+		body.ServiceEndpoint = append(body.ServiceEndpoint, endpoint._ToProtobuf())
+	}
+
+	return body
+}
+
+func (tx RegisteredNodeUpdateTransaction) validateTransactionFields() error {
+	return nil
+}
+
+func (tx RegisteredNodeUpdateTransaction) getMethod(channel *_Channel) _Method {
+	return _Method{
+		transaction: channel._GetAddressBook().UpdateRegisteredNode,
+	}
+}
+
+func (tx RegisteredNodeUpdateTransaction) constructScheduleProtobuf() (*services.SchedulableTransactionBody, error) {
+	return tx.buildScheduled()
+}
+
+func (tx RegisteredNodeUpdateTransaction) getBaseTransaction() *Transaction[TransactionInterface] {
+	return castFromConcreteToBaseTransaction(tx.Transaction, &tx)
+}

--- a/sdk/registered_node_update_transaction.go
+++ b/sdk/registered_node_update_transaction.go
@@ -7,7 +7,13 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// RegisteredNodeUpdateTransaction updates an existing registered node in the network address book.
+/**
+ * A transaction to update an existing registered node in the network
+ * address book.
+ *
+ * This transaction, once complete, SHALL modify the identified registered
+ * node state as requested.
+ */
 type RegisteredNodeUpdateTransaction struct {
 	*Transaction[*RegisteredNodeUpdateTransaction]
 	registeredNodeId *uint64

--- a/sdk/registered_node_update_transaction_e2e_test.go
+++ b/sdk/registered_node_update_transaction_e2e_test.go
@@ -1,0 +1,224 @@
+//go:build all || e2e
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setupLocalClient creates a client pointed at the local network for e2e tests.
+func setupRegisteredNodeUpdateLocalClient(t *testing.T) *Client {
+	t.Helper()
+
+	network := make(map[string]AccountID)
+	network["localhost:50211"] = AccountID{Account: 3}
+	client, err := ClientForNetworkV2(network)
+	require.NoError(t, err)
+	mirror := []string{"localhost:5600"}
+	client.SetMirrorNetwork(mirror)
+
+	originalOperatorKey, err := PrivateKeyFromStringEd25519("302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137")
+	require.NoError(t, err)
+	client.SetOperator(AccountID{Account: 2}, originalOperatorKey)
+
+	return client
+}
+
+// createRegisteredNode creates a registered node with the given admin key and returns the registeredNodeId.
+func createRegisteredNode(t *testing.T, client *Client, adminKey PrivateKey) uint64 {
+	t.Helper()
+
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
+	endpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	createTx, err := NewRegisteredNodeCreateTransaction().
+		SetAdminKey(adminKey).
+		SetDescription("test node").
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	createResp, err := createTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	require.Greater(t, createReceipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	return createReceipt.RegisteredNodeId
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionUpdateDescription(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	registeredNodeId := createRegisteredNode(t, client, adminKey)
+	require.Greater(t, registeredNodeId, uint64(0))
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetDescription("updated description").
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// TODO: query the registered node and verify description == "updated description"
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionReplaceEndpoints(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	registeredNodeId := createRegisteredNode(t, client, adminKey)
+	require.Greater(t, registeredNodeId, uint64(0))
+
+	newEndpoint := &BlockNodeServiceEndpoint{}
+	newEndpoint.SetIPAddress(net.IPv4(172, 16, 0, 1).To4()).SetPort(9090)
+	newEndpoint.SetEndpointApi(BlockNodeApiPublish)
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{newEndpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// TODO: query the registered node and verify endpoints were replaced
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionUpdateAdminKeyBothSign(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	oldAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	registeredNodeId := createRegisteredNode(t, client, oldAdminKey)
+	require.Greater(t, registeredNodeId, uint64(0))
+
+	newAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetAdminKey(newAdminKey.PublicKey()).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.
+		Sign(oldAdminKey).
+		Sign(newAdminKey).
+		Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// TODO: query the registered node and verify admin key was updated to newAdminKey
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionUpdateAdminKeyOnlyOldSigns(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	oldAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	registeredNodeId := createRegisteredNode(t, client, oldAdminKey)
+	require.Greater(t, registeredNodeId, uint64(0))
+
+	newAdminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetAdminKey(newAdminKey.PublicKey()).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.
+		Sign(oldAdminKey).
+		Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.ErrorContains(t, err, "INVALID_SIGNATURE")
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionFailsIfNonExistentId(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(9999999).
+		SetAdminKey(adminKey).
+		SetDescription("should fail").
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.ErrorContains(t, err, "INVALID_REGISTERED_NODE_ID")
+}
+
+func TestIntegrationRegisteredNodeUpdateTransactionReplaceDomainEndpoint(t *testing.T) {
+	t.Parallel()
+
+	client := setupRegisteredNodeUpdateLocalClient(t)
+
+	adminKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	registeredNodeId := createRegisteredNode(t, client, adminKey)
+	require.Greater(t, registeredNodeId, uint64(0))
+
+	domainEndpoint := &BlockNodeServiceEndpoint{}
+	domainEndpoint.SetDomainName("node.example.com").SetPort(443)
+	domainEndpoint.SetEndpointApi(BlockNodeApiStatus)
+
+	updateTx, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(registeredNodeId).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{domainEndpoint}).
+		FreezeWith(client)
+	require.NoError(t, err)
+
+	updateResp, err := updateTx.Sign(adminKey).Execute(client)
+	require.NoError(t, err)
+
+	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
+	require.NoError(t, err)
+
+	// TODO: query the registered node and verify endpoint uses domain name "node.example.com"
+}

--- a/sdk/registered_node_update_transaction_e2e_test.go
+++ b/sdk/registered_node_update_transaction_e2e_test.go
@@ -5,6 +5,7 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -35,7 +36,7 @@ func createRegisteredNode(t *testing.T, client *Client, adminKey PrivateKey) uin
 
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress(net.IPv4(10, 0, 0, 1).To4()).SetPort(8080)
-	endpoint.SetEndpointApi(BlockNodeApiStatus)
+	endpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	createTx, err := NewRegisteredNodeCreateTransaction().
 		SetAdminKey(adminKey).
@@ -51,6 +52,8 @@ func createRegisteredNode(t *testing.T, client *Client, adminKey PrivateKey) uin
 	require.NoError(t, err)
 
 	require.Greater(t, createReceipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
+	t.Log(createReceipt.RegisteredNodeId)
+	fmt.Println(createReceipt)
 	return createReceipt.RegisteredNodeId
 }
 
@@ -93,7 +96,7 @@ func TestIntegrationRegisteredNodeUpdateTransactionReplaceEndpoints(t *testing.T
 
 	newEndpoint := &BlockNodeServiceEndpoint{}
 	newEndpoint.SetIPAddress(net.IPv4(172, 16, 0, 1).To4()).SetPort(9090)
-	newEndpoint.SetEndpointApi(BlockNodeApiPublish)
+	newEndpoint.AddEndpointApi(BlockNodeApiPublish)
 
 	updateTx, err := NewRegisteredNodeUpdateTransaction().
 		SetRegisteredNodeId(registeredNodeId).
@@ -206,7 +209,7 @@ func TestIntegrationRegisteredNodeUpdateTransactionReplaceDomainEndpoint(t *test
 
 	domainEndpoint := &BlockNodeServiceEndpoint{}
 	domainEndpoint.SetDomainName("node.example.com").SetPort(443)
-	domainEndpoint.SetEndpointApi(BlockNodeApiStatus)
+	domainEndpoint.AddEndpointApi(BlockNodeApiStatus)
 
 	updateTx, err := NewRegisteredNodeUpdateTransaction().
 		SetRegisteredNodeId(registeredNodeId).

--- a/sdk/registered_node_update_transaction_e2e_test.go
+++ b/sdk/registered_node_update_transaction_e2e_test.go
@@ -5,9 +5,9 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
-	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -52,8 +52,6 @@ func createRegisteredNode(t *testing.T, client *Client, adminKey PrivateKey) uin
 	require.NoError(t, err)
 
 	require.Greater(t, createReceipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	t.Log(createReceipt.RegisteredNodeId)
-	fmt.Println(createReceipt)
 	return createReceipt.RegisteredNodeId
 }
 
@@ -80,7 +78,16 @@ func TestIntegrationRegisteredNodeUpdateTransactionUpdateDescription(t *testing.
 	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// TODO: query the registered node and verify description == "updated description"
+	// Wait for mirror node propagation
+	time.Sleep(5 * time.Second)
+
+	// Query the registered node and verify description was updated
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, "updated description", book.RegisteredNodes[0].Description)
 }
 
 func TestIntegrationRegisteredNodeUpdateTransactionReplaceEndpoints(t *testing.T) {
@@ -110,7 +117,22 @@ func TestIntegrationRegisteredNodeUpdateTransactionReplaceEndpoints(t *testing.T
 	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// TODO: query the registered node and verify endpoints were replaced
+	// Wait for mirror node propagation
+	time.Sleep(5 * time.Second)
+
+	// Query the registered node and verify endpoints were replaced
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
+	require.True(t, ok, "expected *BlockNodeServiceEndpoint")
+	require.Equal(t, net.IPv4(172, 16, 0, 1).To4(), net.IP(ep.GetIPAddress()))
+	require.Equal(t, uint32(9090), ep.GetPort())
+	require.Equal(t, []BlockNodeApi{BlockNodeApiPublish}, ep.GetEndpointApis())
 }
 
 func TestIntegrationRegisteredNodeUpdateTransactionUpdateAdminKeyBothSign(t *testing.T) {
@@ -142,7 +164,16 @@ func TestIntegrationRegisteredNodeUpdateTransactionUpdateAdminKeyBothSign(t *tes
 	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// TODO: query the registered node and verify admin key was updated to newAdminKey
+	// Wait for mirror node propagation
+	time.Sleep(5 * time.Second)
+
+	// Query the registered node and verify admin key was updated
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Equal(t, newAdminKey.PublicKey().String(), book.RegisteredNodes[0].AdminKey.String())
 }
 
 func TestIntegrationRegisteredNodeUpdateTransactionUpdateAdminKeyOnlyOldSigns(t *testing.T) {
@@ -223,5 +254,20 @@ func TestIntegrationRegisteredNodeUpdateTransactionReplaceDomainEndpoint(t *test
 	_, err = updateResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	// TODO: query the registered node and verify endpoint uses domain name "node.example.com"
+	// Wait for mirror node propagation
+	time.Sleep(5 * time.Second)
+
+	// Query the registered node and verify endpoint uses domain name
+	book, err := NewRegisteredNodeAddressBookQuery().
+		SetRegisteredNodeId(registeredNodeId).
+		Execute(client)
+	require.NoError(t, err)
+	require.Len(t, book.RegisteredNodes, 1)
+	require.Len(t, book.RegisteredNodes[0].ServiceEndpoints, 1)
+
+	ep, ok := book.RegisteredNodes[0].ServiceEndpoints[0].(*BlockNodeServiceEndpoint)
+	require.True(t, ok, "expected *BlockNodeServiceEndpoint")
+	require.Equal(t, "node.example.com", ep.GetDomainName())
+	require.Equal(t, uint32(443), ep.GetPort())
+	require.Equal(t, []BlockNodeApi{BlockNodeApiStatus}, ep.GetEndpointApis())
 }

--- a/sdk/registered_node_update_transaction_e2e_test.go
+++ b/sdk/registered_node_update_transaction_e2e_test.go
@@ -51,8 +51,8 @@ func createRegisteredNode(t *testing.T, client *Client, adminKey PrivateKey) uin
 	createReceipt, err := createResp.SetValidateStatus(true).GetReceipt(client)
 	require.NoError(t, err)
 
-	require.Greater(t, createReceipt.RegisteredNodeId, uint64(0), "registeredNodeId should be non-zero")
-	return createReceipt.RegisteredNodeId
+	require.NotNil(t, createReceipt.RegisteredNodeId, "registeredNodeId should be set on the receipt")
+	return *createReceipt.RegisteredNodeId
 }
 
 func TestIntegrationRegisteredNodeUpdateTransactionUpdateDescription(t *testing.T) {

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -1,0 +1,361 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestUnitRegisteredNodeUpdateTransactionMock(t *testing.T) {
+	t.Parallel()
+
+	responses := [][]interface{}{{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_COST_ANSWER,
+					},
+				},
+			},
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status:           services.ResponseCodeEnum_SUCCESS,
+						RegisteredNodeId: 7,
+					},
+				},
+			},
+		},
+	}}
+
+	client, server := NewMockClientAndServer(responses)
+	defer server.Close()
+
+	tran := TransactionIDGenerate(AccountID{Account: 3})
+
+	resp, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(7).
+		SetDescription("updated").
+		SetTransactionID(tran).
+		Execute(client)
+	require.NoError(t, err)
+
+	receipt, err := resp.GetReceipt(client)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), receipt.RegisteredNodeId)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionDescriptionSet(t *testing.T) {
+	t.Parallel()
+
+	nodeId := uint64(1)
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(nodeId).
+		SetDescription("Updated Node")
+
+	body := tx.buildProtoBody()
+	assert.NotNil(t, body.Description)
+	assert.Equal(t, "Updated Node", body.Description.Value)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionDescriptionNotSet(t *testing.T) {
+	t.Parallel()
+
+	nodeId := uint64(1)
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(nodeId)
+
+	body := tx.buildProtoBody()
+	assert.Nil(t, body.Description)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, _ := PrivateKeyGenerateEd25519()
+	endpoint := &RpcRelayServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName: "node.example.com",
+			port:       443,
+		},
+	}
+
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(42).
+		SetAdminKey(key.PublicKey()).
+		SetDescription("Updated").
+		AddServiceEndpoint(endpoint)
+
+	body := tx.buildProtoBody()
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_RegisteredNodeUpdate{
+			RegisteredNodeUpdate: body,
+		},
+	}
+
+	restored := _RegisteredNodeUpdateTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.Equal(t, uint64(42), restored.GetRegisteredNodeId())
+	assert.Equal(t, "Updated", restored.GetDescription())
+	assert.Len(t, restored.GetServiceEndpoints(), 1)
+
+	_, ok := restored.GetServiceEndpoints()[0].(*RpcRelayServiceEndpoint)
+	assert.True(t, ok, "expected *RpcRelayServiceEndpoint after round-trip")
+}
+
+func TestUnitRegisteredNodeUpdateTransactionGetName(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeUpdateTransaction()
+	assert.Equal(t, "RegisteredNodeUpdateTransaction", tx.getName())
+}
+
+func TestUnitRegisteredNodeUpdateTransactionGet(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	key, _ := PrivateKeyGenerateEd25519()
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{10, 0, 0, 1},
+			port:      8080,
+		},
+		endpointApi: BlockNodeApiStatus,
+	}
+
+	transaction, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(1).
+		SetAdminKey(key.PublicKey()).
+		SetDescription("test").
+		AddServiceEndpoint(endpoint).
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetTransactionMemo("").
+		SetTransactionValidDuration(60 * time.Second).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	_, err = transaction.GetTransactionHash()
+	require.NoError(t, err)
+
+	transaction.GetMaxTransactionFee()
+	transaction.GetTransactionMemo()
+	transaction.GetRegenerateTransactionID()
+	_, err = transaction.GetSignatures()
+	require.NoError(t, err)
+	transaction.GetRegisteredNodeId()
+	transaction.GetAdminKey()
+	transaction.GetDescription()
+	transaction.GetServiceEndpoints()
+}
+
+func TestUnitRegisteredNodeUpdateTransactionSetNothing(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(0).
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	_, err = transaction.GetTransactionHash()
+	require.NoError(t, err)
+
+	transaction.GetMaxTransactionFee()
+	transaction.GetTransactionMemo()
+	transaction.GetRegenerateTransactionID()
+	_, err = transaction.GetSignatures()
+	require.NoError(t, err)
+	transaction.GetRegisteredNodeId()
+	transaction.GetAdminKey()
+	transaction.GetDescription()
+	transaction.GetServiceEndpoints()
+}
+
+func TestUnitRegisteredNodeUpdateTransactionProtoCheck(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}, {Account: 11}, {Account: 12}}
+	key, _ := PrivateKeyGenerateEd25519()
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	endpoint := &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName: "mirror.example.com",
+			port:       443,
+		},
+	}
+
+	transaction, err := NewRegisteredNodeUpdateTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetRegisteredNodeId(7).
+		SetAdminKey(key.PublicKey()).
+		SetDescription("test").
+		AddServiceEndpoint(endpoint).
+		SetTransactionValidDuration(60 * time.Second).
+		Freeze()
+	require.NoError(t, err)
+
+	transaction.GetTransactionID()
+	transaction.GetNodeAccountIDs()
+
+	proto := transaction.build().GetRegisteredNodeUpdate()
+	require.Equal(t, uint64(7), proto.RegisteredNodeId)
+	require.Equal(t, "test", proto.Description.Value)
+	require.Equal(t, key.PublicKey()._ToProtoKey(), proto.AdminKey)
+	require.Len(t, proto.ServiceEndpoint, 1)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionMinimalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(99)
+
+	body := tx.buildProtoBody()
+	assert.Equal(t, uint64(99), body.RegisteredNodeId)
+	assert.Nil(t, body.Description)
+	assert.Nil(t, body.AdminKey)
+	assert.Empty(t, body.ServiceEndpoint)
+
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_RegisteredNodeUpdate{
+			RegisteredNodeUpdate: body,
+		},
+	}
+
+	restored := _RegisteredNodeUpdateTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.Equal(t, uint64(99), restored.GetRegisteredNodeId())
+	assert.Nil(t, restored.description)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionFromProtobufWithEmptyDescription(t *testing.T) {
+	t.Parallel()
+
+	body := &services.RegisteredNodeUpdateTransactionBody{
+		RegisteredNodeId: 5,
+		Description:      wrapperspb.String(""),
+	}
+
+	pbBody := &services.TransactionBody{
+		Data: &services.TransactionBody_RegisteredNodeUpdate{
+			RegisteredNodeUpdate: body,
+		},
+	}
+
+	tx := NewRegisteredNodeUpdateTransaction()
+	restored := _RegisteredNodeUpdateTransactionFromProtobuf(*tx.Transaction, pbBody)
+	assert.NotNil(t, restored.description)
+	assert.Equal(t, "", restored.GetDescription())
+}
+
+func TestUnitRegisteredNodeUpdateTransactionCoverage(t *testing.T) {
+	t.Parallel()
+
+	nodeAccountID := []AccountID{{Account: 10}}
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	client, err := _NewMockClient()
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	require.NoError(t, err)
+	client.SetAutoValidateChecksums(true)
+
+	trx, err := NewRegisteredNodeUpdateTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		SetRegisteredNodeId(1).
+		SetDescription("test").
+		SetTransactionMemo("").
+		SetTransactionValidDuration(60 * time.Second).
+		SetMaxTransactionFee(NewHbar(3)).
+		SetMaxRetry(3).
+		SetMaxBackoff(time.Second * 30).
+		SetMinBackoff(time.Second * 10).
+		SetTransactionMemo("no").
+		SetTransactionValidDuration(time.Second * 30).
+		SetRegenerateTransactionID(false).
+		Freeze()
+	require.NoError(t, err)
+
+	trx.validateNetworkOnIDs(client)
+	_, err = trx.Schedule()
+	require.NoError(t, err)
+	trx.GetTransactionID()
+	trx.GetNodeAccountIDs()
+	trx.GetMaxRetry()
+	trx.GetMaxTransactionFee()
+	trx.GetMaxBackoff()
+	trx.GetMinBackoff()
+	trx.GetRegenerateTransactionID()
+	byt, err := trx.ToBytes()
+	require.NoError(t, err)
+	txFromBytes, err := TransactionFromBytes(byt)
+	require.NoError(t, err)
+	sig, err := key.SignTransaction(trx)
+	require.NoError(t, err)
+
+	_, err = trx.GetTransactionHash()
+	require.NoError(t, err)
+	trx.GetMaxTransactionFee()
+	trx.GetTransactionMemo()
+	trx.GetRegenerateTransactionID()
+	trx.GetRegisteredNodeId()
+	trx.GetAdminKey()
+	trx.GetDescription()
+	trx.GetServiceEndpoints()
+	_, err = trx.GetSignatures()
+	require.NoError(t, err)
+	trx.getName()
+	switch b := txFromBytes.(type) {
+	case RegisteredNodeUpdateTransaction:
+		b.AddSignature(key.PublicKey(), sig)
+	}
+}
+
+func TestUnitRegisteredNodeUpdateTransactionFromToBytes(t *testing.T) {
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(99).
+		SetDescription("test")
+
+	txBytes, err := tx.ToBytes()
+	require.NoError(t, err)
+
+	txFromBytes, err := TransactionFromBytes(txBytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(RegisteredNodeUpdateTransaction).buildProtoBody())
+}

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -280,9 +280,8 @@ func TestUnitRegisteredNodeUpdateTransactionFromProtobufWithEmptyDescription(t *
 	assert.Equal(t, "", restored.GetDescription())
 }
 
-func TestUnitRegisteredNodeUpdateTransactionCoverage(t *testing.T) {
-	t.Parallel()
-
+func buildFrozenRegisteredNodeUpdateTransaction(t *testing.T) (*RegisteredNodeUpdateTransaction, *Client, PrivateKey) {
+	t.Helper()
 	nodeAccountID := []AccountID{{Account: 10}}
 	transactionID := TransactionIDGenerate(AccountID{Account: 324})
 
@@ -311,8 +310,16 @@ func TestUnitRegisteredNodeUpdateTransactionCoverage(t *testing.T) {
 		Freeze()
 	require.NoError(t, err)
 
+	return trx, client, key
+}
+
+func TestUnitRegisteredNodeUpdateTransactionCoverage(t *testing.T) {
+	t.Parallel()
+
+	trx, client, key := buildFrozenRegisteredNodeUpdateTransaction(t)
+
 	trx.validateNetworkOnIDs(client)
-	_, err = trx.Schedule()
+	_, err := trx.Schedule()
 	require.NoError(t, err)
 	trx.GetTransactionID()
 	trx.GetNodeAccountIDs()

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -140,7 +140,7 @@ func TestUnitRegisteredNodeUpdateTransactionGet(t *testing.T) {
 			ipAddress: []byte{10, 0, 0, 1},
 			port:      8080,
 		},
-		endpointApi: BlockNodeApiStatus,
+		endpointApis: []BlockNodeApi{BlockNodeApiStatus},
 	}
 
 	transaction, err := NewRegisteredNodeUpdateTransaction().

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -366,3 +366,34 @@ func TestUnitRegisteredNodeUpdateTransactionFromToBytes(t *testing.T) {
 
 	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(RegisteredNodeUpdateTransaction).buildProtoBody())
 }
+
+func TestUnitRegisteredNodeUpdateTransactionSetServiceEndpoints(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{10, 0, 0, 1},
+			port:      443,
+		},
+	}
+
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(7).
+		SetServiceEndpoints([]RegisteredServiceEndpoint{endpoint})
+
+	require.Len(t, tx.GetServiceEndpoints(), 1)
+	body := tx.buildProtoBody()
+	require.Len(t, body.ServiceEndpoint, 1)
+}
+
+func TestUnitRegisteredNodeUpdateTransactionScheduleProtobuf(t *testing.T) {
+	t.Parallel()
+
+	tx := NewRegisteredNodeUpdateTransaction().
+		SetRegisteredNodeId(7).
+		SetDescription("scheduled")
+
+	scheduled, err := tx.constructScheduleProtobuf()
+	require.NoError(t, err)
+	require.NotNil(t, scheduled.GetRegisteredNodeUpdate())
+}

--- a/sdk/registered_node_update_transaction_unit_test.go
+++ b/sdk/registered_node_update_transaction_unit_test.go
@@ -61,7 +61,8 @@ func TestUnitRegisteredNodeUpdateTransactionMock(t *testing.T) {
 
 	receipt, err := resp.GetReceipt(client)
 	require.NoError(t, err)
-	require.Equal(t, uint64(7), receipt.RegisteredNodeId)
+	require.NotNil(t, receipt.RegisteredNodeId)
+	require.Equal(t, uint64(7), *receipt.RegisteredNodeId)
 }
 
 func TestUnitRegisteredNodeUpdateTransactionDescriptionSet(t *testing.T) {

--- a/sdk/registered_service_endpoint.go
+++ b/sdk/registered_service_endpoint.go
@@ -1,0 +1,126 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// RegisteredServiceEndpoint a service endpoint published by a registered node. Each endpoint
+// declares an address (IP or FQDN), port, TLS requirement, and the type of node service it provides.
+// The concrete subtypes are BlockNodeServiceEndpoint, MirrorNodeServiceEndpoint and
+// RpcRelayServiceEndpoint.
+type RegisteredServiceEndpoint interface {
+	GetIPAddress() []byte
+	GetDomainName() string
+	GetPort() uint32
+	GetRequiresTls() bool
+	Validate() error
+	_ToProtobuf() *services.RegisteredServiceEndpoint
+}
+
+type registeredEndpointBase struct {
+	ipAddress   []byte
+	domainName  string
+	port        uint32
+	requiresTls bool
+}
+
+// SetIPAddress sets the IP address for this endpoint.
+func (e *registeredEndpointBase) SetIPAddress(ip []byte) *registeredEndpointBase {
+	e.ipAddress = ip
+	return e
+}
+
+// GetIPAddress returns the IP address of this endpoint.
+func (e *registeredEndpointBase) GetIPAddress() []byte {
+	return e.ipAddress
+}
+
+// SetDomainName sets the domain name for this endpoint.
+func (e *registeredEndpointBase) SetDomainName(name string) *registeredEndpointBase {
+	e.domainName = name
+	return e
+}
+
+// GetDomainName returns the domain name of this endpoint.
+func (e *registeredEndpointBase) GetDomainName() string {
+	return e.domainName
+}
+
+// SetPort sets the port number for this endpoint.
+func (e *registeredEndpointBase) SetPort(port uint32) *registeredEndpointBase {
+	e.port = port
+	return e
+}
+
+// GetPort returns the port number of this endpoint.
+func (e *registeredEndpointBase) GetPort() uint32 {
+	return e.port
+}
+
+// SetRequiresTls sets whether this endpoint requires TLS.
+func (e *registeredEndpointBase) SetRequiresTls(tls bool) *registeredEndpointBase {
+	e.requiresTls = tls
+	return e
+}
+
+// GetRequiresTls returns whether this endpoint requires TLS.
+func (e *registeredEndpointBase) GetRequiresTls() bool {
+	return e.requiresTls
+}
+
+// Validate checks that this endpoint has a valid address configuration.
+func (e *registeredEndpointBase) Validate() error {
+	if e.ipAddress != nil && e.domainName != "" {
+		return errEndpointCannotHaveBothAddressAndDomainName
+	}
+	if e.ipAddress == nil && e.domainName == "" {
+		return errEndpointMustHaveAddressOrDomainName
+	}
+	return nil
+}
+
+// addressToProtobuf sets the address oneof on the given protobuf message.
+func (e *registeredEndpointBase) addressToProtobuf(pb *services.RegisteredServiceEndpoint) {
+	if e.ipAddress != nil {
+		pb.Address = &services.RegisteredServiceEndpoint_IpAddress{
+			IpAddress: e.ipAddress,
+		}
+	} else if e.domainName != "" {
+		pb.Address = &services.RegisteredServiceEndpoint_DomainName{
+			DomainName: e.domainName,
+		}
+	}
+}
+
+// baseFromProtobuf populates the base fields from a protobuf message.
+func baseFromProtobuf(pb *services.RegisteredServiceEndpoint) registeredEndpointBase {
+	base := registeredEndpointBase{
+		port:        pb.GetPort(),
+		requiresTls: pb.GetRequiresTls(),
+	}
+
+	switch addr := pb.Address.(type) {
+	case *services.RegisteredServiceEndpoint_IpAddress:
+		base.ipAddress = addr.IpAddress
+	case *services.RegisteredServiceEndpoint_DomainName:
+		base.domainName = addr.DomainName
+	}
+
+	return base
+}
+
+// _RegisteredServiceEndpointFromProtobuf dispatches on the protobuf endpoint_type
+// oneof and returns the appropriate concrete SDK type.
+func _RegisteredServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoint) RegisteredServiceEndpoint {
+	switch pb.EndpointType.(type) {
+	case *services.RegisteredServiceEndpoint_BlockNode:
+		return _BlockNodeServiceEndpointFromProtobuf(pb)
+	case *services.RegisteredServiceEndpoint_MirrorNode:
+		return _MirrorNodeServiceEndpointFromProtobuf(pb)
+	case *services.RegisteredServiceEndpoint_RpcRelay:
+		return _RpcRelayServiceEndpointFromProtobuf(pb)
+	}
+	return nil
+}

--- a/sdk/registered_service_endpoint.go
+++ b/sdk/registered_service_endpoint.go
@@ -8,8 +8,8 @@ import (
 
 // RegisteredServiceEndpoint a service endpoint published by a registered node. Each endpoint
 // declares an address (IP or FQDN), port, TLS requirement, and the type of node service it provides.
-// The concrete subtypes are BlockNodeServiceEndpoint, MirrorNodeServiceEndpoint and
-// RpcRelayServiceEndpoint.
+// The concrete subtypes are BlockNodeServiceEndpoint, MirrorNodeServiceEndpoint,
+// RpcRelayServiceEndpoint and GeneralServiceEndpoint.
 type RegisteredServiceEndpoint interface {
 	GetIPAddress() []byte
 	GetDomainName() string
@@ -121,6 +121,8 @@ func _RegisteredServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoi
 		return _MirrorNodeServiceEndpointFromProtobuf(pb)
 	case *services.RegisteredServiceEndpoint_RpcRelay:
 		return _RpcRelayServiceEndpointFromProtobuf(pb)
+	case *services.RegisteredServiceEndpoint_GeneralService:
+		return _GeneralServiceEndpointFromProtobuf(pb)
 	}
 	return nil
 }

--- a/sdk/registered_service_endpoint_unit_test.go
+++ b/sdk/registered_service_endpoint_unit_test.go
@@ -41,7 +41,7 @@ func TestUnitBlockNodeServiceEndpointRoundTripIP(t *testing.T) {
 			port:        8080,
 			requiresTls: true,
 		},
-		endpointApi: BlockNodeApiStatus,
+		endpointApis: []BlockNodeApi{BlockNodeApiStatus},
 	}
 
 	pb := endpoint._ToProtobuf()
@@ -52,7 +52,7 @@ func TestUnitBlockNodeServiceEndpointRoundTripIP(t *testing.T) {
 	assert.Equal(t, ip, block.GetIPAddress())
 	assert.Equal(t, uint32(8080), block.GetPort())
 	assert.True(t, block.GetRequiresTls())
-	assert.Equal(t, BlockNodeApiStatus, block.GetEndpointApi())
+	assert.Equal(t, []BlockNodeApi{BlockNodeApiStatus}, block.GetEndpointApis())
 	assert.Equal(t, "", block.GetDomainName())
 }
 
@@ -148,7 +148,7 @@ func TestUnitBlockNodeServiceEndpointApiRoundTrip(t *testing.T) {
 				ipAddress: []byte{10, 0, 0, 1},
 				port:      8080,
 			},
-			endpointApi: api,
+			endpointApis: []BlockNodeApi{api},
 		}
 
 		pb := endpoint._ToProtobuf()
@@ -156,7 +156,7 @@ func TestUnitBlockNodeServiceEndpointApiRoundTrip(t *testing.T) {
 
 		block, ok := restored.(*BlockNodeServiceEndpoint)
 		assert.True(t, ok)
-		assert.Equal(t, api, block.GetEndpointApi(), "BlockNodeApi %s did not round-trip", api.String())
+		assert.Equal(t, []BlockNodeApi{api}, block.GetEndpointApis(), "BlockNodeApi %s did not round-trip", api.String())
 	}
 }
 
@@ -167,12 +167,12 @@ func TestUnitBlockNodeServiceEndpointSetters(t *testing.T) {
 	endpoint.SetIPAddress([]byte{192, 168, 0, 1}).
 		SetPort(443).
 		SetRequiresTls(true).
-		SetEndpointApi(BlockNodeApiSubscribeStream)
+		AddEndpointApi(BlockNodeApiSubscribeStream)
 
 	assert.Equal(t, []byte{192, 168, 0, 1}, endpoint.GetIPAddress())
 	assert.Equal(t, uint32(443), endpoint.GetPort())
 	assert.True(t, endpoint.GetRequiresTls())
-	assert.Equal(t, BlockNodeApiSubscribeStream, endpoint.GetEndpointApi())
+	assert.Equal(t, []BlockNodeApi{BlockNodeApiSubscribeStream}, endpoint.GetEndpointApis())
 }
 
 func TestUnitMirrorNodeServiceEndpointSetters(t *testing.T) {

--- a/sdk/registered_service_endpoint_unit_test.go
+++ b/sdk/registered_service_endpoint_unit_test.go
@@ -1,0 +1,231 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitBlockNodeApiValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, BlockNodeApi(0), BlockNodeApiOther)
+	assert.Equal(t, BlockNodeApi(1), BlockNodeApiStatus)
+	assert.Equal(t, BlockNodeApi(2), BlockNodeApiPublish)
+	assert.Equal(t, BlockNodeApi(3), BlockNodeApiSubscribeStream)
+	assert.Equal(t, BlockNodeApi(4), BlockNodeApiStateProof)
+}
+
+func TestUnitBlockNodeApiString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "OTHER", BlockNodeApiOther.String())
+	assert.Equal(t, "STATUS", BlockNodeApiStatus.String())
+	assert.Equal(t, "PUBLISH", BlockNodeApiPublish.String())
+	assert.Equal(t, "SUBSCRIBE_STREAM", BlockNodeApiSubscribeStream.String())
+	assert.Equal(t, "STATE_PROOF", BlockNodeApiStateProof.String())
+}
+
+func TestUnitBlockNodeServiceEndpointRoundTripIP(t *testing.T) {
+	t.Parallel()
+
+	ip := []byte{192, 168, 1, 1}
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress:   ip,
+			port:        8080,
+			requiresTls: true,
+		},
+		endpointApi: BlockNodeApiStatus,
+	}
+
+	pb := endpoint._ToProtobuf()
+	restored := _RegisteredServiceEndpointFromProtobuf(pb)
+
+	block, ok := restored.(*BlockNodeServiceEndpoint)
+	assert.True(t, ok, "expected *BlockNodeServiceEndpoint")
+	assert.Equal(t, ip, block.GetIPAddress())
+	assert.Equal(t, uint32(8080), block.GetPort())
+	assert.True(t, block.GetRequiresTls())
+	assert.Equal(t, BlockNodeApiStatus, block.GetEndpointApi())
+	assert.Equal(t, "", block.GetDomainName())
+}
+
+func TestUnitMirrorNodeServiceEndpointRoundTripDomain(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &MirrorNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName:  "mirror.example.com",
+			port:        443,
+			requiresTls: true,
+		},
+	}
+
+	pb := endpoint._ToProtobuf()
+	restored := _RegisteredServiceEndpointFromProtobuf(pb)
+
+	mirror, ok := restored.(*MirrorNodeServiceEndpoint)
+	assert.True(t, ok, "expected *MirrorNodeServiceEndpoint")
+	assert.Equal(t, "mirror.example.com", mirror.GetDomainName())
+	assert.Equal(t, uint32(443), mirror.GetPort())
+	assert.True(t, mirror.GetRequiresTls())
+	assert.Nil(t, mirror.GetIPAddress())
+}
+
+func TestUnitBlockNodeServiceEndpointValidateBothAddresses(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress:  []byte{10, 0, 0, 1},
+			domainName: "example.com",
+		},
+	}
+
+	err := endpoint.Validate()
+	assert.Equal(t, errEndpointCannotHaveBothAddressAndDomainName, err)
+}
+
+func TestUnitMirrorNodeServiceEndpointValidateNoAddress(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &MirrorNodeServiceEndpoint{}
+
+	err := endpoint.Validate()
+	assert.Equal(t, errEndpointMustHaveAddressOrDomainName, err)
+}
+
+func TestUnitRpcRelayServiceEndpointProtobufOneof(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &RpcRelayServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName: "rpc.example.com",
+			port:       8545,
+		},
+	}
+
+	pb := endpoint._ToProtobuf()
+
+	_, ok := pb.EndpointType.(*services.RegisteredServiceEndpoint_RpcRelay)
+	assert.True(t, ok, "expected EndpointType to be *RegisteredServiceEndpoint_RpcRelay")
+}
+
+func TestUnitBlockNodeServiceEndpointValidateValid(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &BlockNodeServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			ipAddress: []byte{10, 0, 0, 1},
+			port:      8080,
+		},
+	}
+
+	err := endpoint.Validate()
+	assert.NoError(t, err)
+}
+
+func TestUnitBlockNodeServiceEndpointApiRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	apis := []BlockNodeApi{
+		BlockNodeApiOther,
+		BlockNodeApiStatus,
+		BlockNodeApiPublish,
+		BlockNodeApiSubscribeStream,
+		BlockNodeApiStateProof,
+	}
+
+	for _, api := range apis {
+		endpoint := &BlockNodeServiceEndpoint{
+			registeredEndpointBase: registeredEndpointBase{
+				ipAddress: []byte{10, 0, 0, 1},
+				port:      8080,
+			},
+			endpointApi: api,
+		}
+
+		pb := endpoint._ToProtobuf()
+		restored := _RegisteredServiceEndpointFromProtobuf(pb)
+
+		block, ok := restored.(*BlockNodeServiceEndpoint)
+		assert.True(t, ok)
+		assert.Equal(t, api, block.GetEndpointApi(), "BlockNodeApi %s did not round-trip", api.String())
+	}
+}
+
+func TestUnitBlockNodeServiceEndpointSetters(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &BlockNodeServiceEndpoint{}
+	endpoint.SetIPAddress([]byte{192, 168, 0, 1}).
+		SetPort(443).
+		SetRequiresTls(true)
+	endpoint.SetEndpointApi(BlockNodeApiSubscribeStream)
+
+	assert.Equal(t, []byte{192, 168, 0, 1}, endpoint.GetIPAddress())
+	assert.Equal(t, uint32(443), endpoint.GetPort())
+	assert.True(t, endpoint.GetRequiresTls())
+	assert.Equal(t, BlockNodeApiSubscribeStream, endpoint.GetEndpointApi())
+}
+
+func TestUnitMirrorNodeServiceEndpointSetters(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &MirrorNodeServiceEndpoint{}
+	endpoint.SetDomainName("mirror.example.com").
+		SetPort(443).
+		SetRequiresTls(true)
+
+	assert.Equal(t, "mirror.example.com", endpoint.GetDomainName())
+	assert.Equal(t, uint32(443), endpoint.GetPort())
+	assert.True(t, endpoint.GetRequiresTls())
+}
+
+func TestUnitRpcRelayServiceEndpointSetters(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &RpcRelayServiceEndpoint{}
+	endpoint.SetDomainName("rpc.example.com").
+		SetPort(8545)
+
+	assert.Equal(t, "rpc.example.com", endpoint.GetDomainName())
+	assert.Equal(t, uint32(8545), endpoint.GetPort())
+	assert.False(t, endpoint.GetRequiresTls())
+}
+
+func TestUnitRegisteredServiceEndpointFromProtobufDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		endpoint RegisteredServiceEndpoint
+	}{
+		{"BlockNode", &BlockNodeServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 1}}},
+		{"MirrorNode", &MirrorNodeServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 2}}},
+		{"RpcRelay", &RpcRelayServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 3}}},
+	}
+
+	for _, tt := range tests {
+		pb := tt.endpoint._ToProtobuf()
+		restored := _RegisteredServiceEndpointFromProtobuf(pb)
+
+		switch tt.name {
+		case "BlockNode":
+			_, ok := restored.(*BlockNodeServiceEndpoint)
+			assert.True(t, ok, "expected *BlockNodeServiceEndpoint")
+		case "MirrorNode":
+			_, ok := restored.(*MirrorNodeServiceEndpoint)
+			assert.True(t, ok, "expected *MirrorNodeServiceEndpoint")
+		case "RpcRelay":
+			_, ok := restored.(*RpcRelayServiceEndpoint)
+			assert.True(t, ok, "expected *RpcRelayServiceEndpoint")
+		}
+	}
+}

--- a/sdk/registered_service_endpoint_unit_test.go
+++ b/sdk/registered_service_endpoint_unit_test.go
@@ -210,6 +210,7 @@ func TestUnitRegisteredServiceEndpointFromProtobufDispatch(t *testing.T) {
 		{"BlockNode", &BlockNodeServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 1}}},
 		{"MirrorNode", &MirrorNodeServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 2}}},
 		{"RpcRelay", &RpcRelayServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 3}}},
+		{"GeneralService", &GeneralServiceEndpoint{registeredEndpointBase: registeredEndpointBase{ipAddress: []byte{1, 2, 3, 4}, port: 4}}},
 	}
 
 	for _, tt := range tests {
@@ -226,6 +227,75 @@ func TestUnitRegisteredServiceEndpointFromProtobufDispatch(t *testing.T) {
 		case "RpcRelay":
 			_, ok := restored.(*RpcRelayServiceEndpoint)
 			assert.True(t, ok, "expected *RpcRelayServiceEndpoint")
+		case "GeneralService":
+			_, ok := restored.(*GeneralServiceEndpoint)
+			assert.True(t, ok, "expected *GeneralServiceEndpoint")
 		}
 	}
+}
+
+func TestUnitGeneralServiceEndpointRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &GeneralServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName:  "general.example.com",
+			port:        9000,
+			requiresTls: true,
+		},
+		description: "custom-service",
+	}
+
+	pb := endpoint._ToProtobuf()
+	restored := _RegisteredServiceEndpointFromProtobuf(pb)
+
+	general, ok := restored.(*GeneralServiceEndpoint)
+	assert.True(t, ok, "expected *GeneralServiceEndpoint")
+	assert.Equal(t, "general.example.com", general.GetDomainName())
+	assert.Equal(t, uint32(9000), general.GetPort())
+	assert.True(t, general.GetRequiresTls())
+	assert.Equal(t, "custom-service", general.GetDescription())
+	assert.Nil(t, general.GetIPAddress())
+}
+
+func TestUnitGeneralServiceEndpointSetters(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &GeneralServiceEndpoint{}
+	endpoint.SetIPAddress([]byte{10, 0, 0, 2}).
+		SetPort(9090).
+		SetRequiresTls(true).
+		SetDescription("my-service")
+
+	assert.Equal(t, []byte{10, 0, 0, 2}, endpoint.GetIPAddress())
+	assert.Equal(t, uint32(9090), endpoint.GetPort())
+	assert.True(t, endpoint.GetRequiresTls())
+	assert.Equal(t, "my-service", endpoint.GetDescription())
+}
+
+func TestUnitGeneralServiceEndpointValidateNoAddress(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &GeneralServiceEndpoint{}
+
+	err := endpoint.Validate()
+	assert.Equal(t, errEndpointMustHaveAddressOrDomainName, err)
+}
+
+func TestUnitGeneralServiceEndpointProtobufOneof(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &GeneralServiceEndpoint{
+		registeredEndpointBase: registeredEndpointBase{
+			domainName: "general.example.com",
+			port:       9000,
+		},
+		description: "custom-service",
+	}
+
+	pb := endpoint._ToProtobuf()
+
+	gs, ok := pb.EndpointType.(*services.RegisteredServiceEndpoint_GeneralService)
+	assert.True(t, ok, "expected EndpointType to be *RegisteredServiceEndpoint_GeneralService")
+	assert.Equal(t, "custom-service", gs.GeneralService.GetDescription())
 }

--- a/sdk/registered_service_endpoint_unit_test.go
+++ b/sdk/registered_service_endpoint_unit_test.go
@@ -166,8 +166,8 @@ func TestUnitBlockNodeServiceEndpointSetters(t *testing.T) {
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress([]byte{192, 168, 0, 1}).
 		SetPort(443).
-		SetRequiresTls(true)
-	endpoint.SetEndpointApi(BlockNodeApiSubscribeStream)
+		SetRequiresTls(true).
+		SetEndpointApi(BlockNodeApiSubscribeStream)
 
 	assert.Equal(t, []byte{192, 168, 0, 1}, endpoint.GetIPAddress())
 	assert.Equal(t, uint32(443), endpoint.GetPort())

--- a/sdk/registered_service_endpoint_unit_test.go
+++ b/sdk/registered_service_endpoint_unit_test.go
@@ -165,24 +165,29 @@ func TestUnitBlockNodeServiceEndpointSetters(t *testing.T) {
 
 	endpoint := &BlockNodeServiceEndpoint{}
 	endpoint.SetIPAddress([]byte{192, 168, 0, 1}).
+		SetDomainName("block.example.com").
 		SetPort(443).
 		SetRequiresTls(true).
-		AddEndpointApi(BlockNodeApiSubscribeStream)
+		AddEndpointApi(BlockNodeApiSubscribeStream).
+		SetEndpointApis([]BlockNodeApi{BlockNodeApiStatus, BlockNodeApiPublish})
 
 	assert.Equal(t, []byte{192, 168, 0, 1}, endpoint.GetIPAddress())
+	assert.Equal(t, "block.example.com", endpoint.GetDomainName())
 	assert.Equal(t, uint32(443), endpoint.GetPort())
 	assert.True(t, endpoint.GetRequiresTls())
-	assert.Equal(t, []BlockNodeApi{BlockNodeApiSubscribeStream}, endpoint.GetEndpointApis())
+	assert.Equal(t, []BlockNodeApi{BlockNodeApiStatus, BlockNodeApiPublish}, endpoint.GetEndpointApis())
 }
 
 func TestUnitMirrorNodeServiceEndpointSetters(t *testing.T) {
 	t.Parallel()
 
 	endpoint := &MirrorNodeServiceEndpoint{}
-	endpoint.SetDomainName("mirror.example.com").
+	endpoint.SetIPAddress([]byte{10, 0, 0, 1}).
+		SetDomainName("mirror.example.com").
 		SetPort(443).
 		SetRequiresTls(true)
 
+	assert.Equal(t, []byte{10, 0, 0, 1}, endpoint.GetIPAddress())
 	assert.Equal(t, "mirror.example.com", endpoint.GetDomainName())
 	assert.Equal(t, uint32(443), endpoint.GetPort())
 	assert.True(t, endpoint.GetRequiresTls())
@@ -192,12 +197,15 @@ func TestUnitRpcRelayServiceEndpointSetters(t *testing.T) {
 	t.Parallel()
 
 	endpoint := &RpcRelayServiceEndpoint{}
-	endpoint.SetDomainName("rpc.example.com").
-		SetPort(8545)
+	endpoint.SetIPAddress([]byte{10, 0, 0, 2}).
+		SetDomainName("rpc.example.com").
+		SetPort(8545).
+		SetRequiresTls(true)
 
+	assert.Equal(t, []byte{10, 0, 0, 2}, endpoint.GetIPAddress())
 	assert.Equal(t, "rpc.example.com", endpoint.GetDomainName())
 	assert.Equal(t, uint32(8545), endpoint.GetPort())
-	assert.False(t, endpoint.GetRequiresTls())
+	assert.True(t, endpoint.GetRequiresTls())
 }
 
 func TestUnitRegisteredServiceEndpointFromProtobufDispatch(t *testing.T) {
@@ -263,11 +271,13 @@ func TestUnitGeneralServiceEndpointSetters(t *testing.T) {
 
 	endpoint := &GeneralServiceEndpoint{}
 	endpoint.SetIPAddress([]byte{10, 0, 0, 2}).
+		SetDomainName("general.example.com").
 		SetPort(9090).
 		SetRequiresTls(true).
 		SetDescription("my-service")
 
 	assert.Equal(t, []byte{10, 0, 0, 2}, endpoint.GetIPAddress())
+	assert.Equal(t, "general.example.com", endpoint.GetDomainName())
 	assert.Equal(t, uint32(9090), endpoint.GetPort())
 	assert.True(t, endpoint.GetRequiresTls())
 	assert.Equal(t, "my-service", endpoint.GetDescription())

--- a/sdk/rpc_relay_service_endpoint.go
+++ b/sdk/rpc_relay_service_endpoint.go
@@ -1,0 +1,32 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+)
+
+// RpcRelayServiceEndpoint a registered service endpoint for an RPC relay.
+type RpcRelayServiceEndpoint struct {
+	registeredEndpointBase
+}
+
+// _ToProtobuf converts this RpcRelayServiceEndpoint to its protobuf representation.
+func (e *RpcRelayServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
+	pb := &services.RegisteredServiceEndpoint{
+		Port:        e.port,
+		RequiresTls: e.requiresTls,
+		EndpointType: &services.RegisteredServiceEndpoint_RpcRelay{
+			RpcRelay: &services.RegisteredServiceEndpoint_RpcRelayEndpoint{},
+		},
+	}
+	e.addressToProtobuf(pb)
+	return pb
+}
+
+// _RpcRelayServiceEndpointFromProtobuf converts a protobuf RegisteredServiceEndpoint to a RpcRelayServiceEndpoint.
+func _RpcRelayServiceEndpointFromProtobuf(pb *services.RegisteredServiceEndpoint) *RpcRelayServiceEndpoint {
+	return &RpcRelayServiceEndpoint{
+		registeredEndpointBase: baseFromProtobuf(pb),
+	}
+}

--- a/sdk/rpc_relay_service_endpoint.go
+++ b/sdk/rpc_relay_service_endpoint.go
@@ -11,6 +11,30 @@ type RpcRelayServiceEndpoint struct {
 	registeredEndpointBase
 }
 
+// SetIPAddress sets the IP address for this endpoint.
+func (e *RpcRelayServiceEndpoint) SetIPAddress(ip []byte) *RpcRelayServiceEndpoint {
+	e.registeredEndpointBase.SetIPAddress(ip)
+	return e
+}
+
+// SetDomainName sets the domain name for this endpoint.
+func (e *RpcRelayServiceEndpoint) SetDomainName(name string) *RpcRelayServiceEndpoint {
+	e.registeredEndpointBase.SetDomainName(name)
+	return e
+}
+
+// SetPort sets the port number for this endpoint.
+func (e *RpcRelayServiceEndpoint) SetPort(port uint32) *RpcRelayServiceEndpoint {
+	e.registeredEndpointBase.SetPort(port)
+	return e
+}
+
+// SetRequiresTls sets whether this endpoint requires TLS.
+func (e *RpcRelayServiceEndpoint) SetRequiresTls(tls bool) *RpcRelayServiceEndpoint {
+	e.registeredEndpointBase.SetRequiresTls(tls)
+	return e
+}
+
 // _ToProtobuf converts this RpcRelayServiceEndpoint to its protobuf representation.
 func (e *RpcRelayServiceEndpoint) _ToProtobuf() *services.RegisteredServiceEndpoint {
 	pb := &services.RegisteredServiceEndpoint{

--- a/sdk/status.go
+++ b/sdk/status.go
@@ -452,7 +452,7 @@ func (status Status) String() string { // nolint
 	case StatusInvalidSolidityID:
 		return "INVALID_SOLIDITY_ID"
 	case StatusUnknown:
-		return "UNKNOWN"
+		return unknownString
 	case StatusSuccess:
 		return "SUCCESS"
 	case StatusFailInvalid:

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -356,6 +356,8 @@ func TransactionFromBytes(data []byte) (TransactionInterface, error) { // nolint
 		childTx = _NodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*NodeDeleteTransaction](baseTx), first)
 	case *services.TransactionBody_RegisteredNodeCreate:
 		childTx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), first)
+	case *services.TransactionBody_RegisteredNodeDelete:
+		childTx = _RegisteredNodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeDeleteTransaction](baseTx), first)
 	case *services.TransactionBody_TokenAirdrop:
 		childTx = _TokenAirdropTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*TokenAirdropTransaction](baseTx), first)
 	case *services.TransactionBody_TokenCancelAirdrop:
@@ -572,6 +574,11 @@ func transactionFromScheduledTransaction(scheduledBody *services.SchedulableTran
 			RegisteredNodeCreate: scheduledBody.GetRegisteredNodeCreate(),
 		}
 		tx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), pbBody)
+	case *services.SchedulableTransactionBody_RegisteredNodeDelete:
+		pbBody.Data = &services.TransactionBody_RegisteredNodeDelete{
+			RegisteredNodeDelete: scheduledBody.GetRegisteredNodeDelete(),
+		}
+		tx = _RegisteredNodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeDeleteTransaction](baseTx), pbBody)
 	default:
 		return nil, errors.New("unrecognized transaction type")
 	}

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -354,6 +354,8 @@ func TransactionFromBytes(data []byte) (TransactionInterface, error) { // nolint
 		childTx = _NodeUpdateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*NodeUpdateTransaction](baseTx), first)
 	case *services.TransactionBody_NodeDelete:
 		childTx = _NodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*NodeDeleteTransaction](baseTx), first)
+	case *services.TransactionBody_RegisteredNodeCreate:
+		childTx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), first)
 	case *services.TransactionBody_TokenAirdrop:
 		childTx = _TokenAirdropTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*TokenAirdropTransaction](baseTx), first)
 	case *services.TransactionBody_TokenCancelAirdrop:
@@ -565,6 +567,11 @@ func transactionFromScheduledTransaction(scheduledBody *services.SchedulableTran
 			ScheduleDelete: scheduledBody.GetScheduleDelete(),
 		}
 		tx = _ScheduleDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*ScheduleDeleteTransaction](baseTx), pbBody)
+	case *services.SchedulableTransactionBody_RegisteredNodeCreate:
+		pbBody.Data = &services.TransactionBody_RegisteredNodeCreate{
+			RegisteredNodeCreate: scheduledBody.GetRegisteredNodeCreate(),
+		}
+		tx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), pbBody)
 	default:
 		return nil, errors.New("unrecognized transaction type")
 	}

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -356,6 +356,8 @@ func TransactionFromBytes(data []byte) (TransactionInterface, error) { // nolint
 		childTx = _NodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*NodeDeleteTransaction](baseTx), first)
 	case *services.TransactionBody_RegisteredNodeCreate:
 		childTx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), first)
+	case *services.TransactionBody_RegisteredNodeUpdate:
+		childTx = _RegisteredNodeUpdateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeUpdateTransaction](baseTx), first)
 	case *services.TransactionBody_RegisteredNodeDelete:
 		childTx = _RegisteredNodeDeleteTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeDeleteTransaction](baseTx), first)
 	case *services.TransactionBody_TokenAirdrop:
@@ -574,6 +576,11 @@ func transactionFromScheduledTransaction(scheduledBody *services.SchedulableTran
 			RegisteredNodeCreate: scheduledBody.GetRegisteredNodeCreate(),
 		}
 		tx = _RegisteredNodeCreateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeCreateTransaction](baseTx), pbBody)
+	case *services.SchedulableTransactionBody_RegisteredNodeUpdate:
+		pbBody.Data = &services.TransactionBody_RegisteredNodeUpdate{
+			RegisteredNodeUpdate: scheduledBody.GetRegisteredNodeUpdate(),
+		}
+		tx = _RegisteredNodeUpdateTransactionFromProtobuf(*castFromBaseToConcreteTransaction[*RegisteredNodeUpdateTransaction](baseTx), pbBody)
 	case *services.SchedulableTransactionBody_RegisteredNodeDelete:
 		pbBody.Data = &services.TransactionBody_RegisteredNodeDelete{
 			RegisteredNodeDelete: scheduledBody.GetRegisteredNodeDelete(),

--- a/sdk/transaction_receipt.go
+++ b/sdk/transaction_receipt.go
@@ -31,6 +31,7 @@ type TransactionReceipt struct {
 	ScheduledTransactionID  *TransactionID
 	SerialNumbers           []int64
 	NodeID                  uint64
+	RegisteredNodeId        uint64
 	Duplicates              []TransactionReceipt
 	Children                []TransactionReceipt
 	TransactionID           *TransactionID
@@ -45,6 +46,7 @@ func (receipt *TransactionReceipt) _ToMap() map[string]interface{} {
 		"totalSupply":             receipt.TotalSupply,
 		"serialNumbers":           receipt.SerialNumbers,
 		"nodeId":                  receipt.NodeID,
+		"registeredNodeId":        receipt.RegisteredNodeId,
 	}
 
 	// The real ExchangeRate struct has cents and ExpirationTime fields as private, so they can't be marshalled directly
@@ -198,6 +200,7 @@ func _TransactionReceiptFromProtobuf(protoResponse *services.TransactionGetRecei
 		ScheduledTransactionID:  scheduledTransactionID,
 		SerialNumbers:           protoReceipt.SerialNumbers,
 		NodeID:                  protoReceipt.NodeId,
+		RegisteredNodeId:        protoReceipt.RegisteredNodeId,
 		Children:                childReceipts,
 		Duplicates:              duplicateReceipts,
 		TransactionID:           transactionID,
@@ -213,6 +216,7 @@ func (receipt TransactionReceipt) _ToProtobuf() *services.TransactionGetReceiptR
 		NewTotalSupply:          receipt.TotalSupply,
 		SerialNumbers:           receipt.SerialNumbers,
 		NodeId:                  receipt.NodeID,
+		RegisteredNodeId:        receipt.RegisteredNodeId,
 	}
 
 	var currentExchangeRate *services.ExchangeRate

--- a/sdk/transaction_receipt.go
+++ b/sdk/transaction_receipt.go
@@ -31,7 +31,7 @@ type TransactionReceipt struct {
 	ScheduledTransactionID  *TransactionID
 	SerialNumbers           []int64
 	NodeID                  uint64
-	RegisteredNodeId        uint64
+	RegisteredNodeId        *uint64
 	Duplicates              []TransactionReceipt
 	Children                []TransactionReceipt
 	TransactionID           *TransactionID
@@ -46,7 +46,11 @@ func (receipt *TransactionReceipt) _ToMap() map[string]interface{} {
 		"totalSupply":             receipt.TotalSupply,
 		"serialNumbers":           receipt.SerialNumbers,
 		"nodeId":                  receipt.NodeID,
-		"registeredNodeId":        receipt.RegisteredNodeId,
+	}
+	if receipt.RegisteredNodeId != nil {
+		m["registeredNodeId"] = *receipt.RegisteredNodeId
+	} else {
+		m["registeredNodeId"] = nil
 	}
 
 	// The real ExchangeRate struct has cents and ExpirationTime fields as private, so they can't be marshalled directly
@@ -183,6 +187,15 @@ func _TransactionReceiptFromProtobuf(protoResponse *services.TransactionGetRecei
 		}
 	}
 
+	// Match the JS SDK: only expose RegisteredNodeId when the wire value is
+	// non-zero, so callers can distinguish "no registered node assigned" from
+	// "registered node 0".
+	var registeredNodeId *uint64
+	if protoReceipt.RegisteredNodeId != 0 {
+		id := protoReceipt.RegisteredNodeId
+		registeredNodeId = &id
+	}
+
 	return TransactionReceipt{
 		Status:                  Status(protoReceipt.Status),
 		ExchangeRate:            rate,
@@ -200,7 +213,7 @@ func _TransactionReceiptFromProtobuf(protoResponse *services.TransactionGetRecei
 		ScheduledTransactionID:  scheduledTransactionID,
 		SerialNumbers:           protoReceipt.SerialNumbers,
 		NodeID:                  protoReceipt.NodeId,
-		RegisteredNodeId:        protoReceipt.RegisteredNodeId,
+		RegisteredNodeId:        registeredNodeId,
 		Children:                childReceipts,
 		Duplicates:              duplicateReceipts,
 		TransactionID:           transactionID,
@@ -216,7 +229,9 @@ func (receipt TransactionReceipt) _ToProtobuf() *services.TransactionGetReceiptR
 		NewTotalSupply:          receipt.TotalSupply,
 		SerialNumbers:           receipt.SerialNumbers,
 		NodeId:                  receipt.NodeID,
-		RegisteredNodeId:        receipt.RegisteredNodeId,
+	}
+	if receipt.RegisteredNodeId != nil {
+		receiptFinal.RegisteredNodeId = *receipt.RegisteredNodeId
 	}
 
 	var currentExchangeRate *services.ExchangeRate

--- a/sdk/transaction_receipt_query_unit_test.go
+++ b/sdk/transaction_receipt_query_unit_test.go
@@ -268,6 +268,7 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
 						TopicID:       &services.TopicID{TopicNum: 654},
 						ScheduleID:    &services.ScheduleID{ScheduleNum: 321},
 						NodeId:        1,
+						RegisteredNodeId: 2,
 						ScheduledTransactionID: &services.TransactionID{
 							AccountID: &services.AccountID{Account: &services.AccountID_AccountNum{
 								AccountNum: 123,
@@ -304,11 +305,12 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
 							ContractID: &services.ContractID{Contract: &services.ContractID_ContractNum{
 								ContractNum: 456,
 							}},
-							FileID:        &services.FileID{FileNum: 789},
-							TokenID:       &services.TokenID{TokenNum: 987},
-							SerialNumbers: []int64{1, 2, 3},
-							TopicID:       &services.TopicID{TopicNum: 654},
-							ScheduleID:    &services.ScheduleID{ScheduleNum: 321},
+							FileID:           &services.FileID{FileNum: 789},
+							TokenID:          &services.TokenID{TokenNum: 987},
+							SerialNumbers:    []int64{1, 2, 3},
+							TopicID:          &services.TopicID{TopicNum: 654},
+							ScheduleID:       &services.ScheduleID{ScheduleNum: 321},
+							RegisteredNodeId: 2,
 							ScheduledTransactionID: &services.TransactionID{
 								AccountID: &services.AccountID{Account: &services.AccountID_AccountNum{
 									AccountNum: 123,
@@ -339,11 +341,12 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
 							ContractID: &services.ContractID{Contract: &services.ContractID_ContractNum{
 								ContractNum: 456,
 							}},
-							FileID:        &services.FileID{FileNum: 789},
-							TokenID:       &services.TokenID{TokenNum: 987},
-							SerialNumbers: []int64{1, 2, 3},
-							TopicID:       &services.TopicID{TopicNum: 654},
-							ScheduleID:    &services.ScheduleID{ScheduleNum: 321},
+							FileID:           &services.FileID{FileNum: 789},
+							TokenID:          &services.TokenID{TokenNum: 987},
+							SerialNumbers:    []int64{1, 2, 3},
+							TopicID:          &services.TopicID{TopicNum: 654},
+							ScheduleID:       &services.ScheduleID{ScheduleNum: 321},
+							RegisteredNodeId: 2,
 							ScheduledTransactionID: &services.TransactionID{
 								AccountID: &services.AccountID{Account: &services.AccountID_AccountNum{
 									AccountNum: 123,
@@ -404,6 +407,7 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
          },
          "fileId":"0.0.789",
          "nodeId":0,
+         "registeredNodeId":2,
          "scheduleId":"0.0.321",
          "scheduledTransactionId":"0.0.123@1694689200.000000000",
          "serialNumbers":[
@@ -425,11 +429,11 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
       {
          "accountId":"0.0.123",
          "children":[
-            
+
          ],
          "contractId":"0.0.456",
          "duplicates":[
-            
+
          ],
          "fileId":"0.0.789",
          "nextExchangeRate":{
@@ -438,6 +442,7 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
             "hbars":50000
          },
          "nodeId":0,
+         "registeredNodeId":2,
          "scheduleId":"0.0.321",
          "scheduledTransactionId":"0.0.123@1694689200.000000000",
          "serialNumbers":[
@@ -466,6 +471,7 @@ func TestUnitTransactionReceiptToJson(t *testing.T) {
       "hbars":50000
    },
    "nodeId":1,
+   "registeredNodeId":2,
    "scheduleId":"0.0.321",
    "scheduledTransactionId":"0.0.123@1694689200.000000000",
    "serialNumbers":[

--- a/sdk/transaction_record_query_unit_test.go
+++ b/sdk/transaction_record_query_unit_test.go
@@ -262,6 +262,7 @@ func TestUnitTransactionRecordQueryMarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	record.Receipt.ContractID = &contractID
 	record.Receipt.NodeID = 1
+	record.Receipt.RegisteredNodeId = 2
 
 	tokenTransfer := TokenTransfer{
 		AccountID:  accID,
@@ -363,6 +364,7 @@ func TestUnitTransactionRecordQueryMarshalJSON(t *testing.T) {
             "exchangeRate":{"cents":12,"expirationTime":"1963-11-25T17:31:44.000Z","hbars":1},
             "fileId":null,
             "nodeId":1,
+            "registeredNodeId":2,
             "scheduleId":null,
             "scheduledTransactionId":null,
             "serialNumbers":null,

--- a/sdk/transaction_record_query_unit_test.go
+++ b/sdk/transaction_record_query_unit_test.go
@@ -262,7 +262,8 @@ func TestUnitTransactionRecordQueryMarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	record.Receipt.ContractID = &contractID
 	record.Receipt.NodeID = 1
-	record.Receipt.RegisteredNodeId = 2
+	registeredNodeId := uint64(2)
+	record.Receipt.RegisteredNodeId = &registeredNodeId
 
 	tokenTransfer := TokenTransfer{
 		AccountID:  accID,

--- a/sdk/transaction_unit_test.go
+++ b/sdk/transaction_unit_test.go
@@ -469,6 +469,9 @@ func TestUnitTransactionSignSwitchCases(t *testing.T) {
 		NewTopicDeleteTransaction(),
 		NewTopicUpdateTransaction(),
 		NewTransferTransaction(),
+		NewRegisteredNodeCreateTransaction(),
+		NewRegisteredNodeUpdateTransaction(),
+		NewRegisteredNodeDeleteTransaction(),
 	}
 
 	for _, tx := range txs {
@@ -531,6 +534,9 @@ func TestUnitTransactionSignSwitchCasesPointers(t *testing.T) {
 		NewTopicDeleteTransaction(),
 		NewTopicUpdateTransaction(),
 		NewTransferTransaction(),
+		NewRegisteredNodeCreateTransaction(),
+		NewRegisteredNodeUpdateTransaction(),
+		NewRegisteredNodeDeleteTransaction(),
 	}
 
 	for _, tx := range txs {
@@ -601,6 +607,9 @@ func TestUnitTransactionAttributes(t *testing.T) {
 		NewTopicDeleteTransaction(),
 		NewTopicUpdateTransaction(),
 		NewTransferTransaction(),
+		NewRegisteredNodeCreateTransaction(),
+		NewRegisteredNodeUpdateTransaction(),
+		NewRegisteredNodeDeleteTransaction(),
 	}
 
 	for _, tx := range txs {
@@ -668,6 +677,9 @@ func TestUnitTransactionAttributesDereferanced(t *testing.T) {
 		NewTopicDeleteTransaction(),
 		NewTopicUpdateTransaction(),
 		NewTransferTransaction(),
+		NewRegisteredNodeCreateTransaction(),
+		NewRegisteredNodeUpdateTransaction(),
+		NewRegisteredNodeDeleteTransaction(),
 	}
 
 	for _, tx := range txs {
@@ -733,6 +745,9 @@ func TestUnitTransactionAttributesSerialization(t *testing.T) {
 		NewTopicDeleteTransaction(),
 		NewTopicUpdateTransaction(),
 		NewTransferTransaction(),
+		NewRegisteredNodeCreateTransaction(),
+		NewRegisteredNodeUpdateTransaction(),
+		NewRegisteredNodeDeleteTransaction(),
 	}
 
 	for _, tx := range txs {

--- a/sdk/utilities_for_test.go
+++ b/sdk/utilities_for_test.go
@@ -1,4 +1,4 @@
-//go:build all || unit || e2e || testnets || abnet
+//go:build all || unit || e2e || testnets || abnet || dab
 
 package hiero
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

 Add support for HIP-1137.                                                                                                                                                                                                                                                                            
                          
 - Add BlockNodeApi enum with well-known block node API kinds (OTHER, STATUS, PUBLISH, SUBSCRIBE_STREAM, STATE_PROOF)                                                                                                                                                                                 
 - Add RegisteredServiceEndpoint interface with registeredEndpointBase shared struct for common endpoint fields (IP/domain, port, TLS)
 - Add BlockNodeServiceEndpoint, MirrorNodeServiceEndpoint, RpcRelayServiceEndpoint, and GeneralServiceEndpoint as concrete endpoint subtypes with protobuf round-trip support                                                                                                                        
 - Add RegisteredNodeCreateTransaction for creating registered nodes with admin key, description, and service endpoints                                                                                                                                                                               
 - Add RegisteredNodeUpdateTransaction for updating registered node description, admin key, and service endpoints                                                                                                                                                                                     
 - Add RegisteredNodeDeleteTransaction for removing registered nodes from the address book                                                                                                                                                                                                            
 - Wire all three registered-node transactions into SchedulableTransactionBody so they can be scheduled via ScheduleCreateTransaction
 - Add RegisteredNodeAddressBookQuery (REST against the mirror node) along with RegisteredNode and RegisteredNodeAddressBook result types — supports SetRegisteredNodeId filtering and SetLimit page size                                                                                                                                                                                                                              
 - Add RegisteredNodeId field to TransactionReceipt                                                                                                                                                                                                                                                   
 - Add new response status codes (INVALID_REGISTERED_NODE_ID, INVALID_REGISTERED_ENDPOINT, REGISTERED_ENDPOINTS_EXCEEDED_LIMIT, INVALID_REGISTERED_ENDPOINT_ADDRESS, INVALID_REGISTERED_ENDPOINT_TYPE, REGISTERED_NODE_STILL_ASSOCIATED, MAX_REGISTERED_NODES_EXCEEDED)                               
 - Add associatedRegisteredNodes field to NodeCreateTransaction with setter and getter                                                                                                                                                                                                                
 - Add associatedRegisteredNodes field to NodeUpdateTransaction with Set/Add/Clear/Get methods (three-state semantics: nil = unchanged, empty = clear, non-empty = replace)                                                                                                                           
 - Add examples/registered_node/main.go walking through the full lifecycle                                                                                                                                             
 - Add unit tests for all new types and transactions including mock server, protobuf round-trip, coverage, and serialization tests                                                                                                                                                                    
 - Add e2e tests covering the test plan**, with mirror-node verification on every success-path test**                                                                                                                                                                                                 
 - Fix record/receipt query unit tests that need the new registeredNodeId field                                                                                                                                                                                                                       
 - Add constants.go and extract shared "UNKNOWN" string literal to fix goconst lint warning            

**Related issue(s)**:

Fixes #1634

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
