### PR TITLE
chore: Replace panic to fallback Unknow in freeze_type.go

### DIFF
--- a/sdk/freeze_type.go
+++ b/sdk/freeze_type.go
@@ -29,7 +29,7 @@ func (freezeType FreezeType) String() string {
 		return "FREEZE_ABORT"
 	case FreezeTypeTelemetryUpgrade:
 		return "TELEMETRY_UPGRADE"
+	default:
+		return fmt.Sprintf("UNKNOWN_FREEZE_TYPE(%d)", freezeType)
 	}
-
-	panic(fmt.Sprintf("unreachable: FreezeType.String() switch statement is non-exhaustive. Status: %v", uint32(freezeType)))
 }

--- a/sdk/freeze_type_unit_test.go
+++ b/sdk/freeze_type_unit_test.go
@@ -34,14 +34,7 @@ func TestUnitFreezeTypeString(t *testing.T) {
 	}
 }
 
-func TestUnitFreezeTypeStringPanicsOnUnknownValue(t *testing.T) {
+func TestUnitFreezeTypeStringFallbackUnknownValue(t *testing.T) {
 	t.Parallel()
-
-	require.PanicsWithValue(
-		t,
-		"unreachable: FreezeType.String() switch statement is non-exhaustive. Status: 6",
-		func() {
-			_ = FreezeType(6).String()
-		},
-	)
+	require.Equal(t, "UNKNOWN_FREEZE_TYPE(6)", FreezeType(6).String())
 }


### PR DESCRIPTION
**Description**:
This PR remove the panic and introduce the fallback to `UNKNOWN_FREEZE_TYPE` for invalid/unknown value for `FreezeType`

**Changes Made:**
- Added a default in switch case to fall back to `UNKNOWN_FREEZE_TYPE`
- Updated unit test for the changes


**Related issue(s)**:

Fixes #1716 

**Notes for reviewer**:
Updated the unit test in `sdk/freeze_type_unit_test.go` to match the fallback case

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
