### PR TITLE
HIP-1261: align Go SDK with updated `FeeEstimateQuery` design doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
                 installMirrorNode: true
                 hieroVersion: v0.73.0
                 mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                soloVersion: v0.65.0
 
             - name: Set Operator Account
               if: success() && matrix.test-type == 'e2e'
@@ -176,7 +176,7 @@ jobs:
                 installMirrorNode: true
                 hieroVersion: v0.73.0
                 mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                soloVersion: v0.65.0
                 dualMode: true
 
             - name: Set Operator Account
@@ -239,7 +239,7 @@ jobs:
                 installMirrorNode: true
                 hieroVersion: v0.73.0
                 mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                soloVersion: v0.65.0
 
             - name: Set Operator Account
               run: |

--- a/examples/fee_estimate_query/main.go
+++ b/examples/fee_estimate_query/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+)
+
+// FeeEstimateQuery example (HIP-1261).
+//
+// Demonstrates how to estimate the fees for a transaction without submitting it
+// to the network. The query talks to the mirror node REST endpoint
+// POST /api/v1/network/fees and returns network, node, and service fee components.
+func main() {
+	client, err := hiero.ClientForName(os.Getenv("HEDERA_NETWORK"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error creating client", err))
+	}
+
+	operatorAccountID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to AccountID", err))
+	}
+
+	operatorKey, err := hiero.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to PrivateKey", err))
+	}
+
+	client.SetOperator(operatorAccountID, operatorKey)
+
+	fmt.Println("FeeEstimateQuery Example (HIP-1261)")
+
+	// Step 1: Create and freeze a transfer transaction. The query auto-freezes
+	// if the transaction is not already frozen, but freezing up front lets us
+	// reuse the same transaction across multiple estimates.
+	transferTx, err := hiero.NewTransferTransaction().
+		AddHbarTransfer(client.GetOperatorAccountID(), hiero.NewHbar(-1)).
+		AddHbarTransfer(hiero.AccountID{Account: 3}, hiero.NewHbar(1)).
+		FreezeWith(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error freezing transaction", err))
+	}
+
+	// Step 2: Estimate fees in INTRINSIC mode (default). Estimated from the
+	// payload alone, ignoring state-dependent costs. Deterministic and fast.
+	intrinsicEstimate, err := hiero.NewFeeEstimateQuery().
+		SetMode(hiero.FeeEstimateModeIntrinsic).
+		SetTransaction(transferTx).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing intrinsic fee estimate", err))
+	}
+	printEstimate("INTRINSIC", intrinsicEstimate)
+
+	// Step 3: Estimate fees in STATE mode. Uses the mirror node's latest known
+	// state to account for state-dependent costs (auto-creation, custom fees,
+	// hooks, etc).
+	stateEstimate, err := hiero.NewFeeEstimateQuery().
+		SetMode(hiero.FeeEstimateModeState).
+		SetTransaction(transferTx).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing state fee estimate", err))
+	}
+	printEstimate("STATE", stateEstimate)
+
+	fmt.Printf("\nDifference (state - intrinsic): %d tinycents\n",
+		int64(stateEstimate.Total)-int64(intrinsicEstimate.Total))
+
+	// Step 4: Same query reached via the Transaction.EstimateFee() helper.
+	// Optionally simulate high-volume pricing (HIP-1313) at 50% throttle
+	// utilization (5000 basis points).
+	helperEstimate, err := transferTx.EstimateFee().
+		SetMode(hiero.FeeEstimateModeIntrinsic).
+		SetHighVolumeThrottle(5000).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing fee estimate via helper", err))
+	}
+	printEstimate("INTRINSIC (high-volume 50%)", helperEstimate)
+	fmt.Printf("  high_volume_multiplier: %d\n", helperEstimate.HighVolumeMultiplier)
+}
+
+func printEstimate(label string, response hiero.FeeEstimateResponse) {
+	fmt.Printf("\n%s estimate (tinycents):\n", label)
+	fmt.Printf("  network: %d (multiplier=%d)\n", response.NetworkFee.Subtotal, response.NetworkFee.Multiplier)
+	fmt.Printf("  node:    %d (base=%d, %d extras)\n", response.NodeFee.Subtotal(), response.NodeFee.Base, len(response.NodeFee.Extras))
+	fmt.Printf("  service: %d (base=%d, %d extras)\n", response.ServiceFee.Subtotal(), response.ServiceFee.Base, len(response.ServiceFee.Extras))
+	fmt.Printf("  total:   %d\n", response.Total)
+}

--- a/sdk/fee_estimate_query.go
+++ b/sdk/fee_estimate_query.go
@@ -18,21 +18,22 @@ import (
 
 // FeeEstimateQuery allows users to query expected transaction fees without submitting transactions to the network
 type FeeEstimateQuery struct {
-	mode        FeeEstimateMode
-	transaction TransactionInterface
-	attempt     uint64
-	maxAttempts uint64
+	mode               FeeEstimateMode
+	transaction        TransactionInterface
+	highVolumeThrottle uint16
+	attempt            uint64
+	maxAttempts        uint64
 }
 
 // NewFeeEstimateQuery creates a new FeeEstimateQuery
 func NewFeeEstimateQuery() *FeeEstimateQuery {
 	return &FeeEstimateQuery{
-		mode:        FeeEstimateModeState, // Default mode is STATE
+		mode:        FeeEstimateModeIntrinsic, // Default mode is INTRINSIC
 		maxAttempts: maxAttempts,
 	}
 }
 
-// SetMode sets the estimation mode (optional, defaults to STATE)
+// SetMode sets the estimation mode (optional, defaults to INTRINSIC)
 func (q *FeeEstimateQuery) SetMode(mode FeeEstimateMode) *FeeEstimateQuery {
 	q.mode = mode
 	return q
@@ -52,6 +53,19 @@ func (q *FeeEstimateQuery) SetTransaction(transaction TransactionInterface) *Fee
 // GetTransaction returns the current transaction
 func (q *FeeEstimateQuery) GetTransaction() TransactionInterface {
 	return q.transaction
+}
+
+// SetHighVolumeThrottle sets the high-volume throttle utilization in basis points (0–10000, where 10000 = 100%).
+// A value of 0 (the default) indicates no high-volume pricing simulation. Maps to the
+// `high_volume_throttle` query parameter
+func (q *FeeEstimateQuery) SetHighVolumeThrottle(throttle uint16) *FeeEstimateQuery {
+	q.highVolumeThrottle = throttle
+	return q
+}
+
+// GetHighVolumeThrottle returns the current high-volume throttle utilization in basis points
+func (q *FeeEstimateQuery) GetHighVolumeThrottle() uint16 {
+	return q.highVolumeThrottle
 }
 
 // SetMaxAttempts sets the maximum number of retry attempts
@@ -111,7 +125,6 @@ func (q *FeeEstimateQuery) executeChunkedTransaction(client *Client, tx Transact
 	aggregatedResponse.NodeFee = FeeEstimate{Base: 0, Extras: []FeeExtra{}}
 	aggregatedResponse.ServiceFee = FeeEstimate{Base: 0, Extras: []FeeExtra{}}
 	aggregatedResponse.NetworkFee = NetworkFee{Multiplier: 0, Subtotal: 0}
-	aggregatedResponse.Notes = []string{}
 
 	var totalNodeSubtotal uint64
 	var totalServiceSubtotal uint64
@@ -133,9 +146,8 @@ func (q *FeeEstimateQuery) executeChunkedTransaction(client *Client, tx Transact
 
 		if i == 0 {
 			aggregatedResponse.NetworkFee.Multiplier = chunkResponse.NetworkFee.Multiplier
+			aggregatedResponse.HighVolumeMultiplier = chunkResponse.HighVolumeMultiplier
 		}
-
-		aggregatedResponse.Notes = append(aggregatedResponse.Notes, chunkResponse.Notes...)
 	}
 
 	aggregatedResponse.NodeFee.Base = totalNodeSubtotal
@@ -180,6 +192,9 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 	}
 
 	url := fmt.Sprintf("%s/network/fees?mode=%s", mirrorUrl, q.mode.String())
+	if q.highVolumeThrottle != 0 {
+		url = fmt.Sprintf("%s&high_volume_throttle=%d", url, q.highVolumeThrottle)
+	}
 
 	var lastErr error
 	var resp *http.Response

--- a/sdk/fee_estimate_query.go
+++ b/sdk/fee_estimate_query.go
@@ -224,8 +224,9 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 			return FeeEstimateResponse{}, errors.Wrap(lastErr, "failed to call fee estimate API")
 		}
 
-		// Calculate delay with exponential backoff
-		delayMs := 250.0 * float64(uint64(1)<<attempt) // 250ms, 500ms, 1000ms, etc.
+		// Exponential backoff capped at 8s; exp is clamped to avoid shift overflow.
+		exp := min(attempt, uint64(5))
+		delayMs := 250.0 * float64(uint64(1)<<exp)
 		if delayMs > 8000 {
 			delayMs = 8000
 		}

--- a/sdk/fee_estimate_query.go
+++ b/sdk/fee_estimate_query.go
@@ -21,7 +21,6 @@ type FeeEstimateQuery struct {
 	mode               FeeEstimateMode
 	transaction        TransactionInterface
 	highVolumeThrottle uint16
-	attempt            uint64
 	maxAttempts        uint64
 }
 
@@ -199,7 +198,7 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 	var lastErr error
 	var resp *http.Response
 
-	for q.attempt < q.maxAttempts {
+	for attempt := uint64(0); attempt < q.maxAttempts; attempt++ {
 		resp, err = http.Post(url, "application/protobuf", bytes.NewBuffer(txBytes)) // #nosec
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			break
@@ -226,7 +225,7 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 		}
 
 		// Calculate delay with exponential backoff
-		delayMs := 250.0 * float64(uint64(1)<<q.attempt) // 250ms, 500ms, 1000ms, etc.
+		delayMs := 250.0 * float64(uint64(1)<<attempt) // 250ms, 500ms, 1000ms, etc.
 		if delayMs > 8000 {
 			delayMs = 8000
 		}
@@ -237,8 +236,6 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 			return FeeEstimateResponse{}, client.networkUpdateContext.Err()
 		case <-time.After(time.Duration(delayMs) * time.Millisecond):
 		}
-
-		q.attempt++
 	}
 
 	if resp == nil {

--- a/sdk/fee_estimate_query_e2e_test.go
+++ b/sdk/fee_estimate_query_e2e_test.go
@@ -12,18 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const mirrorSyncDelayMillis = 2 * time.Second
+const mirrorSyncDelay = 2 * time.Second
 
 func waitForMirrorNodeSync() {
-	time.Sleep(mirrorSyncDelayMillis)
-}
-
-func subtotal(estimate FeeEstimate) uint64 {
-	total := estimate.Base
-	for _, extra := range estimate.Extras {
-		total += extra.Subtotal
-	}
-	return total
+	time.Sleep(mirrorSyncDelay)
 }
 
 func assertFeeComponentsPresent(t *testing.T, response FeeEstimateResponse) {
@@ -31,31 +23,22 @@ func assertFeeComponentsPresent(t *testing.T, response FeeEstimateResponse) {
 
 	require.NotNil(t, response.NetworkFee)
 	assert.Greater(t, response.NetworkFee.Multiplier, uint32(0))
-	assert.GreaterOrEqual(t, response.NetworkFee.Subtotal, uint64(0))
 
 	require.NotNil(t, response.NodeFee)
-	assert.GreaterOrEqual(t, response.NodeFee.Base, uint64(0))
 	require.NotNil(t, response.NodeFee.Extras)
 
 	require.NotNil(t, response.ServiceFee)
-	assert.GreaterOrEqual(t, response.ServiceFee.Base, uint64(0))
 	require.NotNil(t, response.ServiceFee.Extras)
-
-	assert.GreaterOrEqual(t, response.HighVolumeMultiplier, uint64(1))
 
 	assert.Greater(t, response.Total, uint64(0))
 }
 
 func assertComponentTotalsConsistent(t *testing.T, response FeeEstimateResponse) {
-	network := response.NetworkFee
-	node := response.NodeFee
-	service := response.ServiceFee
+	nodeSubtotal := response.NodeFee.Subtotal()
+	serviceSubtotal := response.ServiceFee.Subtotal()
 
-	nodeSubtotal := subtotal(node)
-	serviceSubtotal := subtotal(service)
-
-	assert.Equal(t, network.Subtotal, nodeSubtotal*uint64(network.Multiplier))
-	assert.Equal(t, response.Total, network.Subtotal+nodeSubtotal+serviceSubtotal)
+	assert.Equal(t, response.NetworkFee.Subtotal, nodeSubtotal*uint64(response.NetworkFee.Multiplier))
+	assert.Equal(t, response.Total, response.NetworkFee.Subtotal+nodeSubtotal+serviceSubtotal)
 }
 
 func TestIntegrationFeeEstimateQueryTokenCreateTransaction(t *testing.T) {

--- a/sdk/fee_estimate_query_e2e_test.go
+++ b/sdk/fee_estimate_query_e2e_test.go
@@ -41,7 +41,8 @@ func assertFeeComponentsPresent(t *testing.T, response FeeEstimateResponse) {
 	assert.GreaterOrEqual(t, response.ServiceFee.Base, uint64(0))
 	require.NotNil(t, response.ServiceFee.Extras)
 
-	require.NotNil(t, response.Notes)
+	assert.GreaterOrEqual(t, response.HighVolumeMultiplier, uint64(1))
+
 	assert.Greater(t, response.Total, uint64(0))
 }
 
@@ -58,7 +59,6 @@ func assertComponentTotalsConsistent(t *testing.T, response FeeEstimateResponse)
 }
 
 func TestIntegrationFeeEstimateQueryTokenCreateTransaction(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -89,7 +89,6 @@ func TestIntegrationFeeEstimateQueryTokenCreateTransaction(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryTransferTransactionStateMode(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -116,7 +115,6 @@ func TestIntegrationFeeEstimateQueryTransferTransactionStateMode(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryTransferTransactionIntrinsicMode(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -139,8 +137,7 @@ func TestIntegrationFeeEstimateQueryTransferTransactionIntrinsicMode(t *testing.
 	assertComponentTotalsConsistent(t, response)
 }
 
-func TestIntegrationFeeEstimateQueryTransferTransactionDefaultModeIsState(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
+func TestIntegrationFeeEstimateQueryTransferTransactionDefaultModeIsIntrinsic(t *testing.T) {
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -156,9 +153,10 @@ func TestIntegrationFeeEstimateQueryTransferTransactionDefaultModeIsState(t *tes
 
 	waitForMirrorNodeSync()
 
-	response, err := NewFeeEstimateQuery().
-		SetTransaction(transaction).
-		Execute(env.Client)
+	query := NewFeeEstimateQuery().SetTransaction(transaction)
+	require.Equal(t, FeeEstimateModeIntrinsic, query.GetMode())
+
+	response, err := query.Execute(env.Client)
 	require.NoError(t, err)
 
 	assertFeeComponentsPresent(t, response)
@@ -166,7 +164,6 @@ func TestIntegrationFeeEstimateQueryTransferTransactionDefaultModeIsState(t *tes
 }
 
 func TestIntegrationFeeEstimateQueryTokenMintTransaction(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -191,7 +188,6 @@ func TestIntegrationFeeEstimateQueryTokenMintTransaction(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryTopicCreateTransaction(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -217,7 +213,6 @@ func TestIntegrationFeeEstimateQueryTopicCreateTransaction(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryContractCreateTransaction(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -245,7 +240,6 @@ func TestIntegrationFeeEstimateQueryContractCreateTransaction(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryFileCreateTransaction(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -272,7 +266,6 @@ func TestIntegrationFeeEstimateQueryFileCreateTransaction(t *testing.T) {
 }
 
 func TestIntegrationFeeEstimateQueryFileAppendTransactionAggregatesChunks(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -296,7 +289,6 @@ func TestIntegrationFeeEstimateQueryFileAppendTransactionAggregatesChunks(t *tes
 }
 
 func TestIntegrationFeeEstimateQueryTopicMessageSubmitSingleChunk(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -320,7 +312,6 @@ func TestIntegrationFeeEstimateQueryTopicMessageSubmitSingleChunk(t *testing.T) 
 }
 
 func TestIntegrationFeeEstimateQueryTopicMessageSubmitMultipleChunk(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -344,7 +335,6 @@ func TestIntegrationFeeEstimateQueryTopicMessageSubmitMultipleChunk(t *testing.T
 }
 
 func TestIntegrationFeeEstimateQueryWithoutTransactionThrowsError(t *testing.T) {
-	t.Skip("Disabled in version .151 of mirror node")
 	t.Parallel()
 	env := NewIntegrationTestEnv(t)
 	defer CloseIntegrationTestEnv(env, nil)
@@ -354,4 +344,33 @@ func TestIntegrationFeeEstimateQueryWithoutTransactionThrowsError(t *testing.T) 
 		Execute(env.Client)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "transaction is required")
+}
+
+func TestIntegrationFeeEstimateQueryWithHighVolumeThrottle(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	transaction, err := NewTransferTransaction().
+		AddHbarTransfer(env.Client.GetOperatorAccountID(), NewHbar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, NewHbar(1)).
+		FreezeWith(env.Client)
+	require.NoError(t, err)
+
+	_, err = transaction.SignWithOperator(env.Client)
+	require.NoError(t, err)
+
+	waitForMirrorNodeSync()
+
+	response, err := NewFeeEstimateQuery().
+		SetTransaction(transaction).
+		SetMode(FeeEstimateModeIntrinsic).
+		SetHighVolumeThrottle(5000).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	assertFeeComponentsPresent(t, response)
+	assertComponentTotalsConsistent(t, response)
+	assert.GreaterOrEqual(t, response.HighVolumeMultiplier, uint64(1),
+		"highVolumeMultiplier should be >= 1 when throttle is non-zero")
 }

--- a/sdk/fee_estimate_query_mock_test.go
+++ b/sdk/fee_estimate_query_mock_test.go
@@ -20,10 +20,10 @@ func newSuccessResponse(networkMultiplier int, nodeBase, serviceBase uint64) str
 	networkSubtotal := nodeBase * uint64(networkMultiplier)
 	total := networkSubtotal + nodeBase + serviceBase
 	return fmt.Sprintf(`{
+  "high_volume_multiplier": 1,
   "network": {"multiplier": %d, "subtotal": %d},
   "node": {"base": %d, "extras": []},
   "service": {"base": %d, "extras": []},
-  "notes": [],
   "total": %d
 }`, networkMultiplier, networkSubtotal, nodeBase, serviceBase, total)
 }
@@ -153,6 +153,7 @@ func TestUnitFeeEstimateQuerySucceedsOnFirstAttempt(t *testing.T) {
 		queryParams := r.URL.Query()
 		assert.Contains(t, queryParams, "mode", "request should contain mode query parameter")
 		assert.Equal(t, "INTRINSIC", queryParams.Get("mode"), "mode should be INTRINSIC")
+		assert.NotContains(t, queryParams, "high_volume_throttle", "high_volume_throttle should be omitted when zero")
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -175,4 +176,83 @@ func TestUnitFeeEstimateQuerySucceedsOnFirstAttempt(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, uint64(60), response.Total)
+	assert.Equal(t, uint64(1), response.HighVolumeMultiplier)
+}
+
+func TestUnitFeeEstimateQueryDefaultsToIntrinsic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryParams := r.URL.Query()
+		assert.Equal(t, "INTRINSIC", queryParams.Get("mode"), "default mode should be INTRINSIC")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(newSuccessResponse(2, 5, 10)))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain("localhost:8084", server.URL)
+	defer cleanup()
+
+	client := newMockClientForREST()
+	tx := NewTransferTransaction()
+
+	response, err := NewFeeEstimateQuery().
+		SetTransaction(tx).
+		Execute(client)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(25), response.Total)
+}
+
+func TestUnitFeeEstimateQuerySendsHighVolumeThrottle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryParams := r.URL.Query()
+		assert.Equal(t, "5000", queryParams.Get("high_volume_throttle"),
+			"high_volume_throttle should be forwarded as a query parameter")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(newSuccessResponse(3, 10, 20)))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain("localhost:8084", server.URL)
+	defer cleanup()
+
+	client := newMockClientForREST()
+	tx := NewTransferTransaction()
+
+	response, err := NewFeeEstimateQuery().
+		SetTransaction(tx).
+		SetHighVolumeThrottle(5000).
+		Execute(client)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(60), response.Total)
+	assert.GreaterOrEqual(t, response.HighVolumeMultiplier, uint64(1),
+		"highVolumeMultiplier should be >= 1 when throttle is non-zero")
+}
+
+func TestUnitFeeEstimateQueryDoesNotRetryOn400(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("malformed transaction"))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain("localhost:8084", server.URL)
+	defer cleanup()
+
+	client := newMockClientForREST()
+	client.SetMaxBackoff(500 * time.Millisecond)
+
+	tx := NewTransferTransaction()
+
+	_, err := NewFeeEstimateQuery().
+		SetTransaction(tx).
+		SetMaxAttempts(3).
+		Execute(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Equal(t, 1, requestCount, "HTTP 400 must not trigger a retry")
 }

--- a/sdk/fee_estimate_query_unit_test.go
+++ b/sdk/fee_estimate_query_unit_test.go
@@ -196,3 +196,15 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 	err = json.Unmarshal([]byte("invalid json"), &response3)
 	require.Error(t, err)
 }
+
+func TestUnitTransactionEstimateFee(t *testing.T) {
+	t.Parallel()
+
+	tx := NewTransferTransaction()
+	query := tx.EstimateFee()
+
+	require.NotNil(t, query)
+	require.Equal(t, FeeEstimateModeIntrinsic, query.GetMode())
+	require.NotNil(t, query.GetTransaction())
+	require.Equal(t, tx, query.GetTransaction())
+}

--- a/sdk/fee_estimate_query_unit_test.go
+++ b/sdk/fee_estimate_query_unit_test.go
@@ -197,6 +197,35 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUnitFeeEstimateResponseTotalFormula(t *testing.T) {
+	t.Parallel()
+
+	response := FeeEstimateResponse{
+		NetworkFee: NetworkFee{Multiplier: 3},
+		NodeFee: FeeEstimate{
+			Base: 1000,
+			Extras: []FeeExtra{
+				{Subtotal: 50},
+				{Subtotal: 500},
+			},
+		},
+		ServiceFee: FeeEstimate{
+			Base:   200,
+			Extras: []FeeExtra{{Subtotal: 75}},
+		},
+	}
+
+	nodeSubtotal := response.NodeFee.Subtotal()
+	serviceSubtotal := response.ServiceFee.Subtotal()
+	response.NetworkFee.Subtotal = nodeSubtotal * uint64(response.NetworkFee.Multiplier)
+	response.Total = response.NetworkFee.Subtotal + nodeSubtotal + serviceSubtotal
+
+	require.Equal(t, uint64(1550), nodeSubtotal)
+	require.Equal(t, uint64(275), serviceSubtotal)
+	require.Equal(t, uint64(4650), response.NetworkFee.Subtotal)
+	require.Equal(t, response.NetworkFee.Subtotal+nodeSubtotal+serviceSubtotal, response.Total)
+}
+
 func TestUnitTransactionEstimateFee(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/fee_estimate_query_unit_test.go
+++ b/sdk/fee_estimate_query_unit_test.go
@@ -29,10 +29,14 @@ func TestUnitFeeEstimateQueryCoverage(t *testing.T) {
 	require.Equal(t, uint64(5), query.GetMaxAttempts())
 
 	query2 := NewFeeEstimateQuery()
-	require.Equal(t, FeeEstimateModeState, query2.GetMode())
+	require.Equal(t, FeeEstimateModeIntrinsic, query2.GetMode())
+	require.Equal(t, uint16(0), query2.GetHighVolumeThrottle())
 
 	query.SetMode(FeeEstimateModeIntrinsic)
 	require.Equal(t, FeeEstimateModeIntrinsic, query.GetMode())
+
+	query.SetHighVolumeThrottle(5000)
+	require.Equal(t, uint16(5000), query.GetHighVolumeThrottle())
 
 	require.Equal(t, "STATE", FeeEstimateModeState.String())
 	require.Equal(t, "INTRINSIC", FeeEstimateModeIntrinsic.String())
@@ -129,6 +133,7 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 	t.Parallel()
 
 	jsonData := `{
+		"high_volume_multiplier": 2,
 		"network": {
 			"multiplier": 3,
 			"subtotal": 3000
@@ -141,7 +146,7 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 					"included": 0,
 					"count": 1,
 					"charged": 1,
-					"feePerUnit": 100,
+					"fee_per_unit": 100,
 					"subtotal": 100
 				}
 			]
@@ -149,22 +154,22 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 		"service": {
 			"base": 500
 		},
-		"notes": ["note1", "note2"],
 		"total": 4600
 	}`
 
 	var response FeeEstimateResponse
 	err := json.Unmarshal([]byte(jsonData), &response)
 	require.NoError(t, err)
+	require.Equal(t, uint64(2), response.HighVolumeMultiplier)
 	require.Equal(t, uint32(3), response.NetworkFee.Multiplier)
 	require.Equal(t, uint64(3000), response.NetworkFee.Subtotal)
 	require.Equal(t, uint64(1000), response.NodeFee.Base)
 	require.Len(t, response.NodeFee.Extras, 1)
 	require.Equal(t, "extra1", response.NodeFee.Extras[0].Name)
+	require.Equal(t, uint64(1), response.NodeFee.Extras[0].Count)
+	require.Equal(t, uint64(1), response.NodeFee.Extras[0].Charged)
+	require.Equal(t, uint64(100), response.NodeFee.Extras[0].FeePerUnit)
 	require.Equal(t, uint64(500), response.ServiceFee.Base)
-	require.Len(t, response.Notes, 2)
-	require.Equal(t, "note1", response.Notes[0])
-	require.Equal(t, "note2", response.Notes[1])
 	require.Equal(t, uint64(4600), response.Total)
 
 	jsonData2 := `{
@@ -185,7 +190,7 @@ func TestUnitFeeEstimateResponseFromREST(t *testing.T) {
 	err = json.Unmarshal([]byte(jsonData2), &response2)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), response2.NetworkFee.Multiplier)
-	require.Empty(t, response2.Notes)
+	require.Equal(t, uint64(0), response2.HighVolumeMultiplier)
 
 	var response3 FeeEstimateResponse
 	err = json.Unmarshal([]byte("invalid json"), &response3)

--- a/sdk/fee_estimate_types.go
+++ b/sdk/fee_estimate_types.go
@@ -6,19 +6,19 @@ package hiero
 type FeeEstimateMode int32
 
 const (
-	// FeeEstimateModeState uses the latest known state for fee estimation
-	FeeEstimateModeState FeeEstimateMode = iota
-	// FeeEstimateModeIntrinsic estimates from the payload alone, ignoring state-dependent costs
-	FeeEstimateModeIntrinsic
+	// FeeEstimateModeIntrinsic estimates from the payload alone, ignoring state-dependent costs (default)
+	FeeEstimateModeIntrinsic FeeEstimateMode = iota
+	// FeeEstimateModeState uses the mirror node's latest known state for fee estimation
+	FeeEstimateModeState
 )
 
 // String returns the string representation of FeeEstimateMode
 func (m FeeEstimateMode) String() string {
 	switch m {
-	case FeeEstimateModeState:
-		return "STATE"
 	case FeeEstimateModeIntrinsic:
 		return "INTRINSIC"
+	case FeeEstimateModeState:
+		return "STATE"
 	default:
 		return "UNKNOWN"
 	}
@@ -26,12 +26,12 @@ func (m FeeEstimateMode) String() string {
 
 // FeeExtra represents an extra fee charged for the transaction
 type FeeExtra struct {
-	Name       string `json:"name"`       // The unique name of this extra fee as defined in the fee schedule
-	Included   uint32 `json:"included"`   // The count of this "extra" that is included for free
-	Count      uint32 `json:"count"`      // The actual count of items received
-	Charged    uint32 `json:"charged"`    // The charged count of items as calculated by max(0, count - included)
-	FeePerUnit uint64 `json:"feePerUnit"` // The fee price per unit in tinycents
-	Subtotal   uint64 `json:"subtotal"`   // The subtotal in tinycents for this extra fee
+	Name       string `json:"name"`         // The unique name of this extra fee as defined in the fee schedule
+	Included   uint64 `json:"included"`     // The count of this "extra" that is included for free
+	Count      uint64 `json:"count"`        // The actual count of items received
+	Charged    uint64 `json:"charged"`      // The charged count of items as calculated by max(0, count - included)
+	FeePerUnit uint64 `json:"fee_per_unit"` // The fee price per unit in tinycents
+	Subtotal   uint64 `json:"subtotal"`     // The subtotal in tinycents for this extra fee
 }
 
 // FeeEstimate represents the fee estimate for a component
@@ -58,9 +58,16 @@ type NetworkFee struct {
 
 // FeeEstimateResponse represents the response containing the estimated transaction fees
 type FeeEstimateResponse struct {
-	NetworkFee NetworkFee  `json:"network"` // The network fee component
-	NodeFee    FeeEstimate `json:"node"`    // The node fee component which is to be paid to the node that submitted the transaction to the network. This fee exists to compensate the node for the work it performed to pre-check the transaction before submitting it, and incentivizes the node to accept new transactions from users (required)
-	ServiceFee FeeEstimate `json:"service"` // The service fee component which covers execution costs, state saved in the Merkle tree, and additional costs to the blockchain storage
-	Notes      []string    `json:"notes"`
-	Total      uint64      `json:"total"` // The sum of the network, node, and service subtotals in tinycents
+	// The high-volume pricing multiplier per HIP-1313. A value of 1 indicates no
+	// high-volume pricing. A value greater than 1 applies when the transaction's
+	// highVolume flag is true and throttle utilization is non-zero.
+	HighVolumeMultiplier uint64 `json:"high_volume_multiplier"`
+	// NetworkFee covers gossip, consensus, signature verification, fee payment, and storage.
+	NetworkFee NetworkFee `json:"network"`
+	// NodeFee is paid to the submitting node for pre-checking the transaction (required).
+	NodeFee FeeEstimate `json:"node"`
+	// ServiceFee covers execution, Merkle state, and blockchain storage costs.
+	ServiceFee FeeEstimate `json:"service"`
+	// Total is the sum of network, node, and service subtotals in tinycents.
+	Total uint64 `json:"total"`
 }

--- a/sdk/transaction.go
+++ b/sdk/transaction.go
@@ -1253,6 +1253,11 @@ func (tx *Transaction[T]) SetHighVolume(highVolume bool) T {
 	return tx.childTransaction
 }
 
+// EstimateFee returns a FeeEstimateQuery pre-populated with this transaction.
+func (tx *Transaction[T]) EstimateFee() *FeeEstimateQuery {
+	return NewFeeEstimateQuery().SetTransaction(tx.childTransaction)
+}
+
 // Batchify method is used to mark a transaction as part of a batch transaction or make it so-called inner transaction.
 // The Transaction will be frozen and signed by the operator of the client.
 func (tx *Transaction[T]) Batchify(client *Client, batchKey Key) (T, error) {


### PR DESCRIPTION
**Description**:                  
  <!--                                                                       
  One or two line summary of what this PR does and why it is needed, followed by a list
  of changes in imperative, present tense for use in the commit message or changelog. Example:                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                         
  Add support for ...                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                         
  * Add config property                                     
  * Change column name
  * Remove ...
  -->

  Sync the Go SDK's `FeeEstimateQuery` with the updated HIP-1261 design doc                                                                                                                                                                                                                              
  ([sdk-collaboration-hub#179](https://github.com/hiero-ledger/sdk-collaboration-hub/pull/179)).
                                                                                                                                                                                                                                                                                                         
  * Default `FeeEstimateMode` is now `INTRINSIC`            
  * `FeeExtra.Included/Count/Charged` widened to `uint64`; JSON tag `feePerUnit` → `fee_per_unit`                                                                                                                                                                                                        
  * Remove `FeeEstimateResponse.Notes`; add `HighVolumeMultiplier` (JSON `high_volume_multiplier`, HIP-1313)                                                                                                                                                                                             
  * Add `SetHighVolumeThrottle` / `GetHighVolumeThrottle`; URL appends `&high_volume_throttle=<n>` when non-zero                                                                                                                                                                                         
  * Propagate `HighVolumeMultiplier` from the first chunk during chunked aggregation                                                                                                                                                                                                                     
  * Update unit and mock tests for the new types and JSON shape                                                                                                                                                                                                                                          
  * New tests: defaults-to-INTRINSIC, sends-high-volume-throttle, does-not-retry-on-400, plus an e2e high-volume throttle test                                                                                                                                                                           
  * Rename e2e `…DefaultModeIsState` → `…DefaultModeIsIntrinsic`
  * Changed solo version to `v0.65.0` as the tests are flakey on the higher versions

**Related issue(s)**:

Fixes #1682, #1551

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
