### PR TITLE
test: Add LiveHash unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Added
 - Support for HIP-1137: Block Node discoverability via on-chain registry. New `RegisteredNodeCreateTransaction`, `RegisteredNodeUpdateTransaction`, `RegisteredNodeDeleteTransaction`, and `RegisteredNodeAddressBookQuery`, plus typed service endpoints (`BlockNodeServiceEndpoint`, `MirrorNodeServiceEndpoint`, `RpcRelayServiceEndpoint`, `GeneralServiceEndpoint`) for registering and discovering non-consensus nodes via the on-chain address book [#1659](https://github.com/hiero-ledger/hiero-sdk-go/pull/1659)
-- Comprehensive unit test coverage for `LiveHash` type: serialization round-trips, protobuf conversion, nil parameter handling, and deprecated field exclusion validation
 
 ## v2.79.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Support for HIP-1137: Block Node discoverability via on-chain registry. New `RegisteredNodeCreateTransaction`, `RegisteredNodeUpdateTransaction`, `RegisteredNodeDeleteTransaction`, and `RegisteredNodeAddressBookQuery`, plus typed service endpoints (`BlockNodeServiceEndpoint`, `MirrorNodeServiceEndpoint`, `RpcRelayServiceEndpoint`, `GeneralServiceEndpoint`) for registering and discovering non-consensus nodes via the on-chain address book [#1659](https://github.com/hiero-ledger/hiero-sdk-go/pull/1659)
+- Comprehensive unit test coverage for `LiveHash` type: serialization round-trips, protobuf conversion, nil parameter handling, and deprecated field exclusion validation
 
 ## v2.79.0
 

--- a/sdk/live_hash_unit_test.go
+++ b/sdk/live_hash_unit_test.go
@@ -1,0 +1,103 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitLiveHash_BytesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	key, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	keys := NewKeyList()
+	keys.Add(key.PublicKey())
+
+	original := LiveHash{
+		AccountID:        AccountID{Shard: 0, Realm: 0, Account: 123},
+		Hash:             []byte{1, 2, 3},
+		Keys:             *keys,
+		LiveHashDuration: 30 * time.Second,
+	}
+
+	bytes := original.ToBytes()
+
+	recovered, err := LiveHashFromBytes(bytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.AccountID, recovered.AccountID)
+	assert.Equal(t, original.Hash, recovered.Hash)
+	assert.Equal(t, original.Keys, recovered.Keys)
+	assert.Equal(t, original.LiveHashDuration, recovered.LiveHashDuration)
+}
+
+func TestUnitLiveHash_FromProtobufNil(t *testing.T) {
+	t.Parallel()
+
+	result, err := _LiveHashFromProtobuf(nil)
+
+	assert.Equal(t, LiveHash{}, result)
+	require.ErrorIs(t, err, errParameterNull)
+}
+
+func TestUnitLiveHash_FromBytesNil(t *testing.T) {
+	t.Parallel()
+
+	result, err := LiveHashFromBytes(nil)
+
+	assert.Equal(t, LiveHash{}, result)
+	require.ErrorIs(t, err, errByteArrayNull)
+}
+
+func TestUnitLiveHash_ProtobufRoundTripNilKeys(t *testing.T) {
+	t.Parallel()
+
+	pb := &services.LiveHash{
+		AccountId: &services.AccountID{
+			ShardNum: 0,
+			RealmNum: 0,
+			Account: &services.AccountID_AccountNum{
+				AccountNum: 123,
+			},
+		},
+		Duration: &services.Duration{
+			Seconds: 30,
+		},
+		Keys: nil,
+	}
+
+	result, err := _LiveHashFromProtobuf(pb)
+	require.NoError(t, err)
+
+	assert.Equal(t, KeyList{}, result.Keys)
+	assert.Equal(t, AccountID{Shard: 0, Realm: 0, Account: 123}, result.AccountID)
+	assert.Equal(t, 30*time.Second, result.LiveHashDuration)
+}
+
+func TestUnitLiveHash_DeprecatedDurationNotSerialised(t *testing.T) {
+	t.Parallel()
+
+	lh := LiveHash{
+		AccountID:        AccountID{Shard: 0, Realm: 0, Account: 123},
+		Hash:             []byte{1, 2, 3},
+		Keys:             KeyList{},
+		Duration:         time.Unix(1700000000, 0),
+		LiveHashDuration: 30 * time.Second,
+	}
+
+	bytes := lh.ToBytes()
+
+	result, err := LiveHashFromBytes(bytes)
+	require.NoError(t, err)
+
+	assert.True(t, result.Duration.IsZero())
+	assert.Equal(t, 30*time.Second, result.LiveHashDuration)
+}


### PR DESCRIPTION
**Description**:
Add comprehensive unit test coverage for LiveHash type

The LiveHash struct required additional test coverage for serialization, deserialization, and error handling paths. This PR adds five unit tests covering:

* Bytes round-trip serialization and deserialization
* Nil protobuf parameter handling with appropriate error returns
* Nil byte array parameter handling with appropriate error returns
* Protobuf conversion with nil KeyList handling
* Deprecated Duration field exclusion from serialization (only LiveHashDuration is serialized)

**Related issue(s)**:

Fixes #1713 

**Notes for reviewer**:
All tests pass successfully:
- [x] TestUnitLiveHash_BytesRoundTrip (0.00s)
- [x] TestUnitLiveHash_FromProtobufNil (0.00s)
- [x] TestUnitLiveHash_FromBytesNil (0.00s)
- [x] TestUnitLiveHash_ProtobufRoundTripNilKeys (0.00s)
- [x] TestUnitLiveHash_DeprecatedDurationNotSerialised (0.00s)


The deprecated duration test confirms the invariant is properly wired in the codebase - the deprecated `Duration` field (time.Time) is not serialized, only `LiveHashDuration` (time.Duration) is used.

**Checklist**

- [x] Documented (Code uses clear test names and assertions)
- [x] Tested (All 5 unit tests pass; go build and go vet pass)