### PR TITLE
fix: stabilize node readmit selection

### DIFF
--- a/sdk/managed_network.go
+++ b/sdk/managed_network.go
@@ -100,7 +100,11 @@ func (mn *_ManagedNetwork) _ReadmitNodes() {
 	mn.healthyNodesMutex.Lock()
 	defer mn.healthyNodesMutex.Unlock()
 
-	if mn.earliestReadmitTime.Before(now) {
+	mn._ReadmitNodesLocked(now)
+}
+
+func (mn *_ManagedNetwork) _ReadmitNodesLocked(now time.Time) {
+	if !mn.earliestReadmitTime.After(now) {
 		nextEarliestReadmitTime := now.Add(mn.maxNodeReadmitPeriod)
 
 		for _, node := range mn.nodes {
@@ -122,7 +126,7 @@ func (mn *_ManagedNetwork) _ReadmitNodes() {
 				}
 			}
 
-			if node._GetReadmitTime().Before(now) {
+			if !node._GetReadmitTime().After(now) {
 				mn.healthyNodes = append(mn.healthyNodes, node)
 			}
 		}
@@ -177,17 +181,20 @@ func (mn *_ManagedNetwork) _SetMinBackoff(minBackoff time.Duration) {
 }
 
 func (mn *_ManagedNetwork) _GetNode() _IManagedNode {
-	mn._ReadmitNodes()
-	mn.healthyNodesMutex.RLock()
-	defer mn.healthyNodesMutex.RUnlock()
+	mn.healthyNodesMutex.Lock()
+	mn._ReadmitNodesLocked(time.Now())
 
 	if len(mn.healthyNodes) == 0 {
+		mn.healthyNodesMutex.Unlock()
 		panic("failed to find a healthy working node")
 	}
 
-	bg := big.NewInt(int64(len(mn.healthyNodes)))
+	healthyNodes := slices.Clone(mn.healthyNodes)
+	mn.healthyNodesMutex.Unlock()
+
+	bg := big.NewInt(int64(len(healthyNodes)))
 	index, _ := rand.Int(rand.Reader, bg)
-	return mn.healthyNodes[index.Int64()]
+	return healthyNodes[index.Int64()]
 }
 
 func (mn *_ManagedNetwork) _GetMinBackoff() time.Duration {


### PR DESCRIPTION
## Description

Fixes #1714.

`_GetNode()` previously called `_ReadmitNodes()` and then released the write lock before taking a read lock to inspect `healthyNodes`. Under concurrent `_GetNode()` / `_IncreaseBackoff()` calls, another goroutine could remove all healthy nodes in that gap, causing the existing `TestUnitConcurrentGetNodeReadmit` test to panic locally on Windows.

This keeps node readmission and node selection in the same critical section, and treats readmit times equal to `now` as due. The panic behavior is preserved when there is genuinely no healthy or due-for-readmit node.

## Testing

- `go test ./sdk -tags="unit" -v -run TestUnitConcurrentGetNodeReadmit -count=50 -timeout 9999s`
- `go test ./sdk -tags="unit" -v -run TestUnitConcurrentNodeAccess -count=10 -timeout 9999s`
- `go test ./sdk -tags="unit" -v -run TestUnitConcurrentNodeGetChannel -count=10 -timeout 9999s`
- `go test ./sdk -tags="unit" -v -run TestUnitGetNodePanicNoHealthyNodes -count=10 -timeout 9999s`
- `go test ./sdk -tags="unit" -v -run TestUnitReadmitNodes -count=10 -timeout 9999s`

Notes:
- `go test ./sdk -tags="unit" -timeout 9999s` currently fails locally with an unrelated `grpc: the server has been stopped` panic from `sdk/mock_test.go`.
- `go test -race ...` could not run in this Windows environment because `runtime/cgo` requires `gcc`, which is not available in PATH.