### PR TITLE
fix: Re-enable fee_estimate_query example and remove mirror-sync sleeps

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,11 +17,6 @@ tasks:
                       echo "Skipping $example"
                       continue
                   fi
-                  # fee_estimate_query is flaky on a fresh local mirror node.
-                  if [ "$dir_name" == "fee_estimate_query" ]; then
-                      echo "Skipping $example (mirror node sync flake)"
-                      continue
-                  fi
                   if [ -d "$example" ]; then
 
                       pushd "$example" > /dev/null

--- a/examples/fee_estimate_query/main.go
+++ b/examples/fee_estimate_query/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
 )
@@ -31,6 +32,14 @@ func main() {
 	client.SetOperator(operatorAccountID, operatorKey)
 
 	fmt.Println("FeeEstimateQuery Example (HIP-1261)")
+
+	// On a fresh solo deployment the mirror node's FeeEstimationService races
+	// the importer ingesting the genesis fee schedule, so the first few calls
+	// return HTTP 400 "Unknown transaction type". Poll until it answers or 10
+	// minutes have elapsed.
+	if err := waitForFeeEstimationService(client); err != nil {
+		panic(fmt.Sprintf("%v : fee estimation service never became ready", err))
+	}
 
 	// Step 1: Create and freeze a transfer transaction. The query auto-freezes
 	// if the transaction is not already frozen, but freezing up front lets us
@@ -81,6 +90,26 @@ func main() {
 	}
 	printEstimate("INTRINSIC (high-volume 50%)", helperEstimate)
 	fmt.Printf("  high_volume_multiplier: %d\n", helperEstimate.HighVolumeMultiplier)
+}
+
+func waitForFeeEstimationService(client *hiero.Client) error {
+	probe := hiero.NewTransferTransaction().
+		AddHbarTransfer(client.GetOperatorAccountID(), hiero.NewHbar(-1)).
+		AddHbarTransfer(client.GetOperatorAccountID(), hiero.NewHbar(1))
+
+	deadline := time.Now().Add(10 * time.Minute)
+	for time.Now().Before(deadline) {
+		_, err := hiero.NewFeeEstimateQuery().
+			SetMode(hiero.FeeEstimateModeIntrinsic).
+			SetTransaction(probe).
+			SetMaxAttempts(1).
+			Execute(client)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("timed out after 10 minutes")
 }
 
 func printEstimate(label string, response hiero.FeeEstimateResponse) {

--- a/sdk/fee_estimate_query_e2e_test.go
+++ b/sdk/fee_estimate_query_e2e_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	mirrorSyncDelay            = 2 * time.Second
 	feeEstimationProbeInterval = 5 * time.Second
 	feeEstimationProbeTimeout  = 10 * time.Minute
 )
@@ -31,10 +30,6 @@ var (
 	feeEstimationReadyOnce sync.Once
 	feeEstimationReadyErr  error
 )
-
-func waitForMirrorNodeSync() {
-	time.Sleep(mirrorSyncDelay)
-}
 
 // waitForFeeEstimationServiceReady blocks until the mirror node's
 // FeeEstimationService can answer a known-good probe query. Re-issues
@@ -110,7 +105,6 @@ func TestIntegrationFeeEstimateQueryTokenCreateTransaction(t *testing.T) {
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -137,8 +131,6 @@ func TestIntegrationFeeEstimateQueryTransferTransactionStateMode(t *testing.T) {
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
-
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
 		SetMode(FeeEstimateModeState).
@@ -160,8 +152,6 @@ func TestIntegrationFeeEstimateQueryTransferTransactionIntrinsicMode(t *testing.
 		AddHbarTransfer(AccountID{Account: 3}, NewHbar(1)).
 		FreezeWith(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -188,8 +178,6 @@ func TestIntegrationFeeEstimateQueryTransferTransactionDefaultModeIsIntrinsic(t 
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
-
 	query := NewFeeEstimateQuery().SetTransaction(transaction)
 	require.Equal(t, FeeEstimateModeIntrinsic, query.GetMode())
 
@@ -211,8 +199,6 @@ func TestIntegrationFeeEstimateQueryTokenMintTransaction(t *testing.T) {
 		SetAmount(10).
 		FreezeWith(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -238,8 +224,6 @@ func TestIntegrationFeeEstimateQueryTopicCreateTransaction(t *testing.T) {
 
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -267,8 +251,6 @@ func TestIntegrationFeeEstimateQueryContractCreateTransaction(t *testing.T) {
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
-
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
 		SetMode(FeeEstimateModeState).
@@ -294,8 +276,6 @@ func TestIntegrationFeeEstimateQueryFileCreateTransaction(t *testing.T) {
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
-
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
 		SetMode(FeeEstimateModeState).
@@ -317,8 +297,6 @@ func TestIntegrationFeeEstimateQueryFileAppendTransactionAggregatesChunks(t *tes
 		SetContents(make([]byte, 5000)).
 		FreezeWith(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -342,8 +320,6 @@ func TestIntegrationFeeEstimateQueryTopicMessageSubmitSingleChunk(t *testing.T) 
 		FreezeWith(env.Client)
 	require.NoError(t, err)
 
-	waitForMirrorNodeSync()
-
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
 		SetMode(FeeEstimateModeIntrinsic).
@@ -365,8 +341,6 @@ func TestIntegrationFeeEstimateQueryTopicMessageSubmitMultipleChunk(t *testing.T
 		SetMessage(make([]byte, 5000)).
 		FreezeWith(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
@@ -404,8 +378,6 @@ func TestIntegrationFeeEstimateQueryWithHighVolumeThrottle(t *testing.T) {
 
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
-
-	waitForMirrorNodeSync()
 
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).

--- a/sdk/fee_estimate_query_e2e_test.go
+++ b/sdk/fee_estimate_query_e2e_test.go
@@ -105,7 +105,6 @@ func TestIntegrationFeeEstimateQueryTokenCreateTransaction(t *testing.T) {
 	_, err = transaction.SignWithOperator(env.Client)
 	require.NoError(t, err)
 
-
 	response, err := NewFeeEstimateQuery().
 		SetTransaction(transaction).
 		SetMode(FeeEstimateModeState).


### PR DESCRIPTION
**Description**:

Re-enable fee_estimate_query example in run-examples and remove mirror-sync sleeps

The `fee_estimate_query` example was previously skipped in the `run-examples` task due to intermittent failures on fresh local mirror node deployments. The underlying issue was that the mirror node hadn't ingested the operator's state when the example ran back-to-back with others.

This PR removes the band-aid `time.Sleep()` workarounds and re-enables the example by relying on the proper `waitForFeeEstimationServiceReady()` readiness probe, which polls the FeeEstimationService until it's actually ready to handle queries.

* Remove fee_estimate_query skip block from Taskfile.yml run-examples task
* Remove all waitForMirrorNodeSync() calls from fee_estimate_query_e2e_test.go (12 instances)
* Remove mirrorSyncDelay constant and waitForMirrorNodeSync() helper function
* Rely on waitForFeeEstimationServiceReady() readiness probe instead of arbitrary sleeps

**Related issue(s)**:

Fixes #1696

**Notes for reviewer**:

The `waitForFeeEstimationServiceReady()` function was already in place and working correctly. It probes the FeeEstimationService with a fresh INTRINSIC estimate request every 5 seconds until it succeeds or 10 minutes elapse. This is a proper solution compared to the previous blind 2-second sleep, as it:
- Doesn't waste time if the service is ready quickly
- Properly detects when the FeeEstimationService can handle queries
- Works across all parallel tests with a shared readiness check

**Checklist**

- [x] Documented (Issue references and comment block explain the behavior)
- [x] Tested (Integration tests now run without artificial sleeps and use proper readiness probing)

