### PR TITLE
feat: add EthereumEipXXXXTransaction support

### DIFF
--- a/sdk/access_list_item.go
+++ b/sdk/access_list_item.go
@@ -1,0 +1,122 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// AccessListItem represents an entry in an EIP-2930 access list.
+// Each entry specifies an Ethereum address and a list of storage keys
+// that the transaction plans to access.
+type AccessListItem struct {
+	address     []byte
+	storageKeys [][]byte
+}
+
+// NewAccessListItem creates a new AccessListItem with the given address and storage keys.
+func NewAccessListItem(address []byte, storageKeys [][]byte) AccessListItem {
+	return AccessListItem{
+		address:     address,
+		storageKeys: storageKeys,
+	}
+}
+
+// GetAddress returns the Ethereum address for this access list entry.
+func (a *AccessListItem) GetAddress() []byte { return a.address }
+
+// SetAddress sets the Ethereum address for this access list entry.
+func (a *AccessListItem) SetAddress(address []byte) *AccessListItem {
+	a.address = address
+	return a
+}
+
+// GetStorageKeys returns the storage keys for this access list entry.
+func (a *AccessListItem) GetStorageKeys() [][]byte { return a.storageKeys }
+
+// SetStorageKeys sets the storage keys for this access list entry.
+func (a *AccessListItem) SetStorageKeys(storageKeys [][]byte) *AccessListItem {
+	a.storageKeys = storageKeys
+	return a
+}
+
+// AddStorageKey appends a storage key to this access list entry.
+func (a *AccessListItem) AddStorageKey(storageKey []byte) *AccessListItem {
+	a.storageKeys = append(a.storageKeys, storageKey)
+	return a
+}
+
+// String returns a string representation of the AccessListItem.
+func (a AccessListItem) String() string {
+	var encodedKeys []string
+	for _, key := range a.storageKeys {
+		encodedKeys = append(encodedKeys, hex.EncodeToString(key))
+	}
+	return fmt.Sprintf("{Address: %s, StorageKeys: [%s]}",
+		hex.EncodeToString(a.address),
+		strings.Join(encodedKeys, ", "),
+	)
+}
+
+// _accessListItemToBytes encodes an AccessListItem as RLP [address, [storageKeys...]].
+func _accessListItemToBytes(a AccessListItem) []byte {
+	item := NewRLPItem(LIST_TYPE)
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(a.address))
+
+	storageKeysItem := NewRLPItem(LIST_TYPE)
+	for _, key := range a.storageKeys {
+		storageKeysItem.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(key))
+	}
+	item.PushBack(storageKeysItem)
+
+	bytes, _ := item.Write()
+	return bytes
+}
+
+// _accessListItemsToBytes converts a slice of AccessListItem into [][]byte.
+func _accessListItemsToBytes(items []AccessListItem) [][]byte {
+	result := make([][]byte, len(items))
+	for i, item := range items {
+		result[i] = _accessListItemToBytes(item)
+	}
+	return result
+}
+
+// _accessListItemFromBytes decodes a single RLP-encoded byte slice into an AccessListItem.
+func _accessListItemFromBytes(data []byte) (AccessListItem, error) {
+	item := NewRLPItem(LIST_TYPE)
+	if err := item.Read(data); err != nil {
+		return AccessListItem{}, fmt.Errorf("failed to decode access list entry: %w", err)
+	}
+
+	if item.itemType != LIST_TYPE || len(item.childItems) != 2 {
+		return AccessListItem{}, fmt.Errorf("invalid access list entry: expected list of [address, storageKeys]")
+	}
+
+	address := item.childItems[0].itemValue
+
+	var storageKeys [][]byte
+	if item.childItems[1].itemType == LIST_TYPE {
+		for _, keyItem := range item.childItems[1].childItems {
+			storageKeys = append(storageKeys, keyItem.itemValue)
+		}
+	}
+
+	return NewAccessListItem(address, storageKeys), nil
+}
+
+// _accessListItemsFromBytes converts [][]byte into a slice of AccessListItem.
+// Entries that fail to decode are skipped.
+func _accessListItemsFromBytes(data [][]byte) []AccessListItem {
+	var result []AccessListItem
+	for _, entry := range data {
+		ali, err := _accessListItemFromBytes(entry)
+		if err != nil {
+			continue
+		}
+		result = append(result, ali)
+	}
+	return result
+}

--- a/sdk/access_list_item_unit_test.go
+++ b/sdk/access_list_item_unit_test.go
@@ -1,0 +1,146 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitAccessListItemGettersSetters(t *testing.T) {
+	t.Parallel()
+
+	addr := []byte{0x01, 0x02, 0x03}
+	k1 := []byte{0x10}
+	k2 := []byte{0x20}
+
+	item := NewAccessListItem(addr, [][]byte{k1, k2})
+
+	assert.Equal(t, addr, item.GetAddress())
+	assert.Equal(t, [][]byte{k1, k2}, item.GetStorageKeys())
+
+	newAddr := []byte{0xAA, 0xBB}
+	item.SetAddress(newAddr)
+	assert.Equal(t, newAddr, item.GetAddress())
+
+	newKeys := [][]byte{{0x30}, {0x40}}
+	item.SetStorageKeys(newKeys)
+	assert.Equal(t, newKeys, item.GetStorageKeys())
+
+	item.AddStorageKey([]byte{0x50})
+	assert.Equal(t, 3, len(item.GetStorageKeys()))
+	assert.Equal(t, []byte{0x50}, item.GetStorageKeys()[2])
+}
+
+func TestUnitAccessListItemChaining(t *testing.T) {
+	t.Parallel()
+
+	addr := []byte{0xDE, 0xAD}
+	item := NewAccessListItem(nil, nil)
+	item.SetAddress(addr).
+		SetStorageKeys([][]byte{{0x01}}).
+		AddStorageKey([]byte{0x02})
+
+	assert.Equal(t, addr, item.GetAddress())
+	require.Equal(t, 2, len(item.GetStorageKeys()))
+}
+
+func TestUnitAccessListItemRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := NewAccessListItem(
+		[]byte{0x01, 0x02, 0x03, 0x04},
+		[][]byte{
+			{0xA1, 0xA2},
+			{0xB1, 0xB2, 0xB3},
+		},
+	)
+
+	encoded := _accessListItemToBytes(original)
+	decoded, err := _accessListItemFromBytes(encoded)
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal(original.GetAddress(), decoded.GetAddress()))
+	require.Equal(t, len(original.GetStorageKeys()), len(decoded.GetStorageKeys()))
+	for i, k := range original.GetStorageKeys() {
+		assert.True(t, bytes.Equal(k, decoded.GetStorageKeys()[i]))
+	}
+}
+
+func TestUnitAccessListItemsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	items := []AccessListItem{
+		NewAccessListItem([]byte{0x11}, [][]byte{{0x01}, {0x02}}),
+		NewAccessListItem([]byte{0x22}, nil),
+	}
+
+	encoded := _accessListItemsToBytes(items)
+	require.Equal(t, 2, len(encoded))
+
+	decoded := _accessListItemsFromBytes(encoded)
+	require.Equal(t, 2, len(decoded))
+	assert.Equal(t, items[0].GetAddress(), decoded[0].GetAddress())
+	assert.Equal(t, items[1].GetAddress(), decoded[1].GetAddress())
+}
+
+func TestUnitEIP1559AccessListItems(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP1559Transaction{}
+	items := []AccessListItem{
+		NewAccessListItem([]byte{0xAA}, [][]byte{{0x01}}),
+		NewAccessListItem([]byte{0xBB}, [][]byte{{0x02}, {0x03}}),
+	}
+	tx.SetAccessListItems(items)
+
+	roundTrip := tx.GetAccessListItems()
+	require.Equal(t, 2, len(roundTrip))
+	assert.Equal(t, []byte{0xAA}, roundTrip[0].GetAddress())
+	assert.Equal(t, []byte{0xBB}, roundTrip[1].GetAddress())
+
+	tx.AddAccessListItem(NewAccessListItem([]byte{0xCC}, nil))
+	assert.Equal(t, 3, len(tx.GetAccessListItems()))
+}
+
+func TestUnitEIP2930AccessListItems(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP2930Transaction{}
+	tx.AddAccessListItem(NewAccessListItem([]byte{0xAA}, [][]byte{{0x01}}))
+	tx.AddAccessListItem(NewAccessListItem([]byte{0xBB}, nil))
+
+	got := tx.GetAccessListItems()
+	require.Equal(t, 2, len(got))
+	assert.Equal(t, []byte{0xAA}, got[0].GetAddress())
+	assert.Equal(t, []byte{0xBB}, got[1].GetAddress())
+}
+
+func TestUnitEIP7702AccessListItems(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP7702Transaction{}
+	items := []AccessListItem{
+		NewAccessListItem([]byte{0x01}, [][]byte{{0xFE}}),
+	}
+	tx.SetAccessListItems(items)
+
+	got := tx.GetAccessListItems()
+	require.Equal(t, 1, len(got))
+	assert.Equal(t, []byte{0x01}, got[0].GetAddress())
+	assert.Equal(t, [][]byte{{0xFE}}, got[0].GetStorageKeys())
+}
+
+func TestUnitAccessListItemEmptyList(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP1559Transaction{}
+	assert.Equal(t, 0, len(tx.GetAccessListItems()))
+	tx.SetAccessListItems(nil)
+	assert.Equal(t, 0, len(tx.GetAccessListItems()))
+}

--- a/sdk/access_list_item_unit_test.go
+++ b/sdk/access_list_item_unit_test.go
@@ -144,3 +144,25 @@ func TestUnitAccessListItemEmptyList(t *testing.T) {
 	tx.SetAccessListItems(nil)
 	assert.Equal(t, 0, len(tx.GetAccessListItems()))
 }
+
+func TestUnitAccessListItemString(t *testing.T) {
+	t.Parallel()
+
+	item := NewAccessListItem([]byte{0xab, 0xcd}, [][]byte{{0x01}, {0x02}})
+	s := item.String()
+	assert.Contains(t, s, "abcd")
+	assert.Contains(t, s, "Address:")
+	assert.Contains(t, s, "StorageKeys:")
+}
+
+func TestUnitAccessListItemFromBytesError(t *testing.T) {
+	t.Parallel()
+
+	// A value (non-list) RLP payload is not a valid [address, storageKeys] entry.
+	value := NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01})
+	notAList, err := value.Write()
+	require.NoError(t, err)
+
+	_, err = _accessListItemFromBytes(notAList)
+	assert.Error(t, err)
+}

--- a/sdk/authorization.go
+++ b/sdk/authorization.go
@@ -1,0 +1,131 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// Authorization represents a single EIP-7702 authorization tuple
+// [chainId, address, nonce, yParity, r, s], authorizing the delegation of an
+// EOA's code to a contract address. Introduced for SDKs in HIP-1340.
+type Authorization struct {
+	chainId []byte
+	address []byte
+	nonce   uint64
+	yParity uint32
+	r       []byte
+	s       []byte
+}
+
+// NewAuthorization creates a new Authorization with the provided fields.
+func NewAuthorization(chainId, address []byte, nonce uint64, yParity uint32, r, s []byte) Authorization {
+	return Authorization{
+		chainId: chainId,
+		address: address,
+		nonce:   nonce,
+		yParity: yParity,
+		r:       r,
+		s:       s,
+	}
+}
+
+// GetChainId returns the chain id for this authorization.
+func (a *Authorization) GetChainId() []byte { return a.chainId }
+
+// SetChainId sets the chain id for this authorization.
+func (a *Authorization) SetChainId(chainId []byte) *Authorization {
+	a.chainId = chainId
+	return a
+}
+
+// GetAddress returns the delegated contract address.
+func (a *Authorization) GetAddress() []byte { return a.address }
+
+// SetAddress sets the delegated contract address.
+func (a *Authorization) SetAddress(address []byte) *Authorization {
+	a.address = address
+	return a
+}
+
+// GetNonce returns the authorization nonce.
+func (a *Authorization) GetNonce() uint64 { return a.nonce }
+
+// SetNonce sets the authorization nonce.
+func (a *Authorization) SetNonce(nonce uint64) *Authorization {
+	a.nonce = nonce
+	return a
+}
+
+// GetYParity returns the signature y-parity (recovery id).
+func (a *Authorization) GetYParity() uint32 { return a.yParity }
+
+// SetYParity sets the signature y-parity (recovery id).
+func (a *Authorization) SetYParity(yParity uint32) *Authorization {
+	a.yParity = yParity
+	return a
+}
+
+// GetR returns the R signature component.
+func (a *Authorization) GetR() []byte { return a.r }
+
+// SetR sets the R signature component.
+func (a *Authorization) SetR(r []byte) *Authorization {
+	a.r = r
+	return a
+}
+
+// GetS returns the S signature component.
+func (a *Authorization) GetS() []byte { return a.s }
+
+// SetS sets the S signature component.
+func (a *Authorization) SetS(s []byte) *Authorization {
+	a.s = s
+	return a
+}
+
+// String returns a string representation of the Authorization.
+func (a Authorization) String() string {
+	return fmt.Sprintf("{ChainId: %s, Address: %s, Nonce: %d, YParity: %d, R: %s, S: %s}",
+		hex.EncodeToString(a.chainId),
+		hex.EncodeToString(a.address),
+		a.nonce,
+		a.yParity,
+		hex.EncodeToString(a.r),
+		hex.EncodeToString(a.s),
+	)
+}
+
+// _toRLPItem encodes the authorization as a 6-element RLP list, with nonce and
+// yParity in canonical minimal big-endian form.
+func (a Authorization) _toRLPItem() *RLPItem {
+	item := NewRLPItem(LIST_TYPE)
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(a.chainId))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(a.address))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(_uint64ToEthBytes(a.nonce)))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(_uint64ToEthBytes(uint64(a.yParity))))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(a.r))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(a.s))
+	return item
+}
+
+// _authorizationFromRLPItem decodes a 6-element RLP list into an Authorization.
+func _authorizationFromRLPItem(item *RLPItem) (Authorization, error) {
+	if item.itemType != LIST_TYPE {
+		return Authorization{}, errors.New("invalid authorization list entry: must be a list")
+	}
+	if len(item.childItems) != 6 {
+		return Authorization{}, errors.New("invalid authorization list entry: must be [chainId, address, nonce, yParity, r, s]")
+	}
+	return NewAuthorization(
+		item.childItems[0].itemValue,
+		item.childItems[1].itemValue,
+		_ethBytesToUint64(item.childItems[2].itemValue),
+		uint32(_ethBytesToUint64(item.childItems[3].itemValue)),
+		item.childItems[4].itemValue,
+		item.childItems[5].itemValue,
+	), nil
+}

--- a/sdk/authorization_unit_test.go
+++ b/sdk/authorization_unit_test.go
@@ -1,0 +1,85 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitAuthorizationGettersSetters(t *testing.T) {
+	t.Parallel()
+
+	chainId := []byte{0x01, 0x2a}
+	addr := []byte{0xAA, 0xBB}
+	r := []byte{0x11}
+	s := []byte{0x22}
+
+	auth := NewAuthorization(chainId, addr, 5, 1, r, s)
+
+	assert.Equal(t, chainId, auth.GetChainId())
+	assert.Equal(t, addr, auth.GetAddress())
+	assert.Equal(t, uint64(5), auth.GetNonce())
+	assert.Equal(t, uint32(1), auth.GetYParity())
+	assert.Equal(t, r, auth.GetR())
+	assert.Equal(t, s, auth.GetS())
+
+	auth.SetChainId([]byte{0x09}).
+		SetAddress([]byte{0xCC}).
+		SetNonce(7).
+		SetYParity(0).
+		SetR([]byte{0x33}).
+		SetS([]byte{0x44})
+
+	assert.Equal(t, []byte{0x09}, auth.GetChainId())
+	assert.Equal(t, []byte{0xCC}, auth.GetAddress())
+	assert.Equal(t, uint64(7), auth.GetNonce())
+	assert.Equal(t, uint32(0), auth.GetYParity())
+	assert.Equal(t, []byte{0x33}, auth.GetR())
+	assert.Equal(t, []byte{0x44}, auth.GetS())
+}
+
+func TestUnitAuthorizationString(t *testing.T) {
+	t.Parallel()
+
+	auth := NewAuthorization([]byte{0xab, 0xcd}, []byte{0xde}, 3, 1, []byte{0x11}, []byte{0x22})
+	str := auth.String()
+	assert.Contains(t, str, "ChainId:")
+	assert.Contains(t, str, "abcd")
+	assert.Contains(t, str, "Nonce: 3")
+	assert.Contains(t, str, "YParity: 1")
+}
+
+func TestUnitAuthorizationRLPRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	auth := NewAuthorization([]byte{0x01, 0x2a}, make([]byte, 20), 5, 1, make([]byte, 32), make([]byte, 32))
+
+	encoded, err := auth._toRLPItem().Write()
+	require.NoError(t, err)
+
+	item := NewRLPItem(LIST_TYPE)
+	require.NoError(t, item.Read(encoded))
+
+	decoded, err := _authorizationFromRLPItem(item)
+	require.NoError(t, err)
+	assert.Equal(t, auth, decoded)
+}
+
+func TestUnitAuthorizationFromRLPItemErrors(t *testing.T) {
+	t.Parallel()
+
+	// Not a list.
+	_, err := _authorizationFromRLPItem(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	assert.Error(t, err)
+
+	// A list, but not 6 elements.
+	short := NewRLPItem(LIST_TYPE)
+	short.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	_, err = _authorizationFromRLPItem(short)
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_eip1559_transaction.go
+++ b/sdk/ethereum_eip1559_transaction.go
@@ -5,6 +5,7 @@ package hiero
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -177,4 +178,204 @@ func (txn *EthereumEIP1559Transaction) String() string {
 		hex.EncodeToString(txn.R),
 		hex.EncodeToString(txn.S),
 	)
+}
+
+// GetChainId returns the chain id as a uint64.
+func (txn *EthereumEIP1559Transaction) GetChainId() uint64 {
+	return _ethBytesToUint64(txn.ChainId)
+}
+
+// SetChainId sets the chain id from a uint64.
+func (txn *EthereumEIP1559Transaction) SetChainId(v uint64) *EthereumEIP1559Transaction {
+	txn.ChainId = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetChainIdBytes returns the raw canonical big-endian chain id bytes.
+func (txn *EthereumEIP1559Transaction) GetChainIdBytes() []byte { return txn.ChainId }
+
+// SetChainIdBytes sets the chain id from raw canonical big-endian bytes.
+func (txn *EthereumEIP1559Transaction) SetChainIdBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.ChainId = v
+	return txn
+}
+
+// GetNonce returns the nonce as a uint64.
+func (txn *EthereumEIP1559Transaction) GetNonce() uint64 {
+	return _ethBytesToUint64(txn.Nonce)
+}
+
+// SetNonce sets the nonce from a uint64.
+func (txn *EthereumEIP1559Transaction) SetNonce(v uint64) *EthereumEIP1559Transaction {
+	txn.Nonce = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetNonceBytes returns the raw canonical big-endian nonce bytes.
+func (txn *EthereumEIP1559Transaction) GetNonceBytes() []byte { return txn.Nonce }
+
+// SetNonceBytes sets the nonce from raw canonical big-endian bytes.
+func (txn *EthereumEIP1559Transaction) SetNonceBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.Nonce = v
+	return txn
+}
+
+// GetMaxPriorityGas returns the max priority fee per gas as a *big.Int.
+func (txn *EthereumEIP1559Transaction) GetMaxPriorityGas() *big.Int {
+	return _ethBytesToBigInt(txn.MaxPriorityGas)
+}
+
+// SetMaxPriorityGas sets the max priority fee per gas from a *big.Int.
+func (txn *EthereumEIP1559Transaction) SetMaxPriorityGas(v *big.Int) *EthereumEIP1559Transaction {
+	txn.MaxPriorityGas = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetMaxPriorityGasBytes returns the raw canonical big-endian max priority fee bytes.
+func (txn *EthereumEIP1559Transaction) GetMaxPriorityGasBytes() []byte { return txn.MaxPriorityGas }
+
+// SetMaxPriorityGasBytes sets the max priority fee per gas from raw bytes.
+func (txn *EthereumEIP1559Transaction) SetMaxPriorityGasBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.MaxPriorityGas = v
+	return txn
+}
+
+// GetMaxGas returns the max fee per gas as a *big.Int.
+func (txn *EthereumEIP1559Transaction) GetMaxGas() *big.Int {
+	return _ethBytesToBigInt(txn.MaxGas)
+}
+
+// SetMaxGas sets the max fee per gas from a *big.Int.
+func (txn *EthereumEIP1559Transaction) SetMaxGas(v *big.Int) *EthereumEIP1559Transaction {
+	txn.MaxGas = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetMaxGasBytes returns the raw canonical big-endian max fee bytes.
+func (txn *EthereumEIP1559Transaction) GetMaxGasBytes() []byte { return txn.MaxGas }
+
+// SetMaxGasBytes sets the max fee per gas from raw bytes.
+func (txn *EthereumEIP1559Transaction) SetMaxGasBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.MaxGas = v
+	return txn
+}
+
+// GetGasLimit returns the gas limit as a uint64.
+func (txn *EthereumEIP1559Transaction) GetGasLimit() uint64 {
+	return _ethBytesToUint64(txn.GasLimit)
+}
+
+// SetGasLimit sets the gas limit from a uint64.
+func (txn *EthereumEIP1559Transaction) SetGasLimit(v uint64) *EthereumEIP1559Transaction {
+	txn.GasLimit = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetGasLimitBytes returns the raw canonical big-endian gas limit bytes.
+func (txn *EthereumEIP1559Transaction) GetGasLimitBytes() []byte { return txn.GasLimit }
+
+// SetGasLimitBytes sets the gas limit from raw bytes.
+func (txn *EthereumEIP1559Transaction) SetGasLimitBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.GasLimit = v
+	return txn
+}
+
+// GetTo returns the recipient address bytes.
+func (txn *EthereumEIP1559Transaction) GetTo() []byte { return txn.To }
+
+// SetTo sets the recipient address bytes.
+func (txn *EthereumEIP1559Transaction) SetTo(v []byte) *EthereumEIP1559Transaction {
+	txn.To = v
+	return txn
+}
+
+// GetValue returns the transaction value (wei) as a *big.Int.
+func (txn *EthereumEIP1559Transaction) GetValue() *big.Int {
+	return _ethBytesToBigInt(txn.Value)
+}
+
+// SetValue sets the transaction value (wei) from a *big.Int.
+func (txn *EthereumEIP1559Transaction) SetValue(v *big.Int) *EthereumEIP1559Transaction {
+	txn.Value = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetValueBytes returns the raw canonical big-endian value bytes.
+func (txn *EthereumEIP1559Transaction) GetValueBytes() []byte { return txn.Value }
+
+// SetValueBytes sets the value from raw bytes.
+func (txn *EthereumEIP1559Transaction) SetValueBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.Value = v
+	return txn
+}
+
+// GetCallData returns the call data.
+func (txn *EthereumEIP1559Transaction) GetCallData() []byte { return txn.CallData }
+
+// SetCallData sets the call data.
+func (txn *EthereumEIP1559Transaction) SetCallData(v []byte) *EthereumEIP1559Transaction {
+	txn.CallData = v
+	return txn
+}
+
+// GetRecoveryId returns the recovery id as an int.
+func (txn *EthereumEIP1559Transaction) GetRecoveryId() int {
+	if len(txn.RecoveryId) == 0 {
+		return 0
+	}
+	return int(txn.RecoveryId[0])
+}
+
+// SetRecoveryId sets the recovery id from an int.
+func (txn *EthereumEIP1559Transaction) SetRecoveryId(v int) *EthereumEIP1559Transaction {
+	if v == 0 {
+		txn.RecoveryId = []byte{}
+	} else {
+		txn.RecoveryId = []byte{byte(v)}
+	}
+	return txn
+}
+
+// GetRecoveryIdBytes returns the raw recovery id bytes.
+func (txn *EthereumEIP1559Transaction) GetRecoveryIdBytes() []byte { return txn.RecoveryId }
+
+// SetRecoveryIdBytes sets the recovery id from raw bytes.
+func (txn *EthereumEIP1559Transaction) SetRecoveryIdBytes(v []byte) *EthereumEIP1559Transaction {
+	txn.RecoveryId = v
+	return txn
+}
+
+// GetR returns the R signature component.
+func (txn *EthereumEIP1559Transaction) GetR() []byte { return txn.R }
+
+// SetR sets the R signature component.
+func (txn *EthereumEIP1559Transaction) SetR(v []byte) *EthereumEIP1559Transaction {
+	txn.R = v
+	return txn
+}
+
+// GetS returns the S signature component.
+func (txn *EthereumEIP1559Transaction) GetS() []byte { return txn.S }
+
+// SetS sets the S signature component.
+func (txn *EthereumEIP1559Transaction) SetS(v []byte) *EthereumEIP1559Transaction {
+	txn.S = v
+	return txn
+}
+
+// GetAccessListItems returns the access list as structured AccessListItem entries.
+func (txn *EthereumEIP1559Transaction) GetAccessListItems() []AccessListItem {
+	return _accessListItemsFromBytes(txn.AccessList)
+}
+
+// SetAccessListItems replaces the access list from structured AccessListItem entries.
+func (txn *EthereumEIP1559Transaction) SetAccessListItems(items []AccessListItem) *EthereumEIP1559Transaction {
+	txn.AccessList = _accessListItemsToBytes(items)
+	return txn
+}
+
+// AddAccessListItem appends a single access list entry.
+func (txn *EthereumEIP1559Transaction) AddAccessListItem(item AccessListItem) *EthereumEIP1559Transaction {
+	txn.AccessList = append(txn.AccessList, _accessListItemToBytes(item))
+	return txn
 }

--- a/sdk/ethereum_eip1559_transaction.go
+++ b/sdk/ethereum_eip1559_transaction.go
@@ -85,8 +85,8 @@ func EthereumEIP1559TransactionFromBytes(bytes []byte) (*EthereumEIP1559Transact
 	), nil
 }
 
-// ToBytes encodes the EthereumEIP1559Transaction into RLP format.
-func (txn *EthereumEIP1559Transaction) ToBytes() ([]byte, error) {
+// _toUnsignedRLP builds the unsigned portion of the EIP-1559 RLP list
+func (txn *EthereumEIP1559Transaction) _toUnsignedRLP() *RLPItem {
 	item := NewRLPItem(LIST_TYPE)
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.ChainId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.Nonce))
@@ -101,18 +101,56 @@ func (txn *EthereumEIP1559Transaction) ToBytes() ([]byte, error) {
 		accessListItem.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(itemBytes))
 	}
 	item.PushBack(accessListItem)
+	return item
+}
+
+// _encodeWithSignature appends RecoveryId/R/S to the given
+// unsigned RLP list, serializes it, and prepends the 0x02 type prefix.
+func (txn *EthereumEIP1559Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-
-	transactionBytes, err := item.Write()
+	bytes, err := item.Write()
 	if err != nil {
 		return nil, err
 	}
-	// Append 02 byte as it is the standard for EIP1559
-	combinedBytes := append([]byte{0x02}, transactionBytes...)
 
-	return combinedBytes, nil
+	// Append 02 byte as it is the standard for EIP1559
+	return append([]byte{0x02}, bytes...), nil
+}
+
+// ToBytes encodes the EthereumEIP1559Transaction into RLP format.
+func (txn *EthereumEIP1559Transaction) ToBytes() ([]byte, error) {
+	return txn._encodeWithSignature(txn._toUnsignedRLP())
+}
+
+// Sign signs the unsigned transaction with the given ECDSA key, populates
+// RecoveryId/R/S on the receiver, and returns the signed RLP bytes ready to
+// wrap in EthereumTransaction.
+func (txn *EthereumEIP1559Transaction) Sign(key PrivateKey) ([]byte, error) {
+	item := txn._toUnsignedRLP()
+	unsignedBytes, err := item.Write()
+	if err != nil {
+		return nil, err
+	}
+	message := append([]byte{0x02}, unsignedBytes...)
+
+	sig := key.Sign(message)
+	if len(sig) < 64 {
+		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
+	}
+	r := sig[0:32]
+	s := sig[32:64]
+	v := key.GetRecoveryId(r, s, message)
+	if v < 0 {
+		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
+	}
+
+	txn.R = r
+	txn.S = s
+	txn.RecoveryId = []byte{byte(v)}
+
+	return txn._encodeWithSignature(item)
 }
 
 // String returns a string representation of the EthereumEIP1559Transaction.

--- a/sdk/ethereum_eip1559_transaction.go
+++ b/sdk/ethereum_eip1559_transaction.go
@@ -105,19 +105,10 @@ func (txn *EthereumEIP1559Transaction) _toUnsignedRLP() *RLPItem {
 	return item
 }
 
-// _encodeWithSignature appends RecoveryId/R/S to the given
-// unsigned RLP list, serializes it, and prepends the 0x02 type prefix.
+// _encodeWithSignature appends the signature to the unsigned RLP list and
+// prepends the 0x02 EIP-1559 type prefix.
 func (txn *EthereumEIP1559Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-	bytes, err := item.Write()
-	if err != nil {
-		return nil, err
-	}
-
-	// Append 02 byte as it is the standard for EIP1559
-	return append([]byte{0x02}, bytes...), nil
+	return _encodeTypedWithSignature(item, 0x02, txn.RecoveryId, txn.R, txn.S)
 }
 
 // ToBytes encodes the EthereumEIP1559Transaction into RLP format.
@@ -130,27 +121,13 @@ func (txn *EthereumEIP1559Transaction) ToBytes() ([]byte, error) {
 // wrap in EthereumTransaction.
 func (txn *EthereumEIP1559Transaction) Sign(key PrivateKey) ([]byte, error) {
 	item := txn._toUnsignedRLP()
-	unsignedBytes, err := item.Write()
+	r, s, v, err := _signTypedTransaction(item, 0x02, key)
 	if err != nil {
 		return nil, err
 	}
-	message := append([]byte{0x02}, unsignedBytes...)
-
-	sig := key.Sign(message)
-	if len(sig) < 64 {
-		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
-	}
-	r := sig[0:32]
-	s := sig[32:64]
-	v := key.GetRecoveryId(r, s, message)
-	if v < 0 {
-		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
-	}
-
 	txn.R = r
 	txn.S = s
 	txn.RecoveryId = []byte{byte(v)}
-
 	return txn._encodeWithSignature(item)
 }
 

--- a/sdk/ethereum_eip1559_transaction.go
+++ b/sdk/ethereum_eip1559_transaction.go
@@ -47,13 +47,12 @@ func NewEthereumEIP1559Transaction(
 	}
 }
 
-// FromBytes decodes the RLP encoded bytes into an EthereumEIP1559Transaction.
+// EthereumEIP1559TransactionFromBytes decodes signed EIP-1559 RLP bytes into a transaction.
 func EthereumEIP1559TransactionFromBytes(bytes []byte) (*EthereumEIP1559Transaction, error) {
 	if len(bytes) == 0 || bytes[0] != 0x02 {
 		return nil, errors.New("input byte array is malformed; it should start with 0x02 followed by 12 RLP-encoded elements")
 	}
 
-	// Remove the prefix byte (0x02)
 	item := NewRLPItem(LIST_TYPE)
 	if err := item.Read(bytes[1:]); err != nil {
 		return nil, errors.Wrap(err, "failed to read RLP data")
@@ -63,13 +62,11 @@ func EthereumEIP1559TransactionFromBytes(bytes []byte) (*EthereumEIP1559Transact
 		return nil, errors.New("input byte array is malformed; it should be a list of 12 RLP-encoded elements")
 	}
 
-	// Handle the access list
 	var accessListValues [][]byte
 	for _, child := range item.childItems[8].childItems {
 		accessListValues = append(accessListValues, child.itemValue)
 	}
 
-	// Extract values from the RLP item
 	return NewEthereumEIP1559Transaction(
 		item.childItems[0].itemValue,
 		item.childItems[1].itemValue,
@@ -133,7 +130,6 @@ func (txn *EthereumEIP1559Transaction) Sign(key PrivateKey) ([]byte, error) {
 
 // String returns a string representation of the EthereumEIP1559Transaction.
 func (txn *EthereumEIP1559Transaction) String() string {
-	// Encode each element in the AccessList slice individually
 	var encodedAccessList []string
 	for _, entry := range txn.AccessList {
 		encodedAccessList = append(encodedAccessList, hex.EncodeToString(entry))

--- a/sdk/ethereum_eip1559_transaction_unit_test.go
+++ b/sdk/ethereum_eip1559_transaction_unit_test.go
@@ -1,0 +1,101 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitEthereumEIP1559TypedAccessors(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(5).
+		SetMaxPriorityGas(big.NewInt(2_000_000_000)).
+		SetMaxGas(big.NewInt(20_000_000_000)).
+		SetGasLimit(150_000).
+		SetTo(to).
+		SetValue(big.NewInt(1_000_000)).
+		SetCallData([]byte{0xDE, 0xAD}).
+		SetRecoveryId(1).
+		SetR([]byte{0xAA}).
+		SetS([]byte{0xBB})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(2_000_000_000), tx.GetMaxPriorityGas().Int64())
+	assert.Equal(t, int64(20_000_000_000), tx.GetMaxGas().Int64())
+	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
+	assert.Equal(t, to, tx.GetTo())
+	assert.Equal(t, int64(1_000_000), tx.GetValue().Int64())
+	assert.Equal(t, []byte{0xDE, 0xAD}, tx.GetCallData())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+	assert.Equal(t, []byte{0xAA}, tx.GetR())
+	assert.Equal(t, []byte{0xBB}, tx.GetS())
+
+	assert.Equal(t, []byte{0x01, 0x2a}, tx.GetChainIdBytes())
+	assert.Equal(t, []byte{0x05}, tx.GetNonceBytes())
+	assert.Equal(t, []byte{0x77, 0x35, 0x94, 0x00}, tx.GetMaxPriorityGasBytes())
+	assert.Equal(t, []byte{0x04, 0xa8, 0x17, 0xc8, 0x00}, tx.GetMaxGasBytes())
+	assert.Equal(t, []byte{0x02, 0x49, 0xf0}, tx.GetGasLimitBytes())
+	assert.Equal(t, []byte{0x0f, 0x42, 0x40}, tx.GetValueBytes())
+	assert.Equal(t, []byte{0x01}, tx.GetRecoveryIdBytes())
+}
+
+func TestUnitEthereumEIP1559BytesAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainIdBytes([]byte{0x01, 0x2a}).
+		SetNonceBytes([]byte{0x05}).
+		SetMaxPriorityGasBytes([]byte{0x02}).
+		SetMaxGasBytes([]byte{0x03}).
+		SetGasLimitBytes([]byte{0x04}).
+		SetValueBytes([]byte{0x05}).
+		SetRecoveryIdBytes([]byte{0x01})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(2), tx.GetMaxPriorityGas().Int64())
+	assert.Equal(t, int64(3), tx.GetMaxGas().Int64())
+	assert.Equal(t, uint64(4), tx.GetGasLimit())
+	assert.Equal(t, int64(5), tx.GetValue().Int64())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+}
+
+func TestUnitEthereumEIP1559String(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP1559Transaction{}).SetChainId(1).SetMaxGas(big.NewInt(5))
+	s := tx.String()
+	assert.Contains(t, s, "ChainId:")
+	assert.Contains(t, s, "MaxGas:")
+	assert.Contains(t, s, "AccessList:")
+}
+
+func TestUnitEthereumEIP1559FromBytesErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := EthereumEIP1559TransactionFromBytes(nil)
+	assert.Error(t, err)
+
+	_, err = EthereumEIP1559TransactionFromBytes([]byte{0x01, 0x00})
+	assert.Error(t, err, "wrong type prefix should be rejected")
+
+	list := NewRLPItem(LIST_TYPE)
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	body, err := list.Write()
+	require.NoError(t, err)
+	_, err = EthereumEIP1559TransactionFromBytes(append([]byte{0x02}, body...))
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_eip2930_transaction.go
+++ b/sdk/ethereum_eip2930_transaction.go
@@ -98,19 +98,10 @@ func (txn *EthereumEIP2930Transaction) _toUnsignedRLP() *RLPItem {
 	return item
 }
 
-// _encodeWithSignature appends RecoveryId/R/S to the given (already-built)
-// unsigned RLP list, serializes it, and prepends the 0x01 type prefix.
+// _encodeWithSignature appends the signature to the unsigned RLP list and
+// prepends the 0x01 EIP-2930 type prefix.
 func (txn *EthereumEIP2930Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-	bytes, err := item.Write()
-	if err != nil {
-		return nil, err
-	}
-
-	// Append 01 byte as it is the standard for EIP2930
-	return append([]byte{0x01}, bytes...), nil
+	return _encodeTypedWithSignature(item, 0x01, txn.RecoveryId, txn.R, txn.S)
 }
 
 // ToBytes encodes the EthereumEIP2930Transaction into RLP format.
@@ -123,27 +114,13 @@ func (txn *EthereumEIP2930Transaction) ToBytes() ([]byte, error) {
 // wrap in EthereumTransaction.
 func (txn *EthereumEIP2930Transaction) Sign(key PrivateKey) ([]byte, error) {
 	item := txn._toUnsignedRLP()
-	unsignedBytes, err := item.Write()
+	r, s, v, err := _signTypedTransaction(item, 0x01, key)
 	if err != nil {
 		return nil, err
 	}
-	message := append([]byte{0x01}, unsignedBytes...)
-
-	sig := key.Sign(message)
-	if len(sig) < 64 {
-		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
-	}
-	r := sig[0:32]
-	s := sig[32:64]
-	v := key.GetRecoveryId(r, s, message)
-	if v < 0 {
-		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
-	}
-
 	txn.R = r
 	txn.S = s
 	txn.RecoveryId = []byte{byte(v)}
-
 	return txn._encodeWithSignature(item)
 }
 

--- a/sdk/ethereum_eip2930_transaction.go
+++ b/sdk/ethereum_eip2930_transaction.go
@@ -43,13 +43,13 @@ func NewEthereumEIP2930Transaction(
 	}
 }
 
-// EthereumEIP2930TransactionFromBytes decodes the RLP encoded bytes into an EthereumEIP2930Transaction.
+// EthereumEIP2930TransactionFromBytes decodes signed EIP-2930 RLP bytes
+// (leading 0x01 prefix + list of 11 elements) into a transaction.
 func EthereumEIP2930TransactionFromBytes(bytes []byte) (*EthereumEIP2930Transaction, error) {
 	if len(bytes) == 0 || bytes[0] != 0x01 {
 		return nil, errors.New("input byte array is malformed; it should start with 0x01 followed by 11 RLP-encoded elements")
 	}
 
-	// Remove the prefix byte (0x01)
 	item := NewRLPItem(LIST_TYPE)
 	if err := item.Read(bytes[1:]); err != nil {
 		return nil, errors.Wrap(err, "failed to read RLP data")
@@ -59,13 +59,11 @@ func EthereumEIP2930TransactionFromBytes(bytes []byte) (*EthereumEIP2930Transact
 		return nil, errors.New("input byte array is malformed; it should be a list of 11 RLP-encoded elements")
 	}
 
-	// Handle the access list
 	var accessListValues [][]byte
 	for _, child := range item.childItems[7].childItems {
 		accessListValues = append(accessListValues, child.itemValue)
 	}
 
-	// Extract values from the RLP item
 	return NewEthereumEIP2930Transaction(
 		item.childItems[0].itemValue,
 		item.childItems[1].itemValue,
@@ -81,8 +79,8 @@ func EthereumEIP2930TransactionFromBytes(bytes []byte) (*EthereumEIP2930Transact
 	), nil
 }
 
-// ToBytes encodes the EthereumEIP2930Transaction into RLP format.
-func (txn *EthereumEIP2930Transaction) ToBytes() ([]byte, error) {
+// _toUnsignedRLP builds the unsigned portion of the EIP-2930 RLP list
+func (txn *EthereumEIP2930Transaction) _toUnsignedRLP() *RLPItem {
 	item := NewRLPItem(LIST_TYPE)
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.ChainId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.Nonce))
@@ -96,23 +94,60 @@ func (txn *EthereumEIP2930Transaction) ToBytes() ([]byte, error) {
 		accessListItem.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(itemBytes))
 	}
 	item.PushBack(accessListItem)
+	return item
+}
+
+// _encodeWithSignature appends RecoveryId/R/S to the given (already-built)
+// unsigned RLP list, serializes it, and prepends the 0x01 type prefix.
+func (txn *EthereumEIP2930Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-
-	transactionBytes, err := item.Write()
+	bytes, err := item.Write()
 	if err != nil {
 		return nil, err
 	}
-	// Append 01 byte as it is the standard for EIP-2930
-	combinedBytes := append([]byte{0x01}, transactionBytes...)
 
-	return combinedBytes, nil
+	// Append 01 byte as it is the standard for EIP2930
+	return append([]byte{0x01}, bytes...), nil
+}
+
+// ToBytes encodes the EthereumEIP2930Transaction into RLP format.
+func (txn *EthereumEIP2930Transaction) ToBytes() ([]byte, error) {
+	return txn._encodeWithSignature(txn._toUnsignedRLP())
+}
+
+// Sign signs the unsigned transaction with the given ECDSA key, populates
+// RecoveryId/R/S on the receiver, and returns the signed RLP bytes ready to
+// wrap in EthereumTransaction.
+func (txn *EthereumEIP2930Transaction) Sign(key PrivateKey) ([]byte, error) {
+	item := txn._toUnsignedRLP()
+	unsignedBytes, err := item.Write()
+	if err != nil {
+		return nil, err
+	}
+	message := append([]byte{0x01}, unsignedBytes...)
+
+	sig := key.Sign(message)
+	if len(sig) < 64 {
+		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
+	}
+	r := sig[0:32]
+	s := sig[32:64]
+	v := key.GetRecoveryId(r, s, message)
+	if v < 0 {
+		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
+	}
+
+	txn.R = r
+	txn.S = s
+	txn.RecoveryId = []byte{byte(v)}
+
+	return txn._encodeWithSignature(item)
 }
 
 // String returns a string representation of the EthereumEIP2930Transaction.
 func (txn *EthereumEIP2930Transaction) String() string {
-	// Encode each element in the AccessList slice individually
 	var encodedAccessList []string
 	for _, entry := range txn.AccessList {
 		encodedAccessList = append(encodedAccessList, hex.EncodeToString(entry))

--- a/sdk/ethereum_eip2930_transaction.go
+++ b/sdk/ethereum_eip2930_transaction.go
@@ -5,6 +5,7 @@ package hiero
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -168,4 +169,184 @@ func (txn *EthereumEIP2930Transaction) String() string {
 		hex.EncodeToString(txn.R),
 		hex.EncodeToString(txn.S),
 	)
+}
+
+// GetChainId returns the chain id as a uint64.
+func (txn *EthereumEIP2930Transaction) GetChainId() uint64 {
+	return _ethBytesToUint64(txn.ChainId)
+}
+
+// SetChainId sets the chain id from a uint64.
+func (txn *EthereumEIP2930Transaction) SetChainId(v uint64) *EthereumEIP2930Transaction {
+	txn.ChainId = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetChainIdBytes returns the raw canonical big-endian chain id bytes.
+func (txn *EthereumEIP2930Transaction) GetChainIdBytes() []byte { return txn.ChainId }
+
+// SetChainIdBytes sets the chain id from raw canonical big-endian bytes.
+func (txn *EthereumEIP2930Transaction) SetChainIdBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.ChainId = v
+	return txn
+}
+
+// GetNonce returns the nonce as a uint64.
+func (txn *EthereumEIP2930Transaction) GetNonce() uint64 {
+	return _ethBytesToUint64(txn.Nonce)
+}
+
+// SetNonce sets the nonce from a uint64.
+func (txn *EthereumEIP2930Transaction) SetNonce(v uint64) *EthereumEIP2930Transaction {
+	txn.Nonce = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetNonceBytes returns the raw canonical big-endian nonce bytes.
+func (txn *EthereumEIP2930Transaction) GetNonceBytes() []byte { return txn.Nonce }
+
+// SetNonceBytes sets the nonce from raw canonical big-endian bytes.
+func (txn *EthereumEIP2930Transaction) SetNonceBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.Nonce = v
+	return txn
+}
+
+// GetGasPrice returns the gas price as a *big.Int.
+func (txn *EthereumEIP2930Transaction) GetGasPrice() *big.Int {
+	return _ethBytesToBigInt(txn.GasPrice)
+}
+
+// SetGasPrice sets the gas price from a *big.Int.
+func (txn *EthereumEIP2930Transaction) SetGasPrice(v *big.Int) *EthereumEIP2930Transaction {
+	txn.GasPrice = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetGasPriceBytes returns the raw canonical big-endian gas price bytes.
+func (txn *EthereumEIP2930Transaction) GetGasPriceBytes() []byte { return txn.GasPrice }
+
+// SetGasPriceBytes sets the gas price from raw bytes.
+func (txn *EthereumEIP2930Transaction) SetGasPriceBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.GasPrice = v
+	return txn
+}
+
+// GetGasLimit returns the gas limit as a uint64.
+func (txn *EthereumEIP2930Transaction) GetGasLimit() uint64 {
+	return _ethBytesToUint64(txn.GasLimit)
+}
+
+// SetGasLimit sets the gas limit from a uint64.
+func (txn *EthereumEIP2930Transaction) SetGasLimit(v uint64) *EthereumEIP2930Transaction {
+	txn.GasLimit = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetGasLimitBytes returns the raw canonical big-endian gas limit bytes.
+func (txn *EthereumEIP2930Transaction) GetGasLimitBytes() []byte { return txn.GasLimit }
+
+// SetGasLimitBytes sets the gas limit from raw bytes.
+func (txn *EthereumEIP2930Transaction) SetGasLimitBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.GasLimit = v
+	return txn
+}
+
+// GetTo returns the recipient address bytes.
+func (txn *EthereumEIP2930Transaction) GetTo() []byte { return txn.To }
+
+// SetTo sets the recipient address bytes.
+func (txn *EthereumEIP2930Transaction) SetTo(v []byte) *EthereumEIP2930Transaction {
+	txn.To = v
+	return txn
+}
+
+// GetValue returns the transaction value (wei) as a *big.Int.
+func (txn *EthereumEIP2930Transaction) GetValue() *big.Int {
+	return _ethBytesToBigInt(txn.Value)
+}
+
+// SetValue sets the transaction value (wei) from a *big.Int.
+func (txn *EthereumEIP2930Transaction) SetValue(v *big.Int) *EthereumEIP2930Transaction {
+	txn.Value = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetValueBytes returns the raw canonical big-endian value bytes.
+func (txn *EthereumEIP2930Transaction) GetValueBytes() []byte { return txn.Value }
+
+// SetValueBytes sets the value from raw bytes.
+func (txn *EthereumEIP2930Transaction) SetValueBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.Value = v
+	return txn
+}
+
+// GetCallData returns the call data.
+func (txn *EthereumEIP2930Transaction) GetCallData() []byte { return txn.CallData }
+
+// SetCallData sets the call data.
+func (txn *EthereumEIP2930Transaction) SetCallData(v []byte) *EthereumEIP2930Transaction {
+	txn.CallData = v
+	return txn
+}
+
+// GetRecoveryId returns the recovery id as an int.
+func (txn *EthereumEIP2930Transaction) GetRecoveryId() int {
+	if len(txn.RecoveryId) == 0 {
+		return 0
+	}
+	return int(txn.RecoveryId[0])
+}
+
+// SetRecoveryId sets the recovery id from an int.
+func (txn *EthereumEIP2930Transaction) SetRecoveryId(v int) *EthereumEIP2930Transaction {
+	if v == 0 {
+		txn.RecoveryId = []byte{}
+	} else {
+		txn.RecoveryId = []byte{byte(v)}
+	}
+	return txn
+}
+
+// GetRecoveryIdBytes returns the raw recovery id bytes.
+func (txn *EthereumEIP2930Transaction) GetRecoveryIdBytes() []byte { return txn.RecoveryId }
+
+// SetRecoveryIdBytes sets the recovery id from raw bytes.
+func (txn *EthereumEIP2930Transaction) SetRecoveryIdBytes(v []byte) *EthereumEIP2930Transaction {
+	txn.RecoveryId = v
+	return txn
+}
+
+// GetR returns the R signature component.
+func (txn *EthereumEIP2930Transaction) GetR() []byte { return txn.R }
+
+// SetR sets the R signature component.
+func (txn *EthereumEIP2930Transaction) SetR(v []byte) *EthereumEIP2930Transaction {
+	txn.R = v
+	return txn
+}
+
+// GetS returns the S signature component.
+func (txn *EthereumEIP2930Transaction) GetS() []byte { return txn.S }
+
+// SetS sets the S signature component.
+func (txn *EthereumEIP2930Transaction) SetS(v []byte) *EthereumEIP2930Transaction {
+	txn.S = v
+	return txn
+}
+
+// GetAccessListItems returns the access list as structured AccessListItem entries.
+func (txn *EthereumEIP2930Transaction) GetAccessListItems() []AccessListItem {
+	return _accessListItemsFromBytes(txn.AccessList)
+}
+
+// SetAccessListItems replaces the access list from structured AccessListItem entries.
+func (txn *EthereumEIP2930Transaction) SetAccessListItems(items []AccessListItem) *EthereumEIP2930Transaction {
+	txn.AccessList = _accessListItemsToBytes(items)
+	return txn
+}
+
+// AddAccessListItem appends a single access list entry.
+func (txn *EthereumEIP2930Transaction) AddAccessListItem(item AccessListItem) *EthereumEIP2930Transaction {
+	txn.AccessList = append(txn.AccessList, _accessListItemToBytes(item))
+	return txn
 }

--- a/sdk/ethereum_eip2930_transaction.go
+++ b/sdk/ethereum_eip2930_transaction.go
@@ -44,8 +44,7 @@ func NewEthereumEIP2930Transaction(
 	}
 }
 
-// EthereumEIP2930TransactionFromBytes decodes signed EIP-2930 RLP bytes
-// (leading 0x01 prefix + list of 11 elements) into a transaction.
+// EthereumEIP2930TransactionFromBytes decodes signed EIP-2930 RLP bytes into a transaction.
 func EthereumEIP2930TransactionFromBytes(bytes []byte) (*EthereumEIP2930Transaction, error) {
 	if len(bytes) == 0 || bytes[0] != 0x01 {
 		return nil, errors.New("input byte array is malformed; it should start with 0x01 followed by 11 RLP-encoded elements")

--- a/sdk/ethereum_eip2930_transaction_unit_test.go
+++ b/sdk/ethereum_eip2930_transaction_unit_test.go
@@ -1,0 +1,118 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitEthereumEIP2930TypedAccessors(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumEIP2930Transaction{}).
+		SetChainId(298).
+		SetNonce(5).
+		SetGasPrice(big.NewInt(20_000_000_000)).
+		SetGasLimit(0x2dc6c0).
+		SetTo(to).
+		SetValue(big.NewInt(0x02540be400)).
+		SetCallData([]byte{0xDE, 0xAD}).
+		SetRecoveryId(1).
+		SetR([]byte{0xAA}).
+		SetS([]byte{0xBB})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(0x2dc6c0), tx.GetGasLimit())
+	assert.Equal(t, to, tx.GetTo())
+	assert.Equal(t, int64(0x02540be400), tx.GetValue().Int64())
+	assert.Equal(t, []byte{0xDE, 0xAD}, tx.GetCallData())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+	assert.Equal(t, []byte{0xAA}, tx.GetR())
+	assert.Equal(t, []byte{0xBB}, tx.GetS())
+
+	assert.Equal(t, []byte{0x01, 0x2a}, tx.GetChainIdBytes())
+	assert.Equal(t, []byte{0x05}, tx.GetNonceBytes())
+	assert.Equal(t, []byte{0x04, 0xa8, 0x17, 0xc8, 0x00}, tx.GetGasPriceBytes())
+	assert.Equal(t, []byte{0x2d, 0xc6, 0xc0}, tx.GetGasLimitBytes())
+	assert.Equal(t, []byte{0x02, 0x54, 0x0b, 0xe4, 0x00}, tx.GetValueBytes())
+	assert.Equal(t, []byte{0x01}, tx.GetRecoveryIdBytes())
+}
+
+func TestUnitEthereumEIP2930BytesAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP2930Transaction{}).
+		SetChainIdBytes([]byte{0x01, 0x2a}).
+		SetNonceBytes([]byte{0x05}).
+		SetGasPriceBytes([]byte{0x02}).
+		SetGasLimitBytes([]byte{0x03}).
+		SetValueBytes([]byte{0x04}).
+		SetRecoveryIdBytes([]byte{0x01})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(2), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(3), tx.GetGasLimit())
+	assert.Equal(t, int64(4), tx.GetValue().Int64())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+
+	// RecoveryId of 0 is stored as empty bytes, and reads back as 0.
+	tx.SetRecoveryId(0)
+	assert.Equal(t, []byte{}, tx.GetRecoveryIdBytes())
+	assert.Equal(t, 0, tx.GetRecoveryId())
+}
+
+func TestUnitEthereumEIP2930SetAccessListItems(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP2930Transaction{}
+	tx.SetAccessListItems([]AccessListItem{
+		NewAccessListItem([]byte{0xAA}, [][]byte{{0x01}}),
+		NewAccessListItem([]byte{0xBB}, nil),
+	})
+
+	got := tx.GetAccessListItems()
+	require.Equal(t, 2, len(got))
+	assert.Equal(t, []byte{0xAA}, got[0].GetAddress())
+}
+
+func TestUnitEthereumEIP2930String(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP2930Transaction{}).
+		SetChainId(1).
+		AddAccessListItem(NewAccessListItem([]byte{0xAA}, [][]byte{{0x01}}))
+	s := tx.String()
+	assert.Contains(t, s, "ChainId:")
+	assert.Contains(t, s, "AccessList:")
+	assert.Contains(t, s, "RecoveryId:")
+}
+
+func TestUnitEthereumEIP2930FromBytesErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := EthereumEIP2930TransactionFromBytes(nil)
+	assert.Error(t, err)
+
+	_, err = EthereumEIP2930TransactionFromBytes([]byte{0x02, 0x00})
+	assert.Error(t, err, "wrong type prefix should be rejected")
+
+	// Correct 0x01 prefix but wrong element count.
+	list := NewRLPItem(LIST_TYPE)
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	body, err := list.Write()
+	require.NoError(t, err)
+	_, err = EthereumEIP2930TransactionFromBytes(append([]byte{0x01}, body...))
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_eip7702_transaction.go
+++ b/sdk/ethereum_eip7702_transaction.go
@@ -5,6 +5,7 @@ package hiero
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -227,4 +228,221 @@ func (txn *EthereumEIP7702Transaction) String() string {
 		hex.EncodeToString(txn.R),
 		hex.EncodeToString(txn.S),
 	)
+}
+
+// GetChainId returns the chain id as a uint64.
+func (txn *EthereumEIP7702Transaction) GetChainId() uint64 {
+	return _ethBytesToUint64(txn.ChainId)
+}
+
+// SetChainId sets the chain id from a uint64.
+func (txn *EthereumEIP7702Transaction) SetChainId(v uint64) *EthereumEIP7702Transaction {
+	txn.ChainId = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetChainIdBytes returns the raw canonical big-endian chain id bytes.
+func (txn *EthereumEIP7702Transaction) GetChainIdBytes() []byte { return txn.ChainId }
+
+// SetChainIdBytes sets the chain id from raw canonical big-endian bytes.
+func (txn *EthereumEIP7702Transaction) SetChainIdBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.ChainId = v
+	return txn
+}
+
+// GetNonce returns the nonce as a uint64.
+func (txn *EthereumEIP7702Transaction) GetNonce() uint64 {
+	return _ethBytesToUint64(txn.Nonce)
+}
+
+// SetNonce sets the nonce from a uint64.
+func (txn *EthereumEIP7702Transaction) SetNonce(v uint64) *EthereumEIP7702Transaction {
+	txn.Nonce = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetNonceBytes returns the raw canonical big-endian nonce bytes.
+func (txn *EthereumEIP7702Transaction) GetNonceBytes() []byte { return txn.Nonce }
+
+// SetNonceBytes sets the nonce from raw canonical big-endian bytes.
+func (txn *EthereumEIP7702Transaction) SetNonceBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.Nonce = v
+	return txn
+}
+
+// GetMaxPriorityGas returns the max priority fee per gas as a *big.Int.
+func (txn *EthereumEIP7702Transaction) GetMaxPriorityGas() *big.Int {
+	return _ethBytesToBigInt(txn.MaxPriorityGas)
+}
+
+// SetMaxPriorityGas sets the max priority fee per gas from a *big.Int.
+func (txn *EthereumEIP7702Transaction) SetMaxPriorityGas(v *big.Int) *EthereumEIP7702Transaction {
+	txn.MaxPriorityGas = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetMaxPriorityGasBytes returns the raw canonical big-endian max priority fee bytes.
+func (txn *EthereumEIP7702Transaction) GetMaxPriorityGasBytes() []byte { return txn.MaxPriorityGas }
+
+// SetMaxPriorityGasBytes sets the max priority fee per gas from raw bytes.
+func (txn *EthereumEIP7702Transaction) SetMaxPriorityGasBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.MaxPriorityGas = v
+	return txn
+}
+
+// GetMaxGas returns the max fee per gas as a *big.Int.
+func (txn *EthereumEIP7702Transaction) GetMaxGas() *big.Int {
+	return _ethBytesToBigInt(txn.MaxGas)
+}
+
+// SetMaxGas sets the max fee per gas from a *big.Int.
+func (txn *EthereumEIP7702Transaction) SetMaxGas(v *big.Int) *EthereumEIP7702Transaction {
+	txn.MaxGas = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetMaxGasBytes returns the raw canonical big-endian max fee bytes.
+func (txn *EthereumEIP7702Transaction) GetMaxGasBytes() []byte { return txn.MaxGas }
+
+// SetMaxGasBytes sets the max fee per gas from raw bytes.
+func (txn *EthereumEIP7702Transaction) SetMaxGasBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.MaxGas = v
+	return txn
+}
+
+// GetGasLimit returns the gas limit as a uint64.
+func (txn *EthereumEIP7702Transaction) GetGasLimit() uint64 {
+	return _ethBytesToUint64(txn.GasLimit)
+}
+
+// SetGasLimit sets the gas limit from a uint64.
+func (txn *EthereumEIP7702Transaction) SetGasLimit(v uint64) *EthereumEIP7702Transaction {
+	txn.GasLimit = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetGasLimitBytes returns the raw canonical big-endian gas limit bytes.
+func (txn *EthereumEIP7702Transaction) GetGasLimitBytes() []byte { return txn.GasLimit }
+
+// SetGasLimitBytes sets the gas limit from raw bytes.
+func (txn *EthereumEIP7702Transaction) SetGasLimitBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.GasLimit = v
+	return txn
+}
+
+// GetTo returns the recipient address bytes.
+func (txn *EthereumEIP7702Transaction) GetTo() []byte { return txn.To }
+
+// SetTo sets the recipient address bytes.
+func (txn *EthereumEIP7702Transaction) SetTo(v []byte) *EthereumEIP7702Transaction {
+	txn.To = v
+	return txn
+}
+
+// GetValue returns the transaction value (wei) as a *big.Int.
+func (txn *EthereumEIP7702Transaction) GetValue() *big.Int {
+	return _ethBytesToBigInt(txn.Value)
+}
+
+// SetValue sets the transaction value (wei) from a *big.Int.
+func (txn *EthereumEIP7702Transaction) SetValue(v *big.Int) *EthereumEIP7702Transaction {
+	txn.Value = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetValueBytes returns the raw canonical big-endian value bytes.
+func (txn *EthereumEIP7702Transaction) GetValueBytes() []byte { return txn.Value }
+
+// SetValueBytes sets the value from raw bytes.
+func (txn *EthereumEIP7702Transaction) SetValueBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.Value = v
+	return txn
+}
+
+// GetCallData returns the call data.
+func (txn *EthereumEIP7702Transaction) GetCallData() []byte { return txn.CallData }
+
+// SetCallData sets the call data.
+func (txn *EthereumEIP7702Transaction) SetCallData(v []byte) *EthereumEIP7702Transaction {
+	txn.CallData = v
+	return txn
+}
+
+// GetRecoveryId returns the recovery id as an int.
+func (txn *EthereumEIP7702Transaction) GetRecoveryId() int {
+	if len(txn.RecoveryId) == 0 {
+		return 0
+	}
+	return int(txn.RecoveryId[0])
+}
+
+// SetRecoveryId sets the recovery id from an int.
+func (txn *EthereumEIP7702Transaction) SetRecoveryId(v int) *EthereumEIP7702Transaction {
+	if v == 0 {
+		txn.RecoveryId = []byte{}
+	} else {
+		txn.RecoveryId = []byte{byte(v)}
+	}
+	return txn
+}
+
+// GetRecoveryIdBytes returns the raw recovery id bytes.
+func (txn *EthereumEIP7702Transaction) GetRecoveryIdBytes() []byte { return txn.RecoveryId }
+
+// SetRecoveryIdBytes sets the recovery id from raw bytes.
+func (txn *EthereumEIP7702Transaction) SetRecoveryIdBytes(v []byte) *EthereumEIP7702Transaction {
+	txn.RecoveryId = v
+	return txn
+}
+
+// GetR returns the R signature component.
+func (txn *EthereumEIP7702Transaction) GetR() []byte { return txn.R }
+
+// SetR sets the R signature component.
+func (txn *EthereumEIP7702Transaction) SetR(v []byte) *EthereumEIP7702Transaction {
+	txn.R = v
+	return txn
+}
+
+// GetS returns the S signature component.
+func (txn *EthereumEIP7702Transaction) GetS() []byte { return txn.S }
+
+// SetS sets the S signature component.
+func (txn *EthereumEIP7702Transaction) SetS(v []byte) *EthereumEIP7702Transaction {
+	txn.S = v
+	return txn
+}
+
+// GetAccessListItems returns the access list as structured AccessListItem entries.
+func (txn *EthereumEIP7702Transaction) GetAccessListItems() []AccessListItem {
+	return _accessListItemsFromBytes(txn.AccessList)
+}
+
+// SetAccessListItems replaces the access list from structured AccessListItem entries.
+func (txn *EthereumEIP7702Transaction) SetAccessListItems(items []AccessListItem) *EthereumEIP7702Transaction {
+	txn.AccessList = _accessListItemsToBytes(items)
+	return txn
+}
+
+// AddAccessListItem appends a single access list entry.
+func (txn *EthereumEIP7702Transaction) AddAccessListItem(item AccessListItem) *EthereumEIP7702Transaction {
+	txn.AccessList = append(txn.AccessList, _accessListItemToBytes(item))
+	return txn
+}
+
+// GetAuthorizationList returns the EIP-7702 authorization list.
+func (txn *EthereumEIP7702Transaction) GetAuthorizationList() []AuthorizationTuple {
+	return txn.AuthorizationList
+}
+
+// SetAuthorizationList replaces the EIP-7702 authorization list.
+func (txn *EthereumEIP7702Transaction) SetAuthorizationList(list []AuthorizationTuple) *EthereumEIP7702Transaction {
+	txn.AuthorizationList = list
+	return txn
+}
+
+// AddAuthorization appends a single authorization tuple to the list.
+func (txn *EthereumEIP7702Transaction) AddAuthorization(tuple AuthorizationTuple) *EthereumEIP7702Transaction {
+	txn.AuthorizationList = append(txn.AuthorizationList, tuple)
+	return txn
 }

--- a/sdk/ethereum_eip7702_transaction.go
+++ b/sdk/ethereum_eip7702_transaction.go
@@ -140,20 +140,10 @@ func (txn *EthereumEIP7702Transaction) _toUnsignedRLP() *RLPItem {
 	return item
 }
 
-// _encodeWithSignature appends RecoveryId/R/S to the given (already-built)
-// unsigned RLP list, serializes it, and prepends the 0x04 type prefix.
+// _encodeWithSignature appends the signature to the unsigned RLP list and
+// prepends the 0x04 EIP-7702 type prefix.
 func (txn *EthereumEIP7702Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
-	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-
-	transactionBytes, err := item.Write()
-	if err != nil {
-		return nil, err
-	}
-
-	// Append 04 byte as it is the standard for EIP7702
-	return append([]byte{0x04}, transactionBytes...), nil
+	return _encodeTypedWithSignature(item, 0x04, txn.RecoveryId, txn.R, txn.S)
 }
 
 // ToBytes encodes the EthereumEIP7702Transaction into RLP format.
@@ -167,27 +157,13 @@ func (txn *EthereumEIP7702Transaction) ToBytes() ([]byte, error) {
 // already carry their own signatures (yParity, r, s) per the EIP-7702 spec.
 func (txn *EthereumEIP7702Transaction) Sign(key PrivateKey) ([]byte, error) {
 	item := txn._toUnsignedRLP()
-	unsignedBytes, err := item.Write()
+	r, s, v, err := _signTypedTransaction(item, 0x04, key)
 	if err != nil {
 		return nil, err
 	}
-	message := append([]byte{0x04}, unsignedBytes...)
-
-	sig := key.Sign(message)
-	if len(sig) < 64 {
-		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
-	}
-	r := sig[0:32]
-	s := sig[32:64]
-	v := key.GetRecoveryId(r, s, message)
-	if v < 0 {
-		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
-	}
-
 	txn.R = r
 	txn.S = s
 	txn.RecoveryId = []byte{byte(v)}
-
 	return txn._encodeWithSignature(item)
 }
 

--- a/sdk/ethereum_eip7702_transaction.go
+++ b/sdk/ethereum_eip7702_transaction.go
@@ -110,8 +110,8 @@ func EthereumEIP7702TransactionFromBytes(bytes []byte) (*EthereumEIP7702Transact
 	), nil
 }
 
-// ToBytes encodes the EthereumEIP7702Transaction into RLP format.
-func (txn *EthereumEIP7702Transaction) ToBytes() ([]byte, error) {
+// _toUnsignedRLP builds the unsigned portion of the EIP-7702 RLP list
+func (txn *EthereumEIP7702Transaction) _toUnsignedRLP() *RLPItem {
 	item := NewRLPItem(LIST_TYPE)
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.ChainId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.Nonce))
@@ -136,6 +136,12 @@ func (txn *EthereumEIP7702Transaction) ToBytes() ([]byte, error) {
 		authorizationListItem.PushBack(authTupleItem)
 	}
 	item.PushBack(authorizationListItem)
+	return item
+}
+
+// _encodeWithSignature appends RecoveryId/R/S to the given (already-built)
+// unsigned RLP list, serializes it, and prepends the 0x04 type prefix.
+func (txn *EthereumEIP7702Transaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.RecoveryId))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
@@ -144,10 +150,44 @@ func (txn *EthereumEIP7702Transaction) ToBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Append 04 byte as it is the standard for EIP7702
-	combinedBytes := append([]byte{0x04}, transactionBytes...)
 
-	return combinedBytes, nil
+	// Append 04 byte as it is the standard for EIP7702
+	return append([]byte{0x04}, transactionBytes...), nil
+}
+
+// ToBytes encodes the EthereumEIP7702Transaction into RLP format.
+func (txn *EthereumEIP7702Transaction) ToBytes() ([]byte, error) {
+	return txn._encodeWithSignature(txn._toUnsignedRLP())
+}
+
+// Sign signs the unsigned transaction with the given ECDSA key, populates
+// RecoveryId/R/S on the receiver, and returns the signed RLP bytes ready to
+// wrap in EthereumTransaction. AuthorizationList entries are expected to
+// already carry their own signatures (yParity, r, s) per the EIP-7702 spec.
+func (txn *EthereumEIP7702Transaction) Sign(key PrivateKey) ([]byte, error) {
+	item := txn._toUnsignedRLP()
+	unsignedBytes, err := item.Write()
+	if err != nil {
+		return nil, err
+	}
+	message := append([]byte{0x04}, unsignedBytes...)
+
+	sig := key.Sign(message)
+	if len(sig) < 64 {
+		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
+	}
+	r := sig[0:32]
+	s := sig[32:64]
+	v := key.GetRecoveryId(r, s, message)
+	if v < 0 {
+		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
+	}
+
+	txn.R = r
+	txn.S = s
+	txn.RecoveryId = []byte{byte(v)}
+
+	return txn._encodeWithSignature(item)
 }
 
 // String returns a string representation of the EthereumEIP7702Transaction.

--- a/sdk/ethereum_eip7702_transaction.go
+++ b/sdk/ethereum_eip7702_transaction.go
@@ -52,13 +52,12 @@ func NewEthereumEIP7702Transaction(
 	}
 }
 
-// FromBytes decodes the RLP encoded bytes into an EthereumEIP7702Transaction.
+// EthereumEIP7702TransactionFromBytes decodes signed EIP-7702 RLP bytes into a transaction.
 func EthereumEIP7702TransactionFromBytes(bytes []byte) (*EthereumEIP7702Transaction, error) {
 	if len(bytes) == 0 || bytes[0] != 0x04 {
 		return nil, errors.New("input byte array is malformed; it should start with 0x04 followed by 13 RLP-encoded elements")
 	}
 
-	// Remove the prefix byte (0x04)
 	item := NewRLPItem(LIST_TYPE)
 	if err := item.Read(bytes[1:]); err != nil {
 		return nil, errors.Wrap(err, "failed to read RLP data")
@@ -68,13 +67,12 @@ func EthereumEIP7702TransactionFromBytes(bytes []byte) (*EthereumEIP7702Transact
 		return nil, errors.New("input byte array is malformed; it should be a list of 13 RLP-encoded elements")
 	}
 
-	// Handle the access list
 	var accessListValues [][]byte
 	for _, child := range item.childItems[8].childItems {
 		accessListValues = append(accessListValues, child.itemValue)
 	}
 
-	// Handle the authorization list: array of [chainId, contractAddress, nonce, yParity, r, s] tuples
+	// Each authorization entry is a [chainId, contractAddress, nonce, yParity, r, s] tuple.
 	var authorizationListValues []AuthorizationTuple
 	if item.childItems[9].itemType != LIST_TYPE {
 		return nil, errors.New("authorization list must be an array")
@@ -93,7 +91,6 @@ func EthereumEIP7702TransactionFromBytes(bytes []byte) (*EthereumEIP7702Transact
 		authorizationListValues = append(authorizationListValues, tuple)
 	}
 
-	// Extract values from the RLP item
 	return NewEthereumEIP7702Transaction(
 		item.childItems[0].itemValue,
 		item.childItems[1].itemValue,
@@ -169,7 +166,6 @@ func (txn *EthereumEIP7702Transaction) Sign(key PrivateKey) ([]byte, error) {
 
 // String returns a string representation of the EthereumEIP7702Transaction.
 func (txn *EthereumEIP7702Transaction) String() string {
-	// Encode each element in the AccessList slice individually
 	var encodedAccessList []string
 	for _, entry := range txn.AccessList {
 		encodedAccessList = append(encodedAccessList, hex.EncodeToString(entry))
@@ -177,7 +173,6 @@ func (txn *EthereumEIP7702Transaction) String() string {
 
 	accessListStr := "[" + strings.Join(encodedAccessList, ", ") + "]"
 
-	// Encode each authorization tuple in the AuthorizationList
 	var encodedAuthorizationList []string
 	for _, authTuple := range txn.AuthorizationList {
 		var tupleParts []string

--- a/sdk/ethereum_eip7702_transaction.go
+++ b/sdk/ethereum_eip7702_transaction.go
@@ -11,9 +11,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AuthorizationTuple represents a single authorization entry: [chainId, contractAddress, nonce, yParity, r, s]
-type AuthorizationTuple [6][]byte
-
 // EthereumEIP7702Transaction represents the EIP-7702 Ethereum transaction data.
 type EthereumEIP7702Transaction struct {
 	ChainId           []byte
@@ -25,7 +22,7 @@ type EthereumEIP7702Transaction struct {
 	Value             []byte
 	CallData          []byte
 	AccessList        [][]byte
-	AuthorizationList []AuthorizationTuple
+	AuthorizationList []Authorization
 	RecoveryId        []byte
 	R                 []byte
 	S                 []byte
@@ -34,7 +31,7 @@ type EthereumEIP7702Transaction struct {
 // nolint
 // NewEthereumEIP7702Transaction creates a new EthereumEIP7702Transaction with the provided fields.
 func NewEthereumEIP7702Transaction(
-	chainId, nonce, maxPriorityGas, maxGas, gasLimit, to, value, callData, recoveryId, r, s []byte, accessList [][]byte, authorizationList []AuthorizationTuple) *EthereumEIP7702Transaction {
+	chainId, nonce, maxPriorityGas, maxGas, gasLimit, to, value, callData, recoveryId, r, s []byte, accessList [][]byte, authorizationList []Authorization) *EthereumEIP7702Transaction {
 	return &EthereumEIP7702Transaction{
 		ChainId:           chainId,
 		Nonce:             nonce,
@@ -72,23 +69,16 @@ func EthereumEIP7702TransactionFromBytes(bytes []byte) (*EthereumEIP7702Transact
 		accessListValues = append(accessListValues, child.itemValue)
 	}
 
-	// Each authorization entry is a [chainId, contractAddress, nonce, yParity, r, s] tuple.
-	var authorizationListValues []AuthorizationTuple
+	var authorizationListValues []Authorization
 	if item.childItems[9].itemType != LIST_TYPE {
 		return nil, errors.New("authorization list must be an array")
 	}
 	for _, authTupleItem := range item.childItems[9].childItems {
-		if authTupleItem.itemType != LIST_TYPE {
-			return nil, errors.New("invalid authorization list entry: must be a list")
+		auth, err := _authorizationFromRLPItem(authTupleItem)
+		if err != nil {
+			return nil, err
 		}
-		if len(authTupleItem.childItems) != 6 {
-			return nil, errors.New("invalid authorization list entry: must be [chainId, contractAddress, nonce, yParity, r, s]")
-		}
-		var tuple AuthorizationTuple
-		for i := 0; i < 6; i++ {
-			tuple[i] = authTupleItem.childItems[i].itemValue
-		}
-		authorizationListValues = append(authorizationListValues, tuple)
+		authorizationListValues = append(authorizationListValues, auth)
 	}
 
 	return NewEthereumEIP7702Transaction(
@@ -125,13 +115,8 @@ func (txn *EthereumEIP7702Transaction) _toUnsignedRLP() *RLPItem {
 	}
 	item.PushBack(accessListItem)
 	authorizationListItem := NewRLPItem(LIST_TYPE)
-	for _, authTuple := range txn.AuthorizationList {
-		// Each authorization entry is a tuple: [chainId, contractAddress, nonce, yParity, r, s]
-		authTupleItem := NewRLPItem(LIST_TYPE)
-		for i := 0; i < 6; i++ {
-			authTupleItem.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(authTuple[i]))
-		}
-		authorizationListItem.PushBack(authTupleItem)
+	for _, auth := range txn.AuthorizationList {
+		authorizationListItem.PushBack(auth._toRLPItem())
 	}
 	item.PushBack(authorizationListItem)
 	return item
@@ -174,12 +159,8 @@ func (txn *EthereumEIP7702Transaction) String() string {
 	accessListStr := "[" + strings.Join(encodedAccessList, ", ") + "]"
 
 	var encodedAuthorizationList []string
-	for _, authTuple := range txn.AuthorizationList {
-		var tupleParts []string
-		for i := 0; i < 6; i++ {
-			tupleParts = append(tupleParts, hex.EncodeToString(authTuple[i]))
-		}
-		encodedAuthorizationList = append(encodedAuthorizationList, "["+strings.Join(tupleParts, ", ")+"]")
+	for _, auth := range txn.AuthorizationList {
+		encodedAuthorizationList = append(encodedAuthorizationList, auth.String())
 	}
 
 	authorizationListStr := "[" + strings.Join(encodedAuthorizationList, ", ") + "]"
@@ -402,18 +383,18 @@ func (txn *EthereumEIP7702Transaction) AddAccessListItem(item AccessListItem) *E
 }
 
 // GetAuthorizationList returns the EIP-7702 authorization list.
-func (txn *EthereumEIP7702Transaction) GetAuthorizationList() []AuthorizationTuple {
+func (txn *EthereumEIP7702Transaction) GetAuthorizationList() []Authorization {
 	return txn.AuthorizationList
 }
 
 // SetAuthorizationList replaces the EIP-7702 authorization list.
-func (txn *EthereumEIP7702Transaction) SetAuthorizationList(list []AuthorizationTuple) *EthereumEIP7702Transaction {
+func (txn *EthereumEIP7702Transaction) SetAuthorizationList(list []Authorization) *EthereumEIP7702Transaction {
 	txn.AuthorizationList = list
 	return txn
 }
 
-// AddAuthorization appends a single authorization tuple to the list.
-func (txn *EthereumEIP7702Transaction) AddAuthorization(tuple AuthorizationTuple) *EthereumEIP7702Transaction {
-	txn.AuthorizationList = append(txn.AuthorizationList, tuple)
+// AddAuthorization appends a single authorization to the list.
+func (txn *EthereumEIP7702Transaction) AddAuthorization(authorization Authorization) *EthereumEIP7702Transaction {
+	txn.AuthorizationList = append(txn.AuthorizationList, authorization)
 	return txn
 }

--- a/sdk/ethereum_eip7702_transaction_unit_test.go
+++ b/sdk/ethereum_eip7702_transaction_unit_test.go
@@ -77,10 +77,10 @@ func TestUnitEthereumEIP7702AuthorizationList(t *testing.T) {
 	t.Parallel()
 
 	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
-	auth1 := AuthorizationTuple{{0x01, 0x2a}, to, {0x00}, {0x00}, make([]byte, 32), make([]byte, 32)}
-	auth2 := AuthorizationTuple{{0x01, 0x2a}, to, {0x01}, {0x01}, make([]byte, 32), make([]byte, 32)}
+	auth1 := NewAuthorization([]byte{0x01, 0x2a}, to, 0, 0, make([]byte, 32), make([]byte, 32))
+	auth2 := NewAuthorization([]byte{0x01, 0x2a}, to, 1, 1, make([]byte, 32), make([]byte, 32))
 
-	tx := (&EthereumEIP7702Transaction{}).SetAuthorizationList([]AuthorizationTuple{auth1})
+	tx := (&EthereumEIP7702Transaction{}).SetAuthorizationList([]Authorization{auth1})
 	require.Equal(t, 1, len(tx.GetAuthorizationList()))
 
 	tx.AddAuthorization(auth2)
@@ -101,8 +101,8 @@ func TestUnitEthereumEIP7702ToBytesRoundTripWithAuthList(t *testing.T) {
 	t.Parallel()
 
 	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
-	// Canonical (non-zero / minimal) field bytes so the RLP round-trip is exact.
-	auth := AuthorizationTuple{{0x01, 0x2a}, to, {0x05}, {0x01}, make([]byte, 32), make([]byte, 32)}
+	// Canonical (non-zero / minimal) field values so the RLP round-trip is exact.
+	auth := NewAuthorization([]byte{0x01, 0x2a}, to, 5, 1, make([]byte, 32), make([]byte, 32))
 
 	tx := (&EthereumEIP7702Transaction{}).
 		SetChainId(298).
@@ -132,7 +132,7 @@ func TestUnitEthereumEIP7702String(t *testing.T) {
 	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
 	tx := (&EthereumEIP7702Transaction{}).
 		SetChainId(1).
-		AddAuthorization(AuthorizationTuple{{0x01}, to, {0x00}, {0x00}, {0x11}, {0x22}})
+		AddAuthorization(NewAuthorization([]byte{0x01}, to, 0, 0, []byte{0x11}, []byte{0x22}))
 	s := tx.String()
 	assert.Contains(t, s, "ChainId:")
 	assert.Contains(t, s, "AuthorizationList:")

--- a/sdk/ethereum_eip7702_transaction_unit_test.go
+++ b/sdk/ethereum_eip7702_transaction_unit_test.go
@@ -1,0 +1,171 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitEthereumEIP7702TypedAccessors(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(298).
+		SetNonce(5).
+		SetMaxPriorityGas(big.NewInt(2_000_000_000)).
+		SetMaxGas(big.NewInt(20_000_000_000)).
+		SetGasLimit(150_000).
+		SetTo(to).
+		SetValue(big.NewInt(1_000_000)).
+		SetCallData([]byte{0xDE, 0xAD}).
+		SetRecoveryId(1).
+		SetR([]byte{0xAA}).
+		SetS([]byte{0xBB})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(2_000_000_000), tx.GetMaxPriorityGas().Int64())
+	assert.Equal(t, int64(20_000_000_000), tx.GetMaxGas().Int64())
+	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
+	assert.Equal(t, to, tx.GetTo())
+	assert.Equal(t, int64(1_000_000), tx.GetValue().Int64())
+	assert.Equal(t, []byte{0xDE, 0xAD}, tx.GetCallData())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+	assert.Equal(t, []byte{0xAA}, tx.GetR())
+	assert.Equal(t, []byte{0xBB}, tx.GetS())
+
+	assert.Equal(t, []byte{0x01, 0x2a}, tx.GetChainIdBytes())
+	assert.Equal(t, []byte{0x05}, tx.GetNonceBytes())
+	assert.Equal(t, []byte{0x77, 0x35, 0x94, 0x00}, tx.GetMaxPriorityGasBytes())
+	assert.Equal(t, []byte{0x04, 0xa8, 0x17, 0xc8, 0x00}, tx.GetMaxGasBytes())
+	assert.Equal(t, []byte{0x02, 0x49, 0xf0}, tx.GetGasLimitBytes())
+	assert.Equal(t, []byte{0x0f, 0x42, 0x40}, tx.GetValueBytes())
+	assert.Equal(t, []byte{0x01}, tx.GetRecoveryIdBytes())
+}
+
+func TestUnitEthereumEIP7702BytesAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainIdBytes([]byte{0x01, 0x2a}).
+		SetNonceBytes([]byte{0x05}).
+		SetMaxPriorityGasBytes([]byte{0x02}).
+		SetMaxGasBytes([]byte{0x03}).
+		SetGasLimitBytes([]byte{0x04}).
+		SetValueBytes([]byte{0x05}).
+		SetRecoveryIdBytes([]byte{0x01})
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(5), tx.GetNonce())
+	assert.Equal(t, int64(2), tx.GetMaxPriorityGas().Int64())
+	assert.Equal(t, int64(3), tx.GetMaxGas().Int64())
+	assert.Equal(t, uint64(4), tx.GetGasLimit())
+	assert.Equal(t, int64(5), tx.GetValue().Int64())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+}
+
+func TestUnitEthereumEIP7702AuthorizationList(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	auth1 := AuthorizationTuple{{0x01, 0x2a}, to, {0x00}, {0x00}, make([]byte, 32), make([]byte, 32)}
+	auth2 := AuthorizationTuple{{0x01, 0x2a}, to, {0x01}, {0x01}, make([]byte, 32), make([]byte, 32)}
+
+	tx := (&EthereumEIP7702Transaction{}).SetAuthorizationList([]AuthorizationTuple{auth1})
+	require.Equal(t, 1, len(tx.GetAuthorizationList()))
+
+	tx.AddAuthorization(auth2)
+	require.Equal(t, 2, len(tx.GetAuthorizationList()))
+	assert.Equal(t, auth2, tx.GetAuthorizationList()[1])
+}
+
+func TestUnitEthereumEIP7702AddAccessListItem(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP7702Transaction{}
+	tx.AddAccessListItem(NewAccessListItem([]byte{0xAA}, [][]byte{{0x01}}))
+	require.Equal(t, 1, len(tx.GetAccessListItems()))
+	assert.Equal(t, []byte{0xAA}, tx.GetAccessListItems()[0].GetAddress())
+}
+
+func TestUnitEthereumEIP7702ToBytesRoundTripWithAuthList(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	// Canonical (non-zero / minimal) field bytes so the RLP round-trip is exact.
+	auth := AuthorizationTuple{{0x01, 0x2a}, to, {0x05}, {0x01}, make([]byte, 32), make([]byte, 32)}
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(298).
+		SetNonce(1).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(to).
+		SetValue(big.NewInt(0)).
+		SetRecoveryId(0).
+		SetR([]byte{0x11}).
+		SetS([]byte{0x22}).
+		AddAuthorization(auth)
+
+	encoded, err := tx.ToBytes()
+	require.NoError(t, err)
+	require.Equal(t, byte(0x04), encoded[0])
+
+	decoded, err := EthereumEIP7702TransactionFromBytes(encoded)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(decoded.GetAuthorizationList()))
+	assert.Equal(t, auth, decoded.GetAuthorizationList()[0])
+}
+
+func TestUnitEthereumEIP7702String(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(1).
+		AddAuthorization(AuthorizationTuple{{0x01}, to, {0x00}, {0x00}, {0x11}, {0x22}})
+	s := tx.String()
+	assert.Contains(t, s, "ChainId:")
+	assert.Contains(t, s, "AuthorizationList:")
+}
+
+func TestUnitEthereumEIP7702FromBytesErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := EthereumEIP7702TransactionFromBytes(nil)
+	assert.Error(t, err)
+
+	_, err = EthereumEIP7702TransactionFromBytes([]byte{0x02, 0x00})
+	assert.Error(t, err, "wrong type prefix should be rejected")
+
+	// Correct prefix, but an authorization tuple without 6 elements.
+	list := NewRLPItem(LIST_TYPE)
+	for i := 0; i < 8; i++ {
+		list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{}))
+	}
+	list.PushBack(NewRLPItem(LIST_TYPE)) // empty access list (index 8)
+
+	authList := NewRLPItem(LIST_TYPE)
+	badTuple := NewRLPItem(LIST_TYPE)
+	badTuple.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	authList.PushBack(badTuple)
+	list.PushBack(authList) // authorization list (index 9)
+
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{})) // recoveryId
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{})) // r
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{})) // s
+
+	body, err := list.Write()
+	require.NoError(t, err)
+	_, err = EthereumEIP7702TransactionFromBytes(append([]byte{0x04}, body...))
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_encoding.go
+++ b/sdk/ethereum_encoding.go
@@ -1,0 +1,59 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/binary"
+	"math/big"
+)
+
+// Helpers for Ethereum RLP canonical integer encoding: big-endian, no
+// leading zeros, zero is the empty byte string.
+
+// _uint64ToEthBytes encodes v as canonical minimal big-endian. Zero → empty.
+func _uint64ToEthBytes(v uint64) []byte {
+	if v == 0 {
+		return []byte{}
+	}
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, v)
+	i := 0
+	for i < len(buf) && buf[i] == 0 {
+		i++
+	}
+	return buf[i:]
+}
+
+// _ethBytesToUint64 decodes canonical bytes to uint64. Empty → 0.
+// Input longer than 8 bytes is truncated to the low 8.
+func _ethBytesToUint64(b []byte) uint64 {
+	if len(b) == 0 {
+		return 0
+	}
+	if len(b) > 8 {
+		b = b[len(b)-8:]
+	}
+	var buf [8]byte
+	copy(buf[8-len(b):], b)
+	return binary.BigEndian.Uint64(buf[:])
+}
+
+// _bigIntToEthBytes encodes v as canonical minimal big-endian.
+// Nil and zero → empty. Negative values encode their absolute value.
+func _bigIntToEthBytes(v *big.Int) []byte {
+	if v == nil || v.Sign() == 0 {
+		return []byte{}
+	}
+	if v.Sign() < 0 {
+		return new(big.Int).Abs(v).Bytes()
+	}
+	return v.Bytes()
+}
+
+// _ethBytesToBigInt decodes canonical bytes to *big.Int. Empty → 0.
+func _ethBytesToBigInt(b []byte) *big.Int {
+	if len(b) == 0 {
+		return new(big.Int)
+	}
+	return new(big.Int).SetBytes(b)
+}

--- a/sdk/ethereum_encoding_unit_test.go
+++ b/sdk/ethereum_encoding_unit_test.go
@@ -1,0 +1,160 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitUint64EthBytesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		v    uint64
+		want []byte
+	}{
+		{"zero is empty", 0, []byte{}},
+		{"one byte", 1, []byte{0x01}},
+		{"0xFF", 0xFF, []byte{0xFF}},
+		{"two bytes", 0x0100, []byte{0x01, 0x00}},
+		{"eight bytes", 0xFFFFFFFFFFFFFFFF, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := _uint64ToEthBytes(tc.v)
+			assert.Equal(t, tc.want, got)
+			back := _ethBytesToUint64(got)
+			assert.Equal(t, tc.v, back)
+		})
+	}
+}
+
+func TestUnitBigIntEthBytesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		v    *big.Int
+	}{
+		{"nil", nil},
+		{"zero", big.NewInt(0)},
+		{"small", big.NewInt(0x42)},
+		{"large", new(big.Int).Lsh(big.NewInt(1), 200)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := _bigIntToEthBytes(tc.v)
+			decoded := _ethBytesToBigInt(encoded)
+			if tc.v == nil || tc.v.Sign() == 0 {
+				assert.Equal(t, 0, decoded.Sign())
+				assert.Equal(t, 0, len(encoded))
+			} else {
+				assert.Equal(t, 0, tc.v.Cmp(decoded))
+			}
+		})
+	}
+}
+
+func TestUnitEIP1559NumberAccessors(t *testing.T) {
+	t.Parallel()
+
+	gasPrice := new(big.Int).SetUint64(900_000_000_000) // 0xd1385c7bf0
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(42).
+		SetGasLimit(150_000).
+		SetMaxGas(gasPrice).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetValue(big.NewInt(1_000_000)).
+		SetRecoveryId(1)
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(42), tx.GetNonce())
+	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
+	assert.Equal(t, 0, gasPrice.Cmp(tx.GetMaxGas()))
+	assert.Equal(t, 0, tx.GetMaxPriorityGas().Sign())
+	assert.Equal(t, int64(1_000_000), tx.GetValue().Int64())
+	assert.Equal(t, 1, tx.GetRecoveryId())
+
+	// Underlying bytes match canonical encoding.
+	require.Equal(t, []byte{0x01, 0x2a}, tx.ChainId)
+	require.Equal(t, []byte{0x2a}, tx.Nonce)
+	require.Equal(t, []byte{}, tx.MaxPriorityGas)
+}
+
+func TestUnitEIP2930NumberAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP2930Transaction{}).
+		SetChainId(1).
+		SetNonce(7).
+		SetGasPrice(big.NewInt(20_000_000_000)).
+		SetGasLimit(21_000).
+		SetValue(big.NewInt(0)).
+		SetRecoveryId(0)
+
+	assert.Equal(t, uint64(1), tx.GetChainId())
+	assert.Equal(t, uint64(7), tx.GetNonce())
+	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(21_000), tx.GetGasLimit())
+	assert.Equal(t, 0, tx.GetValue().Sign())
+	assert.Equal(t, 0, tx.GetRecoveryId())
+	assert.Equal(t, []byte{}, tx.Value)
+}
+
+func TestUnitEIP7702NumberAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxGas(big.NewInt(0x05)).
+		SetMaxPriorityGas(big.NewInt(0x02)).
+		SetGasLimit(150_000).
+		SetValue(big.NewInt(0))
+
+	assert.Equal(t, uint64(298), tx.GetChainId())
+	assert.Equal(t, uint64(0), tx.GetNonce())
+	assert.Equal(t, int64(5), tx.GetMaxGas().Int64())
+	assert.Equal(t, int64(2), tx.GetMaxPriorityGas().Int64())
+	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
+}
+
+func TestUnitLegacyNumberAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumLegacyTransaction{}).
+		SetNonce(3).
+		SetGasPrice(big.NewInt(20_000_000_000)).
+		SetGasLimit(21_000).
+		SetValue(big.NewInt(500)).
+		SetV(27)
+
+	assert.Equal(t, uint64(3), tx.GetNonce())
+	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(21_000), tx.GetGasLimit())
+	assert.Equal(t, int64(500), tx.GetValue().Int64())
+	assert.Equal(t, uint64(27), tx.GetV())
+}
+
+func TestUnitNumberAccessorsAgreeWithRawBytes(t *testing.T) {
+	t.Parallel()
+
+	tx := &EthereumEIP1559Transaction{}
+	tx.SetChainId(0xCAFE)
+	assert.Equal(t, []byte{0xCA, 0xFE}, tx.GetChainIdBytes())
+	assert.Equal(t, uint64(0xCAFE), tx.GetChainId())
+
+	// Writing raw bytes is reflected in the numeric getter.
+	tx.ChainId = []byte{0x00, 0x01} // non-canonical leading zero
+	assert.Equal(t, uint64(1), tx.GetChainId())
+}

--- a/sdk/ethereum_encoding_unit_test.go
+++ b/sdk/ethereum_encoding_unit_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUnitUint64EthBytesRoundTrip(t *testing.T) {
@@ -64,86 +63,15 @@ func TestUnitBigIntEthBytesRoundTrip(t *testing.T) {
 	}
 }
 
-func TestUnitEIP1559NumberAccessors(t *testing.T) {
+func TestUnitEthBytesEncodingEdgeCases(t *testing.T) {
 	t.Parallel()
 
-	gasPrice := new(big.Int).SetUint64(900_000_000_000) // 0xd1385c7bf0
-	tx := (&EthereumEIP1559Transaction{}).
-		SetChainId(298).
-		SetNonce(42).
-		SetGasLimit(150_000).
-		SetMaxGas(gasPrice).
-		SetMaxPriorityGas(big.NewInt(0)).
-		SetValue(big.NewInt(1_000_000)).
-		SetRecoveryId(1)
+	// Decoding truncates inputs longer than 8 bytes to the low 8.
+	assert.Equal(t, uint64(0x0102030405060708),
+		_ethBytesToUint64([]byte{0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}))
 
-	assert.Equal(t, uint64(298), tx.GetChainId())
-	assert.Equal(t, uint64(42), tx.GetNonce())
-	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
-	assert.Equal(t, 0, gasPrice.Cmp(tx.GetMaxGas()))
-	assert.Equal(t, 0, tx.GetMaxPriorityGas().Sign())
-	assert.Equal(t, int64(1_000_000), tx.GetValue().Int64())
-	assert.Equal(t, 1, tx.GetRecoveryId())
-
-	// Underlying bytes match canonical encoding.
-	require.Equal(t, []byte{0x01, 0x2a}, tx.ChainId)
-	require.Equal(t, []byte{0x2a}, tx.Nonce)
-	require.Equal(t, []byte{}, tx.MaxPriorityGas)
-}
-
-func TestUnitEIP2930NumberAccessors(t *testing.T) {
-	t.Parallel()
-
-	tx := (&EthereumEIP2930Transaction{}).
-		SetChainId(1).
-		SetNonce(7).
-		SetGasPrice(big.NewInt(20_000_000_000)).
-		SetGasLimit(21_000).
-		SetValue(big.NewInt(0)).
-		SetRecoveryId(0)
-
-	assert.Equal(t, uint64(1), tx.GetChainId())
-	assert.Equal(t, uint64(7), tx.GetNonce())
-	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
-	assert.Equal(t, uint64(21_000), tx.GetGasLimit())
-	assert.Equal(t, 0, tx.GetValue().Sign())
-	assert.Equal(t, 0, tx.GetRecoveryId())
-	assert.Equal(t, []byte{}, tx.Value)
-}
-
-func TestUnitEIP7702NumberAccessors(t *testing.T) {
-	t.Parallel()
-
-	tx := (&EthereumEIP7702Transaction{}).
-		SetChainId(298).
-		SetNonce(0).
-		SetMaxGas(big.NewInt(0x05)).
-		SetMaxPriorityGas(big.NewInt(0x02)).
-		SetGasLimit(150_000).
-		SetValue(big.NewInt(0))
-
-	assert.Equal(t, uint64(298), tx.GetChainId())
-	assert.Equal(t, uint64(0), tx.GetNonce())
-	assert.Equal(t, int64(5), tx.GetMaxGas().Int64())
-	assert.Equal(t, int64(2), tx.GetMaxPriorityGas().Int64())
-	assert.Equal(t, uint64(150_000), tx.GetGasLimit())
-}
-
-func TestUnitLegacyNumberAccessors(t *testing.T) {
-	t.Parallel()
-
-	tx := (&EthereumLegacyTransaction{}).
-		SetNonce(3).
-		SetGasPrice(big.NewInt(20_000_000_000)).
-		SetGasLimit(21_000).
-		SetValue(big.NewInt(500)).
-		SetV(27)
-
-	assert.Equal(t, uint64(3), tx.GetNonce())
-	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
-	assert.Equal(t, uint64(21_000), tx.GetGasLimit())
-	assert.Equal(t, int64(500), tx.GetValue().Int64())
-	assert.Equal(t, uint64(27), tx.GetV())
+	// A negative big.Int encodes its absolute value.
+	assert.Equal(t, []byte{0x05}, _bigIntToEthBytes(big.NewInt(-5)))
 }
 
 func TestUnitNumberAccessorsAgreeWithRawBytes(t *testing.T) {

--- a/sdk/ethereum_legacy_transaction.go
+++ b/sdk/ethereum_legacy_transaction.go
@@ -5,6 +5,7 @@ package hiero
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 
 	"github.com/pkg/errors"
 )
@@ -133,4 +134,140 @@ func (txn *EthereumLegacyTransaction) String() string {
 		hex.EncodeToString(txn.R),
 		hex.EncodeToString(txn.S),
 	)
+}
+
+// GetNonce returns the nonce as a uint64.
+func (txn *EthereumLegacyTransaction) GetNonce() uint64 {
+	return _ethBytesToUint64(txn.Nonce)
+}
+
+// SetNonce sets the nonce from a uint64.
+func (txn *EthereumLegacyTransaction) SetNonce(v uint64) *EthereumLegacyTransaction {
+	txn.Nonce = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetNonceBytes returns the raw canonical big-endian nonce bytes.
+func (txn *EthereumLegacyTransaction) GetNonceBytes() []byte { return txn.Nonce }
+
+// SetNonceBytes sets the nonce from raw canonical big-endian bytes.
+func (txn *EthereumLegacyTransaction) SetNonceBytes(v []byte) *EthereumLegacyTransaction {
+	txn.Nonce = v
+	return txn
+}
+
+// GetGasPrice returns the gas price as a *big.Int.
+func (txn *EthereumLegacyTransaction) GetGasPrice() *big.Int {
+	return _ethBytesToBigInt(txn.GasPrice)
+}
+
+// SetGasPrice sets the gas price from a *big.Int.
+func (txn *EthereumLegacyTransaction) SetGasPrice(v *big.Int) *EthereumLegacyTransaction {
+	txn.GasPrice = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetGasPriceBytes returns the raw canonical big-endian gas price bytes.
+func (txn *EthereumLegacyTransaction) GetGasPriceBytes() []byte { return txn.GasPrice }
+
+// SetGasPriceBytes sets the gas price from raw bytes.
+func (txn *EthereumLegacyTransaction) SetGasPriceBytes(v []byte) *EthereumLegacyTransaction {
+	txn.GasPrice = v
+	return txn
+}
+
+// GetGasLimit returns the gas limit as a uint64.
+func (txn *EthereumLegacyTransaction) GetGasLimit() uint64 {
+	return _ethBytesToUint64(txn.GasLimit)
+}
+
+// SetGasLimit sets the gas limit from a uint64.
+func (txn *EthereumLegacyTransaction) SetGasLimit(v uint64) *EthereumLegacyTransaction {
+	txn.GasLimit = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetGasLimitBytes returns the raw canonical big-endian gas limit bytes.
+func (txn *EthereumLegacyTransaction) GetGasLimitBytes() []byte { return txn.GasLimit }
+
+// SetGasLimitBytes sets the gas limit from raw bytes.
+func (txn *EthereumLegacyTransaction) SetGasLimitBytes(v []byte) *EthereumLegacyTransaction {
+	txn.GasLimit = v
+	return txn
+}
+
+// GetTo returns the recipient address bytes.
+func (txn *EthereumLegacyTransaction) GetTo() []byte { return txn.To }
+
+// SetTo sets the recipient address bytes.
+func (txn *EthereumLegacyTransaction) SetTo(v []byte) *EthereumLegacyTransaction {
+	txn.To = v
+	return txn
+}
+
+// GetValue returns the transaction value (wei) as a *big.Int.
+func (txn *EthereumLegacyTransaction) GetValue() *big.Int {
+	return _ethBytesToBigInt(txn.Value)
+}
+
+// SetValue sets the transaction value (wei) from a *big.Int.
+func (txn *EthereumLegacyTransaction) SetValue(v *big.Int) *EthereumLegacyTransaction {
+	txn.Value = _bigIntToEthBytes(v)
+	return txn
+}
+
+// GetValueBytes returns the raw canonical big-endian value bytes.
+func (txn *EthereumLegacyTransaction) GetValueBytes() []byte { return txn.Value }
+
+// SetValueBytes sets the value from raw bytes.
+func (txn *EthereumLegacyTransaction) SetValueBytes(v []byte) *EthereumLegacyTransaction {
+	txn.Value = v
+	return txn
+}
+
+// GetCallData returns the call data.
+func (txn *EthereumLegacyTransaction) GetCallData() []byte { return txn.CallData }
+
+// SetCallData sets the call data.
+func (txn *EthereumLegacyTransaction) SetCallData(v []byte) *EthereumLegacyTransaction {
+	txn.CallData = v
+	return txn
+}
+
+// GetV returns V as a uint64.
+func (txn *EthereumLegacyTransaction) GetV() uint64 {
+	return _ethBytesToUint64(txn.V)
+}
+
+// SetV sets V from a uint64.
+func (txn *EthereumLegacyTransaction) SetV(v uint64) *EthereumLegacyTransaction {
+	txn.V = _uint64ToEthBytes(v)
+	return txn
+}
+
+// GetVBytes returns the raw V bytes.
+func (txn *EthereumLegacyTransaction) GetVBytes() []byte { return txn.V }
+
+// SetVBytes sets V from raw bytes.
+func (txn *EthereumLegacyTransaction) SetVBytes(v []byte) *EthereumLegacyTransaction {
+	txn.V = v
+	return txn
+}
+
+// GetR returns the R signature component.
+func (txn *EthereumLegacyTransaction) GetR() []byte { return txn.R }
+
+// SetR sets the R signature component.
+func (txn *EthereumLegacyTransaction) SetR(v []byte) *EthereumLegacyTransaction {
+	txn.R = v
+	return txn
+}
+
+// GetS returns the S signature component.
+func (txn *EthereumLegacyTransaction) GetS() []byte { return txn.S }
+
+// SetS sets the S signature component.
+func (txn *EthereumLegacyTransaction) SetS(v []byte) *EthereumLegacyTransaction {
+	txn.S = v
+	return txn
 }

--- a/sdk/ethereum_legacy_transaction.go
+++ b/sdk/ethereum_legacy_transaction.go
@@ -38,7 +38,8 @@ func NewEthereumLegacyTransaction(nonce, gasPrice, gasLimit, to, value, callData
 	}
 }
 
-// FromBytes decodes the RLP encoded bytes into an EthereumLegacyTransaction.
+// EthereumLegacyTransactionFromBytes decodes a signed legacy transaction
+// (RLP list of 9 elements, no type prefix).
 func EthereumLegacyTransactionFromBytes(bytes []byte) (*EthereumLegacyTransaction, error) {
 	item := NewRLPItem(LIST_TYPE)
 	if err := item.Read(bytes); err != nil {
@@ -53,7 +54,6 @@ func EthereumLegacyTransactionFromBytes(bytes []byte) (*EthereumLegacyTransactio
 		return nil, errors.New("input byte array does not contain 9 RLP-encoded elements")
 	}
 
-	// Extract the values from the RLP item
 	return NewEthereumLegacyTransaction(
 		item.childItems[0].itemValue,
 		item.childItems[1].itemValue,
@@ -67,8 +67,8 @@ func EthereumLegacyTransactionFromBytes(bytes []byte) (*EthereumLegacyTransactio
 	), nil
 }
 
-// ToBytes encodes the EthereumLegacyTransaction into RLP format.
-func (txn *EthereumLegacyTransaction) ToBytes() ([]byte, error) {
+// _toUnsignedRLP builds the unsigned portion of the legacy RLP list
+func (txn *EthereumLegacyTransaction) _toUnsignedRLP() *RLPItem {
 	item := NewRLPItem(LIST_TYPE)
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.Nonce))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.GasPrice))
@@ -76,11 +76,48 @@ func (txn *EthereumLegacyTransaction) ToBytes() ([]byte, error) {
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.To))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.Value))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.CallData))
+	return item
+}
+
+// _encodeWithSignature appends V/R/S to the given unsigned RLP list
+// and serializes it. Legacy has no type prefix.
+func (txn *EthereumLegacyTransaction) _encodeWithSignature(item *RLPItem) ([]byte, error) {
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.V))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.R))
 	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(txn.S))
-
 	return item.Write()
+}
+
+// ToBytes encodes the EthereumLegacyTransaction into RLP format.
+func (txn *EthereumLegacyTransaction) ToBytes() ([]byte, error) {
+	return txn._encodeWithSignature(txn._toUnsignedRLP())
+}
+
+// Sign signs the transaction with the given ECDSA key, populates V/R/S on
+// the receiver, and returns the signed RLP bytes.
+func (txn *EthereumLegacyTransaction) Sign(key PrivateKey) ([]byte, error) {
+	item := txn._toUnsignedRLP()
+	message, err := item.Write()
+	if err != nil {
+		return nil, err
+	}
+
+	sig := key.Sign(message)
+	if len(sig) < 64 {
+		return nil, errors.New("signing produced an invalid signature; expected an ECDSA key")
+	}
+	r := sig[0:32]
+	s := sig[32:64]
+	v := key.GetRecoveryId(r, s, message)
+	if v < 0 {
+		return nil, errors.New("unable to compute recovery id; expected an ECDSA key")
+	}
+
+	txn.R = r
+	txn.S = s
+	txn.V = []byte{byte(27 + v)}
+
+	return txn._encodeWithSignature(item)
 }
 
 // String returns a string representation of the EthereumLegacyTransaction.

--- a/sdk/ethereum_legacy_transaction_unit_test.go
+++ b/sdk/ethereum_legacy_transaction_unit_test.go
@@ -1,0 +1,127 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitEthereumLegacyTypedAccessors(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumLegacyTransaction{}).
+		SetNonce(7).
+		SetGasPrice(big.NewInt(20_000_000_000)).
+		SetGasLimit(21_000).
+		SetTo(to).
+		SetValue(big.NewInt(1_000_000)).
+		SetCallData([]byte{0xDE, 0xAD}).
+		SetV(28).
+		SetR([]byte{0xAA}).
+		SetS([]byte{0xBB})
+
+	assert.Equal(t, uint64(7), tx.GetNonce())
+	assert.Equal(t, int64(20_000_000_000), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(21_000), tx.GetGasLimit())
+	assert.Equal(t, to, tx.GetTo())
+	assert.Equal(t, int64(1_000_000), tx.GetValue().Int64())
+	assert.Equal(t, []byte{0xDE, 0xAD}, tx.GetCallData())
+	assert.Equal(t, uint64(28), tx.GetV())
+	assert.Equal(t, []byte{0xAA}, tx.GetR())
+	assert.Equal(t, []byte{0xBB}, tx.GetS())
+
+	// Typed setters store canonical big-endian bytes.
+	assert.Equal(t, []byte{0x07}, tx.GetNonceBytes())
+	assert.Equal(t, []byte{0x04, 0xa8, 0x17, 0xc8, 0x00}, tx.GetGasPriceBytes())
+	assert.Equal(t, []byte{0x52, 0x08}, tx.GetGasLimitBytes())
+	assert.Equal(t, []byte{0x0f, 0x42, 0x40}, tx.GetValueBytes())
+	assert.Equal(t, []byte{0x1c}, tx.GetVBytes())
+}
+
+func TestUnitEthereumLegacyBytesAccessors(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumLegacyTransaction{}).
+		SetNonceBytes([]byte{0x01}).
+		SetGasPriceBytes([]byte{0x02}).
+		SetGasLimitBytes([]byte{0x03}).
+		SetValueBytes([]byte{0x04}).
+		SetVBytes([]byte{0x1b})
+
+	assert.Equal(t, uint64(1), tx.GetNonce())
+	assert.Equal(t, int64(2), tx.GetGasPrice().Int64())
+	assert.Equal(t, uint64(3), tx.GetGasLimit())
+	assert.Equal(t, int64(4), tx.GetValue().Int64())
+	assert.Equal(t, uint64(27), tx.GetV())
+}
+
+func TestUnitEthereumLegacyConstructorAndToBytesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	tx := NewEthereumLegacyTransaction(
+		[]byte{0x01},       // nonce
+		[]byte{0x04, 0xa8}, // gasPrice
+		[]byte{0x52, 0x08}, // gasLimit
+		to,                 // to
+		[]byte{},           // value
+		[]byte{0xCA, 0xFE}, // callData
+		[]byte{0x1c},       // v
+		[]byte{0x11},       // r
+		[]byte{0x22},       // s
+	)
+
+	encoded, err := tx.ToBytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	decoded, err := EthereumLegacyTransactionFromBytes(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, tx.Nonce, decoded.Nonce)
+	assert.Equal(t, tx.GasPrice, decoded.GasPrice)
+	assert.Equal(t, tx.GasLimit, decoded.GasLimit)
+	assert.Equal(t, tx.To, decoded.To)
+	assert.Equal(t, tx.Value, decoded.Value)
+	assert.Equal(t, tx.CallData, decoded.CallData)
+	assert.Equal(t, tx.V, decoded.V)
+	assert.Equal(t, tx.R, decoded.R)
+	assert.Equal(t, tx.S, decoded.S)
+}
+
+func TestUnitEthereumLegacyString(t *testing.T) {
+	t.Parallel()
+
+	tx := (&EthereumLegacyTransaction{}).SetNonce(1).SetGasLimit(21_000)
+	s := tx.String()
+	assert.Contains(t, s, "Nonce:")
+	assert.Contains(t, s, "GasLimit:")
+	assert.Contains(t, s, "V:")
+}
+
+func TestUnitEthereumLegacyFromBytesErrors(t *testing.T) {
+	t.Parallel()
+
+	// Not an RLP list (a bare value).
+	value := NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01})
+	notAList, err := value.Write()
+	require.NoError(t, err)
+	_, err = EthereumLegacyTransactionFromBytes(notAList)
+	assert.Error(t, err)
+
+	// A list, but not 9 elements.
+	short := NewRLPItem(LIST_TYPE)
+	short.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	shortBytes, err := short.Write()
+	require.NoError(t, err)
+	_, err = EthereumLegacyTransactionFromBytes(shortBytes)
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_transaction.go
+++ b/sdk/ethereum_transaction.go
@@ -52,6 +52,25 @@ func (tx *EthereumTransaction) GetEthereumData() []byte {
 	return tx.ethereumData
 }
 
+// SetEthereumDataFromBody serializes a signed Ethereum transaction body
+// (Legacy, EIP-1559, EIP-2930, or EIP-7702) and sets it as the raw Ethereum
+// data. It returns an error if the body is unsigned.
+func (tx *EthereumTransaction) SetEthereumDataFromBody(body EthereumTransactionBody) (*EthereumTransaction, error) {
+	tx._RequireNotFrozen()
+	if body == nil {
+		return tx, errors.New("ethereum transaction body is nil")
+	}
+	if !_ethereumBodyIsSigned(body) {
+		return tx, errors.New("ethereum transaction body is not signed; call Sign before SetEthereumDataFromBody")
+	}
+	data, err := body.ToBytes()
+	if err != nil {
+		return tx, err
+	}
+	tx.ethereumData = data
+	return tx, nil
+}
+
 // Deprecated
 func (tx *EthereumTransaction) SetCallData(file FileID) *EthereumTransaction {
 	tx._RequireNotFrozen()

--- a/sdk/ethereum_transaction_body_unit_test.go
+++ b/sdk/ethereum_transaction_body_unit_test.go
@@ -1,0 +1,209 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEcdsaKey(t *testing.T) PrivateKey {
+	t.Helper()
+	key, err := PrivateKeyGenerateEcdsa()
+	require.NoError(t, err)
+	return key
+}
+
+func TestUnitEthereumEIP1559BuilderAndSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(900_000_000_000)).
+		SetGasLimit(150_000).
+		SetTo(to).
+		SetValue(big.NewInt(0)).
+		SetCallData([]byte{0xDE, 0xAD, 0xBE, 0xEF}).
+		AddAccessListItem(NewAccessListItem(to, [][]byte{{0x01}}))
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+	require.NotEmpty(t, signed)
+	assert.Equal(t, byte(0x02), signed[0])
+
+	assert.Equal(t, 32, len(tx.GetR()))
+	assert.Equal(t, 32, len(tx.GetS()))
+	rid := tx.GetRecoveryId()
+	assert.True(t, rid == 0 || rid == 1, "recovery id must be 0 or 1, got %d", rid)
+
+	// Round-trip through EthereumTransactionDataFromBytes.
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body := roundTrip.GetTransaction()
+	require.NotNil(t, body)
+
+	concrete, ok := body.(*EthereumEIP1559Transaction)
+	require.True(t, ok)
+	assert.Equal(t, uint64(298), concrete.GetChainId())
+	assert.Equal(t, tx.GetR(), concrete.GetR())
+	assert.Equal(t, tx.GetS(), concrete.GetS())
+}
+
+func TestUnitEthereumEIP2930BuilderAndSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumEIP2930Transaction{}).
+		SetChainId(298).
+		SetNonce(5).
+		SetGasPrice(big.NewInt(0xa54f4c3c00)).
+		SetGasLimit(0x2dc6c0).
+		SetTo(to).
+		SetValue(big.NewInt(0x02540be400)).
+		SetCallData(nil)
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x01), signed[0])
+
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body, ok := roundTrip.GetTransaction().(*EthereumEIP2930Transaction)
+	require.True(t, ok)
+	assert.Equal(t, uint64(298), body.GetChainId())
+	assert.Equal(t, to, body.GetTo())
+}
+
+func TestUnitEthereumEIP7702BuilderAndSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	authTuple := AuthorizationTuple{
+		{0x01, 0x2a},
+		to,
+		{0x00},
+		{0x00},
+		make([]byte, 32),
+		make([]byte, 32),
+	}
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(298).
+		SetNonce(1).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(to).
+		SetValue(big.NewInt(0)).
+		SetCallData([]byte{0x01, 0x02}).
+		AddAuthorization(authTuple)
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x04), signed[0])
+
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body, ok := roundTrip.GetTransaction().(*EthereumEIP7702Transaction)
+	require.True(t, ok)
+	require.Equal(t, 1, len(body.GetAuthorizationList()))
+}
+
+func TestUnitEthereumLegacyBuilderAndSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+
+	tx := (&EthereumLegacyTransaction{}).
+		SetNonce(1).
+		SetGasPrice(big.NewInt(0x04a817c800)).
+		SetGasLimit(21_000).
+		SetTo(to).
+		SetValue(big.NewInt(0)).
+		SetCallData(nil)
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+	require.NotEmpty(t, signed)
+
+	assert.Equal(t, 32, len(tx.GetR()))
+	assert.Equal(t, 32, len(tx.GetS()))
+	assert.True(t, tx.GetV() == 27 || tx.GetV() == 28)
+
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body, ok := roundTrip.GetTransaction().(*EthereumLegacyTransaction)
+	require.True(t, ok)
+	assert.Equal(t, to, body.GetTo())
+}
+
+func TestUnitEthereumTransactionDataWrapAndSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	inner := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(make([]byte, 20)).
+		SetValue(big.NewInt(0)).
+		SetCallData([]byte{0xCA, 0xFE})
+
+	data := NewEthereumTransactionData(inner)
+	require.NotNil(t, data)
+
+	// GetTransaction returns the same pointer we passed in.
+	assert.Same(t, inner, data.GetTransaction())
+
+	signed, err := data.Sign(key)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x02), signed[0])
+
+	// Inner was mutated with R/S/RecoveryId.
+	assert.NotEmpty(t, inner.GetR())
+	assert.NotEmpty(t, inner.GetS())
+	assert.NotEmpty(t, inner.GetRecoveryIdBytes())
+
+	// ToBytes() on the data matches the signed payload.
+	dataBytes, err := data.ToBytes()
+	require.NoError(t, err)
+	assert.Equal(t, signed, dataBytes)
+}
+
+func TestUnitEthereumTransactionDataUnsupportedBody(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, NewEthereumTransactionData(nil))
+}
+
+func TestUnitEthereumEIP1559SignWithNonEcdsaKeyFails(t *testing.T) {
+	t.Parallel()
+	edKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainId(1).
+		SetNonce(0).
+		SetGasLimit(21_000).
+		SetTo(make([]byte, 20)).
+		SetValue(big.NewInt(0))
+
+	_, err = tx.Sign(edKey)
+	assert.Error(t, err)
+}

--- a/sdk/ethereum_transaction_body_unit_test.go
+++ b/sdk/ethereum_transaction_body_unit_test.go
@@ -207,3 +207,109 @@ func TestUnitEthereumEIP1559SignWithNonEcdsaKeyFails(t *testing.T) {
 	_, err = tx.Sign(edKey)
 	assert.Error(t, err)
 }
+
+func TestUnitEthereumLegacySignWithNonEcdsaKeyFails(t *testing.T) {
+	t.Parallel()
+	edKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+
+	tx := (&EthereumLegacyTransaction{}).
+		SetNonce(0).
+		SetGasLimit(21_000).
+		SetTo(make([]byte, 20)).
+		SetValue(big.NewInt(0))
+
+	_, err = tx.Sign(edKey)
+	assert.Error(t, err)
+}
+
+func TestUnitEthereumEIP7702SignWithEmptyAuthorizationList(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	tx := (&EthereumEIP7702Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(make([]byte, 20)).
+		SetValue(big.NewInt(0)).
+		SetCallData(nil)
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x04), signed[0])
+
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body, ok := roundTrip.GetTransaction().(*EthereumEIP7702Transaction)
+	require.True(t, ok)
+	assert.Equal(t, 0, len(body.GetAuthorizationList()))
+}
+
+func TestUnitEthereumEIP1559AccessListSurvivesSign(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	addr1, _ := hex.DecodeString("000000000000000000000000000000000000041d")
+	addr2, _ := hex.DecodeString("00000000000000000000000000000000000004de")
+
+	tx := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(addr1).
+		SetValue(big.NewInt(0)).
+		SetCallData(nil).
+		AddAccessListItem(NewAccessListItem(addr1, [][]byte{{0x01}, {0x02}})).
+		AddAccessListItem(NewAccessListItem(addr2, [][]byte{{0x03}}))
+
+	signed, err := tx.Sign(key)
+	require.NoError(t, err)
+
+	roundTrip, err := EthereumTransactionDataFromBytes(signed)
+	require.NoError(t, err)
+	body, ok := roundTrip.GetTransaction().(*EthereumEIP1559Transaction)
+	require.True(t, ok)
+
+	items := body.GetAccessListItems()
+	require.Equal(t, 2, len(items))
+	assert.Equal(t, addr1, items[0].GetAddress())
+	assert.Equal(t, [][]byte{{0x01}, {0x02}}, items[0].GetStorageKeys())
+	assert.Equal(t, addr2, items[1].GetAddress())
+	assert.Equal(t, [][]byte{{0x03}}, items[1].GetStorageKeys())
+}
+
+func TestUnitEthereumSetEthereumDataFromBody(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	body := (&EthereumEIP1559Transaction{}).
+		SetChainId(298).
+		SetNonce(0).
+		SetMaxPriorityGas(big.NewInt(0)).
+		SetMaxGas(big.NewInt(5)).
+		SetGasLimit(150_000).
+		SetTo(make([]byte, 20)).
+		SetValue(big.NewInt(0)).
+		SetCallData([]byte{0xCA, 0xFE})
+
+	// Unsigned body is rejected — never submitted silently.
+	_, err := NewEthereumTransaction().SetEthereumDataFromBody(body)
+	assert.Error(t, err)
+
+	// nil body is rejected.
+	_, err = NewEthereumTransaction().SetEthereumDataFromBody(nil)
+	assert.Error(t, err)
+
+	// Signed body sets the raw data to the signed RLP.
+	signed, err := body.Sign(key)
+	require.NoError(t, err)
+
+	tx, err := NewEthereumTransaction().SetEthereumDataFromBody(body)
+	require.NoError(t, err)
+	assert.Equal(t, signed, tx.GetEthereumData())
+}

--- a/sdk/ethereum_transaction_body_unit_test.go
+++ b/sdk/ethereum_transaction_body_unit_test.go
@@ -92,14 +92,7 @@ func TestUnitEthereumEIP7702BuilderAndSign(t *testing.T) {
 	key := newTestEcdsaKey(t)
 
 	to, _ := hex.DecodeString("000000000000000000000000000000000000041d")
-	authTuple := AuthorizationTuple{
-		{0x01, 0x2a},
-		to,
-		{0x00},
-		{0x00},
-		make([]byte, 32),
-		make([]byte, 32),
-	}
+	auth := NewAuthorization([]byte{0x01, 0x2a}, to, 0, 0, make([]byte, 32), make([]byte, 32))
 
 	tx := (&EthereumEIP7702Transaction{}).
 		SetChainId(298).
@@ -110,7 +103,7 @@ func TestUnitEthereumEIP7702BuilderAndSign(t *testing.T) {
 		SetTo(to).
 		SetValue(big.NewInt(0)).
 		SetCallData([]byte{0x01, 0x02}).
-		AddAuthorization(authTuple)
+		AddAuthorization(auth)
 
 	signed, err := tx.Sign(key)
 	require.NoError(t, err)

--- a/sdk/ethereum_transaction_data.go
+++ b/sdk/ethereum_transaction_data.go
@@ -1,10 +1,24 @@
 package hiero
 
+// SPDX-License-Identifier: Apache-2.0
+
 import (
 	"github.com/pkg/errors"
 )
 
-// SPDX-License-Identifier: Apache-2.0
+// EthereumTransactionBody is implemented by every Ethereum transaction
+// variant: Legacy, EIP-1559, EIP-2930, EIP-7702.
+type EthereumTransactionBody interface {
+	// ToBytes returns the signed RLP, with the type prefix (0x01/0x02/0x04)
+	// on typed transactions.
+	ToBytes() ([]byte, error)
+
+	// Sign ECDSA-signs the transaction, writes R/S and RecoveryId (V on
+	// Legacy) back onto the receiver, and returns the signed RLP.
+	Sign(key PrivateKey) ([]byte, error)
+
+	String() string
+}
 
 // EthereumTransactionData represents the data of an Ethereum transaction.
 type EthereumTransactionData struct {
@@ -12,6 +26,52 @@ type EthereumTransactionData struct {
 	eip2930 *EthereumEIP2930Transaction
 	eip7702 *EthereumEIP7702Transaction
 	legacy  *EthereumLegacyTransaction
+}
+
+// NewEthereumTransactionData wraps tx. Returns nil if tx is not one of the
+// four concrete variants.
+func NewEthereumTransactionData(tx EthereumTransactionBody) *EthereumTransactionData {
+	data := &EthereumTransactionData{}
+	switch concrete := tx.(type) {
+	case *EthereumEIP1559Transaction:
+		data.eip1559 = concrete
+	case *EthereumEIP2930Transaction:
+		data.eip2930 = concrete
+	case *EthereumEIP7702Transaction:
+		data.eip7702 = concrete
+	case *EthereumLegacyTransaction:
+		data.legacy = concrete
+	default:
+		return nil
+	}
+	return data
+}
+
+// GetTransaction returns the wrapped body. Use a type assertion to recover
+// the concrete pointer (e.g. *EthereumEIP1559Transaction).
+func (ethereumTxData *EthereumTransactionData) GetTransaction() EthereumTransactionBody {
+	if ethereumTxData.eip1559 != nil {
+		return ethereumTxData.eip1559
+	}
+	if ethereumTxData.eip2930 != nil {
+		return ethereumTxData.eip2930
+	}
+	if ethereumTxData.eip7702 != nil {
+		return ethereumTxData.eip7702
+	}
+	if ethereumTxData.legacy != nil {
+		return ethereumTxData.legacy
+	}
+	return nil
+}
+
+// Sign delegates to the wrapped body.
+func (ethereumTxData *EthereumTransactionData) Sign(key PrivateKey) ([]byte, error) {
+	body := ethereumTxData.GetTransaction()
+	if body == nil {
+		return nil, errors.New("transaction data is empty")
+	}
+	return body.Sign(key)
 }
 
 // EthereumTransactionDataFromBytes constructs an EthereumTransactionData from a raw byte array.

--- a/sdk/ethereum_transaction_data.go
+++ b/sdk/ethereum_transaction_data.go
@@ -167,3 +167,39 @@ func (ethereumTxData *EthereumTransactionData) SetData(data []byte) *EthereumTra
 	ethereumTxData.legacy.CallData = data
 	return ethereumTxData
 }
+
+// _signTypedTransaction serializes the unsigned RLP list with the given
+// type prefix, signs it with key, and returns the signature components.
+// Shared by the three typed variants (EIP-1559, EIP-2930, EIP-7702).
+func _signTypedTransaction(item *RLPItem, prefix byte, key PrivateKey) (r, s []byte, recoveryId int, err error) {
+	unsignedBytes, err := item.Write()
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	message := append([]byte{prefix}, unsignedBytes...)
+
+	sig := key.Sign(message)
+	if len(sig) < 64 {
+		return nil, nil, 0, errors.New("signing produced an invalid signature; expected an ECDSA key")
+	}
+	r = sig[0:32]
+	s = sig[32:64]
+	recoveryId = key.GetRecoveryId(r, s, message)
+	if recoveryId < 0 {
+		return nil, nil, 0, errors.New("unable to compute recovery id; expected an ECDSA key")
+	}
+	return r, s, recoveryId, nil
+}
+
+// _encodeTypedWithSignature appends RecoveryId/R/S to item, serializes it,
+// and prepends the type prefix.
+func _encodeTypedWithSignature(item *RLPItem, prefix byte, recoveryId, r, s []byte) ([]byte, error) {
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(recoveryId))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(r))
+	item.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(s))
+	bytes, err := item.Write()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{prefix}, bytes...), nil
+}

--- a/sdk/ethereum_transaction_data.go
+++ b/sdk/ethereum_transaction_data.go
@@ -168,6 +168,22 @@ func (ethereumTxData *EthereumTransactionData) SetData(data []byte) *EthereumTra
 	return ethereumTxData
 }
 
+// _ethereumBodyIsSigned reports whether body carries a populated R/S signature.
+func _ethereumBodyIsSigned(body EthereumTransactionBody) bool {
+	switch b := body.(type) {
+	case *EthereumLegacyTransaction:
+		return len(b.R) > 0 && len(b.S) > 0
+	case *EthereumEIP2930Transaction:
+		return len(b.R) > 0 && len(b.S) > 0
+	case *EthereumEIP1559Transaction:
+		return len(b.R) > 0 && len(b.S) > 0
+	case *EthereumEIP7702Transaction:
+		return len(b.R) > 0 && len(b.S) > 0
+	default:
+		return false
+	}
+}
+
 // _signTypedTransaction serializes the unsigned RLP list with the given
 // type prefix, signs it with key, and returns the signature components.
 // Shared by the three typed variants (EIP-1559, EIP-2930, EIP-7702).

--- a/sdk/ethereum_transaction_data_unit_test.go
+++ b/sdk/ethereum_transaction_data_unit_test.go
@@ -6,6 +6,7 @@ package hiero
 
 import (
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,5 +45,112 @@ func TestUnitEthereumEIP2930TransactionData(t *testing.T) {
 
 	for i, validRlpHex := range validRlpHexes {
 		require.Equal(t, validRlpHex, validRlpHexesOut[i])
+	}
+}
+
+func TestUnitEthereumTransactionDataGetSetDataPerVariant(t *testing.T) {
+	t.Parallel()
+
+	variants := []EthereumTransactionBody{
+		(&EthereumEIP1559Transaction{}).SetCallData([]byte{0x01}),
+		(&EthereumEIP2930Transaction{}).SetCallData([]byte{0x02}),
+		(&EthereumEIP7702Transaction{}).SetCallData([]byte{0x03}),
+		(&EthereumLegacyTransaction{}).SetCallData([]byte{0x04}),
+	}
+
+	for _, v := range variants {
+		data := NewEthereumTransactionData(v)
+		require.NotNil(t, data)
+		require.NotEmpty(t, data.GetData())
+
+		data.SetData([]byte{0xFF})
+		assert.Equal(t, []byte{0xFF}, data.GetData())
+	}
+}
+
+func TestUnitEthereumTransactionDataFromBytesDispatch(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+	to := make([]byte, 20)
+
+	eip1559, err := (&EthereumEIP1559Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)).Sign(key)
+	require.NoError(t, err)
+	eip2930, err := (&EthereumEIP2930Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)).Sign(key)
+	require.NoError(t, err)
+	eip7702, err := (&EthereumEIP7702Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)).Sign(key)
+	require.NoError(t, err)
+	legacy, err := (&EthereumLegacyTransaction{}).SetNonce(0).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)).Sign(key)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		payload []byte
+		isType  func(EthereumTransactionBody) bool
+	}{
+		{"eip1559", eip1559, func(b EthereumTransactionBody) bool { _, ok := b.(*EthereumEIP1559Transaction); return ok }},
+		{"eip2930", eip2930, func(b EthereumTransactionBody) bool { _, ok := b.(*EthereumEIP2930Transaction); return ok }},
+		{"eip7702", eip7702, func(b EthereumTransactionBody) bool { _, ok := b.(*EthereumEIP7702Transaction); return ok }},
+		{"legacy", legacy, func(b EthereumTransactionBody) bool { _, ok := b.(*EthereumLegacyTransaction); return ok }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := EthereumTransactionDataFromBytes(tc.payload)
+			require.NoError(t, err)
+			assert.True(t, tc.isType(data.GetTransaction()), "unexpected concrete type for %s", tc.name)
+
+			// The wrapper's ToBytes round-trips back to the original payload.
+			out, err := data.ToBytes()
+			require.NoError(t, err)
+			assert.Equal(t, tc.payload, out)
+		})
+	}
+}
+
+func TestUnitEthereumTransactionDataEmpty(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+
+	empty := &EthereumTransactionData{}
+	assert.Nil(t, empty.GetTransaction())
+
+	_, err := empty.ToBytes()
+	assert.Error(t, err)
+
+	_, err = empty.Sign(key)
+	assert.Error(t, err)
+
+	_, err = EthereumTransactionDataFromBytes(nil)
+	assert.Error(t, err)
+
+	// A recognized prefix (0x01) wrapping a valid but wrong-length RLP list
+	// surfaces the variant decode error through the dispatcher.
+	list := NewRLPItem(LIST_TYPE)
+	list.PushBack(NewRLPItem(VALUE_TYPE).AssignValue([]byte{0x01}))
+	body, err := list.Write()
+	require.NoError(t, err)
+	_, err = EthereumTransactionDataFromBytes(append([]byte{0x01}, body...))
+	assert.Error(t, err)
+}
+
+func TestUnitEthereumSetEthereumDataFromBodyAllVariants(t *testing.T) {
+	t.Parallel()
+	key := newTestEcdsaKey(t)
+	to := make([]byte, 20)
+
+	bodies := []EthereumTransactionBody{
+		(&EthereumEIP1559Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)),
+		(&EthereumEIP2930Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)),
+		(&EthereumEIP7702Transaction{}).SetChainId(1).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)),
+		(&EthereumLegacyTransaction{}).SetNonce(0).SetGasLimit(21_000).SetTo(to).SetValue(big.NewInt(0)),
+	}
+
+	for _, body := range bodies {
+		_, err := body.Sign(key)
+		require.NoError(t, err)
+
+		tx, err := NewEthereumTransaction().SetEthereumDataFromBody(body)
+		require.NoError(t, err)
+		assert.NotEmpty(t, tx.GetEthereumData())
 	}
 }

--- a/sdk/ethereum_transaction_e2e_test.go
+++ b/sdk/ethereum_transaction_e2e_test.go
@@ -319,21 +319,10 @@ func TestIntegrationEthereumEIP7702Transaction(t *testing.T) {
 	authR := authSignedBytes[0:32]
 	authS := authSignedBytes[32:64]
 	authRecoveryId := ecdsaPrivateKey.GetRecoveryId(authR, authS, authMessage)
-	authYParity := []byte{}
-	if authRecoveryId != 0 {
-		authYParity = []byte{byte(authRecoveryId)}
-	}
 
-	// Create authorization tuple: [chainId, contractAddress, nonce, yParity, r, s]
-	authorizationTuple := AuthorizationTuple{
-		chainId,
-		contractAddressForAuthorization,
-		nonce,
-		authYParity,
-		authR,
-		authS,
-	}
-	authorizationList := []AuthorizationTuple{authorizationTuple}
+	// Create authorization: [chainId, address, nonce, yParity, r, s]
+	authorization := NewAuthorization(chainId, contractAddressForAuthorization, _ethBytesToUint64(nonce), uint32(authRecoveryId), authR, authS)
+	authorizationList := []Authorization{authorization}
 
 	messageBytes, err := getEIP7702CallData(chainId, nonce, maxPriorityGas, maxGas, gasLimitBytes, contractBytes, value, callDataBytes, accessList, authorizationList, ecdsaPrivateKey)
 	require.NoError(t, err)
@@ -364,7 +353,7 @@ func TestIntegrationEthereumEIP7702Transaction(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func getEIP7702CallData(chainId, nonce, maxPriorityGas, maxGas, gasLimitBytes, contractBytes, value, callDataBytes []byte, accessList [][]byte, authorizationList []AuthorizationTuple, ecdsaPrivateKey PrivateKey) ([]byte, error) {
+func getEIP7702CallData(chainId, nonce, maxPriorityGas, maxGas, gasLimitBytes, contractBytes, value, callDataBytes []byte, accessList [][]byte, authorizationList []Authorization, ecdsaPrivateKey PrivateKey) ([]byte, error) {
 	objectsList := &RLPItem{}
 	objectsList.AssignList()
 	objectsList.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(chainId))
@@ -383,15 +372,10 @@ func getEIP7702CallData(chainId, nonce, maxPriorityGas, maxGas, gasLimitBytes, c
 	}
 	objectsList.PushBack(accessListItem)
 
-	// Add authorization list: array of [chainId, contractAddress, nonce, yParity, r, s] tuples
+	// Add authorization list: array of [chainId, address, nonce, yParity, r, s] tuples
 	authorizationListItem := NewRLPItem(LIST_TYPE)
-	for _, authTuple := range authorizationList {
-		// Each authorization entry is a tuple: [chainId, contractAddress, nonce, yParity, r, s]
-		authTupleItem := NewRLPItem(LIST_TYPE)
-		for i := 0; i < 6; i++ {
-			authTupleItem.PushBack(NewRLPItem(VALUE_TYPE).AssignValue(authTuple[i]))
-		}
-		authorizationListItem.PushBack(authTupleItem)
+	for _, auth := range authorizationList {
+		authorizationListItem.PushBack(auth._toRLPItem())
 	}
 	objectsList.PushBack(authorizationListItem)
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
  Add native construction and signing of Ethereum transaction data for all four formats (Legacy, EIP-2930, EIP-1559, EIP-7702), so a developer can build and sign an Ethereum transaction inside the SDK and submit it through the existing EthereumTransaction. Implements the cross-SDK [proposal in sdk-collaboration-hub.](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/native-ethereum-transaction-data.md)

  - Add EthereumTransactionBody interface (Sign, ToBytes, String) implemented by the Legacy, EIP-2930, EIP-1559, and EIP-7702 transaction types
  - Add native Sign(key) to each transaction type — secp256k1 signing with recovery-id computation, writing R/S and V/RecoveryId back onto the receiver and returning the signed RLP; reject non-ECDSA keys
  - Extract shared _signTypedTransaction and _encodeTypedWithSignature helpers for the typed variants, and split serialization into _toUnsignedRLP / _encodeWithSignature
  - Add paired typed and raw-bytes accessors for every field across all four types (GetValue/SetValue and GetValueBytes/SetValueBytes)
  - Add Ethereum RLP canonical integer encoding helpers (uint64/big.Int to minimal big-endian, zero as empty bytes)
  - Add structured AccessListItem type with getters/setters, AddStorageKey, and RLP helpers; expose it through GetAccessListItems/SetAccessListItems/AddAccessListItem
  - Replace the positional AuthorizationTuple [6][]byte with a structured Authorization type (chainId, address, nonce, yParity, r, s) with constructor, accessors, String, and RLP helpers
  - Add EthereumTransaction.SetEthereumDataFromBody(body) to serialize a signed transaction body directly, returning an error rather than submit an unsigned transaction
  - Add EthereumTransactionData wrapper dispatch over the four types (FromBytes, ToBytes, Sign, GetTransaction, GetData/SetData)
  - Add unit tests covering signing, RLP round-trips, accessors, access lists, authorization lists, and decode error paths

**Related issue(s)**:

Fixes #1742


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
