### PR TITLE
fix: correct typo 'unreacahble' → 'unreachable' in FreezeType.String()

### DIFF
--- a/sdk/freeze_type.go
+++ b/sdk/freeze_type.go
@@ -31,5 +31,5 @@ func (freezeType FreezeType) String() string {
 		return "TELEMETRY_UPGRADE"
 	}
 
-	panic(fmt.Sprintf("unreacahble: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
+	panic(fmt.Sprintf("unreachable: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
 }


### PR DESCRIPTION
## Summary
Fix typo in `sdk/freeze_type.go:34` — changed `"unreacahble"` to `"unreachable"` in the panic message for `FreezeType.String()`.

## Test Plan
- [x] Typo corrected from `unreacahble` → `unreachable`
- [x] Code compiles (Go syntax valid)

Closes hiero-ledger/hiero-sdk-go#1709