### PR TITLE
test: add ContractLogInfo unit coverage

### DIFF
--- a/sdk/contract_log_info_unit_test.go
+++ b/sdk/contract_log_info_unit_test.go
@@ -1,0 +1,68 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitContractLogInfo_ProtobufRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	logInfo := ContractLogInfo{
+		ContractID: ContractID{Contract: 7},
+		Bloom:      []byte{1, 2, 3},
+		Topics:     [][]byte{{4, 5}, {6, 7, 8}},
+		Data:       []byte{9, 10, 11},
+	}
+
+	actual := _ContractLogInfoFromProtobuf(logInfo._ToProtobuf())
+
+	assert.Equal(t, logInfo, actual)
+}
+
+func TestUnitContractLogInfo_FromProtobufNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ContractLogInfo{}, _ContractLogInfoFromProtobuf(nil))
+}
+
+func TestUnitContractLogInfo_FromProtobufNilContractID(t *testing.T) {
+	t.Parallel()
+
+	pb := &services.ContractLoginfo{
+		ContractID: nil,
+		Bloom:      []byte{1, 2, 3},
+		Topic:      [][]byte{{4, 5}, {6}},
+		Data:       []byte{7, 8},
+	}
+
+	actual := _ContractLogInfoFromProtobuf(pb)
+
+	assert.Equal(t, ContractID{}, actual.ContractID)
+	assert.Equal(t, []byte{1, 2, 3}, actual.Bloom)
+	assert.Equal(t, [][]byte{{4, 5}, {6}}, actual.Topics)
+	assert.Equal(t, []byte{7, 8}, actual.Data)
+}
+
+func TestUnitContractLogInfo_EmptyTopicsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	logInfo := ContractLogInfo{
+		ContractID: ContractID{Contract: 9},
+		Bloom:      []byte{1},
+		Topics:     [][]byte{},
+		Data:       []byte{2},
+	}
+
+	actual := _ContractLogInfoFromProtobuf(logInfo._ToProtobuf())
+
+	assert.NotNil(t, actual.Topics)
+	assert.Equal(t, 0, len(actual.Topics))
+	assert.Equal(t, logInfo, actual)
+}


### PR DESCRIPTION
## Summary
- add unit coverage for `ContractLogInfo` protobuf round-trip
- add coverage for nil protobuf input and nil contract ID handling
- add coverage for empty `Topics` round-trip so empty-vs-nil behavior stays pinned down

## Validation
- `GOPROXY=https://goproxy.cn,direct go test ./sdk -tags="unit" -v -run TestUnitContractLogInfo -timeout 9999s`
- `GOPROXY=https://goproxy.cn,direct go build ./...`
- `GOPROXY=https://goproxy.cn,direct golangci-lint run`

## Notes
- `go test ./sdk -tags="unit" -v -timeout 9999s` currently fails in existing `TestUnitConcurrentGetNodeReadmit` with `panic: failed to find a healthy working node`.
- I reproduced that same failure on a clean `origin/main` mirror, so it is unrelated to this change.

Fixes: #1707