### PR TITLE
chore: centralize CI versions in workflow env block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+    GO_VERSION: "1.25.7"
+    NODE_VERSION: "22"
+    HIERO_VERSION: v0.73.0
+    MIRROR_NODE_VERSION: v0.153.0
+    SOLO_VERSION: v0.69.0
+    HEDERA_NETWORK: localhost
+
 jobs:
     build:
         name: Build
@@ -33,10 +41,10 @@ jobs:
                 sudo apt-get update
                 sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
 
-            - name: Set up Go 1.25.7
+            - name: Set up Go ${{ env.GO_VERSION }}
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
-                  go-version: "1.25.7"
+                  go-version: ${{ env.GO_VERSION }}
               id: go
 
             - name: Check out code into the Go module directory
@@ -67,9 +75,6 @@ jobs:
           matrix:
             test-type: [unit, e2e]
 
-        env:
-          HEDERA_NETWORK: "localhost"
-
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -79,17 +84,17 @@ jobs:
             - name: Setup NodeJS
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                node-version: 22
+                node-version: ${{ env.NODE_VERSION }}
 
             - name: Setup GCC
               run: |
                 sudo apt-get update
                 sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
 
-            - name: Set up Go 1.25.7
+            - name: Set up Go ${{ env.GO_VERSION }}
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
-                  go-version: "1.25.7"
+                  go-version: ${{ env.GO_VERSION }}
               id: go
 
             - name: Check out code into the Go module directory
@@ -101,9 +106,9 @@ jobs:
               uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
               with:
                 installMirrorNode: true
-                hieroVersion: v0.73.0
-                mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                hieroVersion: ${{ env.HIERO_VERSION }}
+                mirrorNodeVersion: ${{ env.MIRROR_NODE_VERSION }}
+                soloVersion: ${{ env.SOLO_VERSION }}
 
             - name: Set Operator Account
               if: success() && matrix.test-type == 'e2e'
@@ -141,9 +146,6 @@ jobs:
         needs:
             - build
 
-        env:
-          HEDERA_NETWORK: "localhost"
-
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
@@ -153,17 +155,17 @@ jobs:
             - name: Setup NodeJS
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                node-version: 22
+                node-version: ${{ env.NODE_VERSION }}
 
             - name: Setup GCC
               run: |
                 sudo apt-get update
                 sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
 
-            - name: Set up Go 1.25.7
+            - name: Set up Go ${{ env.GO_VERSION }}
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
-                  go-version: "1.25.7"
+                  go-version: ${{ env.GO_VERSION }}
               id: go
 
             - name: Check out code into the Go module directory
@@ -174,9 +176,9 @@ jobs:
               uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
               with:
                 installMirrorNode: true
-                hieroVersion: v0.73.0
-                mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                hieroVersion: ${{ env.HIERO_VERSION }}
+                mirrorNodeVersion: ${{ env.MIRROR_NODE_VERSION }}
+                soloVersion: ${{ env.SOLO_VERSION }}
                 dualMode: true
 
             - name: Set Operator Account
@@ -201,8 +203,6 @@ jobs:
 
         needs:
             - build
-        env:
-          HEDERA_NETWORK: "localhost"
 
         steps:
             - name: Harden Runner
@@ -213,17 +213,17 @@ jobs:
             - name: Setup NodeJS
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
-                node-version: 22
+                node-version: ${{ env.NODE_VERSION }}
 
             - name: Setup GCC
               run: |
                 sudo apt-get update
                 sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
 
-            - name: Set up Go 1.25.7
+            - name: Set up Go ${{ env.GO_VERSION }}
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
-                  go-version: "1.25.7"
+                  go-version: ${{ env.GO_VERSION }}
               id: go
 
             - name: Check out code into the Go module directory
@@ -237,9 +237,9 @@ jobs:
               uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
               with:
                 installMirrorNode: true
-                hieroVersion: v0.73.0
-                mirrorNodeVersion: v0.153.0
-                soloVersion: v0.69.0
+                hieroVersion: ${{ env.HIERO_VERSION }}
+                mirrorNodeVersion: ${{ env.MIRROR_NODE_VERSION }}
+                soloVersion: ${{ env.SOLO_VERSION }}
 
             - name: Set Operator Account
               run: |
@@ -264,10 +264,10 @@ jobs:
                 sudo apt-get update
                 sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
 
-            - name: Set up Go 1.25.7
+            - name: Set up Go ${{ env.GO_VERSION }}
               uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
               with:
-                  go-version: "1.25.7"
+                  go-version: ${{ env.GO_VERSION }}
               id: go
 
             - name: Check out code into the Go module directory


### PR DESCRIPTION
**Description**:                                                                                                                                                                                  
Move shared versions and config strings in .github/workflows/build.yml into a workflow-level env: block so they have a single source of truth across the build, test, test-dab, run-examples, and build-test-tck jobs.
                                                                                              
- Add env: block with GO_VERSION, NODE_VERSION, HIERO_VERSION, MIRROR_NODE_VERSION, SOLO_VERSION, HEDERA_NETWORK                                                                                         
- Replace hardcoded values in all jobs with ${{ env.X }} references
- Remove redundant per-job HEDERA_NETWORK blocks (now inherited from workflow level)                                                                                                                     
                                                                                                                                                                                                           

**Related issue(s)**:

Fixes #1610

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
