### PR TITLE
fix(freezetype): replace panic with safe fallback in String() (#1716)

### DIFF
--- a/sdk/freeze_type.go
+++ b/sdk/freeze_type.go
@@ -31,5 +31,5 @@ func (freezeType FreezeType) String() string {
 		return "TELEMETRY_UPGRADE"
 	}
 
-	panic(fmt.Sprintf("unreacahble: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
+	return fmt.Sprintf("UNKNOWN (%d)", freezeType)
 }


### PR DESCRIPTION
## Summary

Resolves #1716. Replaces the `panic` in `FreezeType.String()` with a descriptive fallback that preserves the unknown numeric value, matching the format used by the JS SDK (`"UNKNOWN (N)"`).

Closes #1716.

## Verification

- [x] `gofmt -l sdk/freeze_type.go` — clean
- [x] `go vet ./sdk/...` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=upstream/main` — 0 issues
- [x] Full unit suite (`go test ./sdk -tags=unit -count=1`) — pass, no regressions