### PR TITLE
fix: correct FreezeType panic typo and add tests

### DIFF
--- a/sdk/freeze_type.go
+++ b/sdk/freeze_type.go
@@ -31,5 +31,5 @@ func (freezeType FreezeType) String() string {
 		return "TELEMETRY_UPGRADE"
 	}
 
-	panic(fmt.Sprintf("unreacahble: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
+	panic(fmt.Sprintf("unreachable: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
 }

--- a/sdk/freeze_type_unit_test.go
+++ b/sdk/freeze_type_unit_test.go
@@ -27,7 +27,6 @@ func TestUnitFreezeTypeString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, test.want, test.ft.String(), "FreezeType(%d).String()", test.ft)

--- a/sdk/freeze_type_unit_test.go
+++ b/sdk/freeze_type_unit_test.go
@@ -1,0 +1,48 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitFreezeTypeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ft   FreezeType
+		want string
+	}{
+		{name: "Unknown", ft: FreezeTypeUnknown, want: "UNKNOWN_FREEZE_TYPE"},
+		{name: "FreezeOnly", ft: FreezeTypeFreezeOnly, want: "FREEZE_ONLY"},
+		{name: "PrepareUpgrade", ft: FreezeTypePrepareUpgrade, want: "PREPARE_UPGRADE"},
+		{name: "FreezeUpgrade", ft: FreezeTypeFreezeUpgrade, want: "FREEZE_UPGRADE"},
+		{name: "FreezeAbort", ft: FreezeTypeFreezeAbort, want: "FREEZE_ABORT"},
+		{name: "TelemetryUpgrade", ft: FreezeTypeTelemetryUpgrade, want: "TELEMETRY_UPGRADE"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, test.ft.String(), "FreezeType(%d).String()", test.ft)
+		})
+	}
+}
+
+func TestUnitFreezeTypeStringPanicsOnUnknownValue(t *testing.T) {
+	t.Parallel()
+
+	require.PanicsWithValue(
+		t,
+		"unreachable: FreezeType.String() switch statement is non-exhaustive. Status: 6",
+		func() {
+			_ = FreezeType(6).String()
+		},
+	)
+}


### PR DESCRIPTION
1. Outcome

This PR fixes the `FreezeType.String()` panic typo and adds focused unit coverage for the defined enum values.

Closes #1709.

2. Summary

2.1 `sdk/freeze_type.go`

Change `unreacahble` to `unreachable` in the panic message.

2.2 `sdk/freeze_type_unit_test.go`

Add table-driven coverage for all defined `FreezeType.String()` outputs.

Add one focused assertion that unknown values still panic, so this PR stays within the current behavior contract instead of changing fallback semantics.

3. Validation

3.1 `gofmt -w sdk/freeze_type.go sdk/freeze_type_unit_test.go`

3.2 `go test ./sdk -tags="unit" -v -run TestUnitFreezeTypeString -timeout 9999s`

3.3 `go build ./...`

3.4 `golangci-lint run`

3.5 `go test ./sdk -tags="unit" -v -timeout 9999s`

This full suite still hits the pre-existing concurrent network panic in `sdk/network_unit_test.go`, so it is not clean on my machine even though the FreezeType-focused coverage passes.

3.6 Local environment note

This Windows host could not fetch `google.golang.org/grpc v1.81.1` from `proxy.golang.org`, so the broader local validation was run against a temporary offline modfile pinned to the already cached `google.golang.org/grpc v1.81.0`.

The temporary validation files were removed after verification, and this PR does not change dependency versions.
