### PR TITLE
chore: skip fee estimate example

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,11 @@ tasks:
                       echo "Skipping $example"
                       continue
                   fi
+                  # fee_estimate_query is flaky on a fresh local mirror node.
+                  if [ "$dir_name" == "fee_estimate_query" ]; then
+                      echo "Skipping $example (mirror node sync flake)"
+                      continue
+                  fi
                   if [ -d "$example" ]; then
 
                       pushd "$example" > /dev/null


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
                                                                                                                                                                                                                                                                                      
  Skip the `fee_estimate_query` example in the `run-examples` Task so a fresh                                                                                                                                                                                                           
  local mirror node doesn't fail the run.
                                                                                                                                                                                                                                                                                        
  * Add `fee_estimate_query` to the skip list in `Taskfile.yml` with a comment                                                                                                                                                                                                          
    explaining the mirror-node-sync flake                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
  **Notes for reviewer**:                                                                                                                                                                                                                                                               
  
  The example itself works against a steady-state network — the failure mode is                                                                                                                                                                                                         
  specifically that a freshly-started local mirror node hasn't ingested the
  operator's state when `run-examples` invokes it back-to-back with all the                                                                                                                                                                                                             
  others.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
