### PR TITLE
refactor: nft allowance delete

### DIFF
--- a/sdk/account_allowance_approve_transaction.go
+++ b/sdk/account_allowance_approve_transaction.go
@@ -214,16 +214,6 @@ func (tx *AccountAllowanceApproveTransaction) _ApproveTokenNftAllowanceAllSerial
 }
 
 func (tx *AccountAllowanceApproveTransaction) _DeleteTokenNftAllowanceAllSerials(tokenID TokenID, ownerAccountID *AccountID, spenderAccount AccountID) *AccountAllowanceApproveTransaction {
-	for _, t := range tx.nftAllowances {
-		if t.TokenID.String() == tokenID.String() {
-			if t.SpenderAccountID.String() == spenderAccount.String() {
-				t.SerialNumbers = []int64{}
-				t.AllSerials = true
-				return tx
-			}
-		}
-	}
-
 	tx.nftAllowances = append(tx.nftAllowances, &TokenNftAllowance{
 		TokenID:          &tokenID,
 		SpenderAccountID: &spenderAccount,

--- a/sdk/account_allowance_approve_transaction_unit_test.go
+++ b/sdk/account_allowance_approve_transaction_unit_test.go
@@ -301,3 +301,71 @@ func TestUnitDeleteTokenNftAllowanceAllSerials(t *testing.T) {
 		})
 	}
 }
+
+func TestUnitDeleteTokenNftAllowanceAllSerialsPreservesPriorSerialApproval(t *testing.T) {
+	t.Parallel()
+
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewAccountAllowanceApproveTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		ApproveTokenNftAllowance(nftID1, owner, spenderAccountID1).
+		DeleteTokenNftAllowanceAllSerials(tokenID2, owner, spenderAccountID1).
+		Freeze()
+	require.NoError(t, err)
+
+	data := transaction.build()
+
+	switch d := data.Data.(type) {
+	case *services.TransactionBody_CryptoApproveAllowance:
+		require.Equal(t, d.CryptoApproveAllowance.NftAllowances, []*services.NftAllowance{
+			{
+				TokenId:           tokenID2._ToProtobuf(),
+				Owner:             owner._ToProtobuf(),
+				Spender:           spenderAccountID1._ToProtobuf(),
+				SerialNumbers:     []int64{serialNumber1},
+				ApprovedForAll:    &wrapperspb.BoolValue{Value: false},
+				DelegatingSpender: nil,
+			},
+			{
+				TokenId:           tokenID2._ToProtobuf(),
+				Owner:             owner._ToProtobuf(),
+				Spender:           spenderAccountID1._ToProtobuf(),
+				SerialNumbers:     []int64{},
+				ApprovedForAll:    &wrapperspb.BoolValue{Value: false},
+				DelegatingSpender: nil,
+			},
+		})
+	}
+}
+
+func TestUnitDeleteTokenNftAllowanceAllSerialsAppendsPerCall(t *testing.T) {
+	t.Parallel()
+
+	transactionID := TransactionIDGenerate(AccountID{Account: 324})
+
+	transaction, err := NewAccountAllowanceApproveTransaction().
+		SetTransactionID(transactionID).
+		SetNodeAccountIDs(nodeAccountID).
+		DeleteTokenNftAllowanceAllSerials(tokenID2, owner, spenderAccountID1).
+		DeleteTokenNftAllowanceAllSerials(tokenID2, owner, spenderAccountID1).
+		Freeze()
+	require.NoError(t, err)
+
+	data := transaction.build()
+
+	switch d := data.Data.(type) {
+	case *services.TransactionBody_CryptoApproveAllowance:
+		revoke := &services.NftAllowance{
+			TokenId:           tokenID2._ToProtobuf(),
+			Owner:             owner._ToProtobuf(),
+			Spender:           spenderAccountID1._ToProtobuf(),
+			SerialNumbers:     []int64{},
+			ApprovedForAll:    &wrapperspb.BoolValue{Value: false},
+			DelegatingSpender: nil,
+		}
+		require.Equal(t, d.CryptoApproveAllowance.NftAllowances, []*services.NftAllowance{revoke, revoke})
+	}
+}
+

--- a/sdk/token_nft_allowance_e2e_test.go
+++ b/sdk/token_nft_allowance_e2e_test.go
@@ -370,3 +370,63 @@ func TestIntegrationCantSendIfTokenNftSerialsDeleted(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "exceptional receipt status: SPENDER_DOES_NOT_HAVE_ALLOWANCE", err.Error())
 }
+
+func TestIntegrationCanApproveSerialAndDeleteAllSerialsInOneTransaction(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	spenderKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	spenderCreate, err := NewAccountCreateTransaction().SetKeyWithoutAlias(spenderKey.PublicKey()).SetInitialBalance(NewHbar(2)).Execute(env.Client)
+	require.NoError(t, err)
+	spenderReceipt, err := spenderCreate.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	spenderAccountId := spenderReceipt.AccountID
+
+	receiverKey, err := PrivateKeyGenerateEd25519()
+	require.NoError(t, err)
+	receiverCreate, err := NewAccountCreateTransaction().SetKeyWithoutAlias(receiverKey.PublicKey()).SetInitialBalance(NewHbar(2)).SetMaxAutomaticTokenAssociations(10).Execute(env.Client)
+	require.NoError(t, err)
+	receiverReceipt, err := receiverCreate.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	receiverAccountId := receiverReceipt.AccountID
+
+	tokenID, err := createNft(&env)
+	require.NoError(t, err)
+
+	frozenAssociate, err := NewTokenAssociateTransaction().SetTokenIDs(tokenID).SetAccountID(*spenderAccountId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	_, err = frozenAssociate.Sign(spenderKey).Execute(env.Client)
+	require.NoError(t, err)
+
+	mint, err := NewTokenMintTransaction().SetTokenID(tokenID).SetMetadata([]byte{0x01}).SetMetadata([]byte{0x02}).Execute(env.Client)
+	require.NoError(t, err)
+	mintReceipt, err := mint.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	nft1 := NftID{TokenID: tokenID, SerialNumber: mintReceipt.SerialNumbers[0]}
+	nft2 := NftID{TokenID: tokenID, SerialNumber: mintReceipt.SerialNumbers[1]}
+
+	approveTx, err := NewAccountAllowanceApproveTransaction().
+		ApproveTokenNftAllowance(nft1, env.OperatorID, *spenderAccountId).
+		DeleteTokenNftAllowanceAllSerials(tokenID, env.OperatorID, *spenderAccountId).
+		Execute(env.Client)
+	require.NoError(t, err)
+	_, err = approveTx.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	onBehalfOfTxId := TransactionIDGenerate(*spenderAccountId)
+	frozenTransfer, err := NewTransferTransaction().AddApprovedNftTransfer(nft1, env.OperatorID, *receiverAccountId, true).SetTransactionID(onBehalfOfTxId).FreezeWith(env.Client)
+	require.NoError(t, err)
+	resp, err := frozenTransfer.Sign(spenderKey).Execute(env.Client)
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	onBehalfOfTxId2 := TransactionIDGenerate(*spenderAccountId)
+	frozenTransfer2, err := NewTransferTransaction().AddApprovedNftTransfer(nft2, env.OperatorID, *receiverAccountId, true).SetTransactionID(onBehalfOfTxId2).FreezeWith(env.Client)
+	require.NoError(t, err)
+	resp, err = frozenTransfer2.Sign(spenderKey).Execute(env.Client)
+	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.Error(t, err)
+	require.Equal(t, "exceptional receipt status: SPENDER_DOES_NOT_HAVE_ALLOWANCE", err.Error())
+}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Simplify `AccountAllowanceApproveTransaction.DeleteTokenNftAllowanceAllSerials` so that each call produces its own `NftAllowance` entry. Repeated or chained calls on the same `(token, spender)` pair are no longer folded into a single entry.

  * Update `_DeleteTokenNftAllowanceAllSerials` to append a new `NftAllowance` entry per call instead of folding into an existing entry
  * Add unit test covering `ApproveTokenNftAllowance` followed by `DeleteTokenNftAllowanceAllSerials` on the same `(token, spender)` pair
  * Add unit test covering repeated `DeleteTokenNftAllowanceAllSerials` calls on the same `(token, spender)` pair
  * Add e2e test covering `ApproveTokenNftAllowance` followed by `DeleteTokenNftAllowanceAllSerials` on the same `(token, spender)` pair


**Related issue(s)**:

Fixes #1722

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
