### PR TITLE
fix: contract revert error message

### DIFF
--- a/sdk/transaction_record_query.go
+++ b/sdk/transaction_record_query.go
@@ -263,10 +263,8 @@ func (q *TransactionRecordQuery) shouldRetry(_ Executable, response interface{})
 	switch status {
 	case StatusBusy, StatusUnknown, StatusOk, StatusReceiptNotFound, StatusRecordNotFound, StatusPlatformNotActive:
 		return executionStateRetry
-	case StatusSuccess:
-		return executionStateFinished
 	default:
-		return executionStateError
+		return executionStateFinished
 	}
 }
 

--- a/sdk/transaction_record_query.go
+++ b/sdk/transaction_record_query.go
@@ -21,6 +21,7 @@ type TransactionRecordQuery struct {
 	transactionID       *TransactionID
 	includeChildRecords *bool
 	duplicates          *bool
+	validateStatus      bool
 }
 
 // NewTransactionRecordQuery creates TransactionRecordQuery which
@@ -34,8 +35,21 @@ type TransactionRecordQuery struct {
 func NewTransactionRecordQuery() *TransactionRecordQuery {
 	header := services.QueryHeader{}
 	return &TransactionRecordQuery{
-		Query: _NewQuery(true, &header),
+		Query:          _NewQuery(true, &header),
+		validateStatus: true,
 	}
+}
+
+// SetValidateStatus sets whether Execute returns an error when the record's
+// receipt status is not SUCCESS. Defaults to true.
+func (q *TransactionRecordQuery) SetValidateStatus(validate bool) *TransactionRecordQuery {
+	q.validateStatus = validate
+	return q
+}
+
+// GetValidateStatus returns whether Execute validates the record's receipt status.
+func (q *TransactionRecordQuery) GetValidateStatus() bool {
+	return q.validateStatus
 }
 
 // When execution is attempted, a single attempt will timeout when this deadline is reached. (The SDK may subsequently retry the execution.)
@@ -96,7 +110,9 @@ func (q *TransactionRecordQuery) Execute(client *Client) (TransactionRecord, err
 		return TransactionRecord{}, err
 	}
 
-	return _TransactionRecordFromProtobuf(resp.GetTransactionGetRecord(), q.transactionID), nil
+	record := _TransactionRecordFromProtobuf(resp.GetTransactionGetRecord(), q.transactionID)
+
+	return record, record.Receipt.ValidateStatus(q.validateStatus)
 }
 
 // SetTransactionID sets the TransactionID for this TransactionRecordQuery.

--- a/sdk/transaction_record_query_e2e_test.go
+++ b/sdk/transaction_record_query_e2e_test.go
@@ -5,6 +5,8 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -383,6 +385,112 @@ func DisabledTestIntegrationTokenNftTransferRecordQuery(t *testing.T) { // nolin
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
 	require.NoError(t, err)
+}
+
+// deployReverterContract deploys a contract with two always-reverting functions:
+//
+//	error InsufficientBalance(uint256 available, uint256 required);
+//	function revertWithReason() external pure { revert("This should fail"); }
+//	function revertWithCustomError() external pure { revert InsufficientBalance(5, 10); }
+//
+// Compiled with solc 0.8.30 --optimize.
+func deployReverterContract(t *testing.T, env IntegrationTestEnv) (ContractID, AccountID) {
+	reverterBytecode := []byte(`6080604052348015600e575f5ffd5b5060da80601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c806346fc4bb11460345780635b2dd10014603c575b5f5ffd5b603a6042565b005b603a606a565b60405163cf47918160e01b815260056004820152600a60248201526044015b60405180910390fd5b60405162461bcd60e51b815260206004820152601060248201526f151a1a5cc81cda1bdd5b190819985a5b60821b6044820152606401606156fea26469706673582212204ff1c43253f237119979541db455673b8e183cb981eee17e42a787a4f1b35fcb64736f6c634300081e0033`)
+
+	resp, err := NewFileCreateTransaction().
+		SetKeys(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetContents(reverterBytecode).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	resp, err = NewContractCreateTransaction().
+		SetAdminKey(env.Client.GetOperatorPublicKey()).
+		SetGas(contractDeployGas).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetBytecodeFileID(*receipt.FileID).
+		SetContractMemo("hiero-sdk-go::TestTransactionRecordQueryContractRevert").
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	receipt, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	return *receipt.ContractID, resp.NodeID
+}
+
+func TestIntegrationTransactionRecordQueryContractRevertReturnsRecord(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	contractID, nodeID := deployReverterContract(t, env)
+
+	resp, err := NewContractExecuteTransaction().
+		SetContractID(contractID).
+		SetNodeAccountIDs([]AccountID{nodeID}).
+		SetGas(contractDeployGas).
+		SetFunction("revertWithReason", nil).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	record, err := resp.GetRecord(env.Client)
+	var receiptErr ErrHederaReceiptStatus
+	require.ErrorAs(t, err, &receiptErr)
+	assert.Equal(t, StatusContractRevertExecuted, receiptErr.Status)
+
+	require.Equal(t, StatusContractRevertExecuted, record.Receipt.Status)
+	result, err := record.GetContractExecuteResult()
+	require.NoError(t, err)
+
+	// ErrorMessage is the hex-encoded Error(string) revert data (selector 0x08c379a0).
+	require.True(t, strings.HasPrefix(result.ErrorMessage, "0x08c379a0"))
+	payload, err := hex.DecodeString(strings.TrimPrefix(result.ErrorMessage, "0x"))
+	require.NoError(t, err)
+	assert.Contains(t, string(payload), "This should fail")
+
+	// A direct TransactionRecordQuery behaves the same.
+	record, err = NewTransactionRecordQuery().
+		SetTransactionID(resp.TransactionID).
+		SetNodeAccountIDs([]AccountID{nodeID}).
+		Execute(env.Client)
+	require.Error(t, err)
+	require.NotNil(t, record.CallResult)
+	assert.Equal(t, result.ErrorMessage, record.CallResult.ErrorMessage)
+}
+
+func TestIntegrationTransactionRecordQueryContractRevertValidateStatusFalse(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	contractID, nodeID := deployReverterContract(t, env)
+
+	resp, err := NewContractExecuteTransaction().
+		SetContractID(contractID).
+		SetNodeAccountIDs([]AccountID{nodeID}).
+		SetGas(contractDeployGas).
+		SetFunction("revertWithCustomError", nil).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	record, err := resp.SetValidateStatus(false).GetRecord(env.Client)
+	require.NoError(t, err)
+
+	require.Equal(t, StatusContractRevertExecuted, record.Receipt.Status)
+	result, err := record.GetContractExecuteResult()
+	require.NoError(t, err)
+
+	// Custom error InsufficientBalance(uint256,uint256): selector 0xcf479181 + args (5, 10).
+	require.True(t, strings.HasPrefix(result.ErrorMessage, "0xcf479181"))
+	payload, err := hex.DecodeString(strings.TrimPrefix(result.ErrorMessage, "0x"))
+	require.NoError(t, err)
+	require.Equal(t, 4+32+32, len(payload))
+	assert.Equal(t, byte(5), payload[4+31])
+	assert.Equal(t, byte(10), payload[4+63])
 }
 
 func TestIntegrationTransactionRecordQueryGetScheduleRef(t *testing.T) {

--- a/sdk/transaction_record_query_unit_test.go
+++ b/sdk/transaction_record_query_unit_test.go
@@ -6,6 +6,8 @@ package hiero
 
 import (
 	"encoding/hex"
+	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -246,6 +248,252 @@ func TestUnitTransactionRecordReceiptNotFound(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "exceptional precheck status RECEIPT_NOT_FOUND", err.Error())
 	require.Equal(t, StatusReceiptNotFound, record.Receipt.Status)
+}
+
+// _encodeErrorString builds the ABI revert payload for a Solidity Error(string)
+// revert: the 0x08c379a0 selector followed by offset || length || padded utf8 bytes.
+func _encodeErrorString(reason string) []byte {
+	out := []byte{0x08, 0xc3, 0x79, 0xa0}
+
+	offset := make([]byte, 32)
+	offset[31] = 0x20 // the string data begins 32 bytes after the head
+	out = append(out, offset...)
+
+	length := make([]byte, 32)
+	big.NewInt(int64(len(reason))).FillBytes(length)
+	out = append(out, length...)
+
+	data := []byte(reason)
+	padded := ((len(data) + 31) / 32) * 32
+	buf := make([]byte, padded)
+	copy(buf, data)
+	return append(out, buf...)
+}
+
+// _contractRevertRecordResponse is a reverting record response. As the node does, the
+// Error(string) payload is hex-encoded into ErrorMessage.
+func _contractRevertRecordResponse(reason string) *services.Response {
+	return &services.Response{
+		Response: &services.Response_TransactionGetRecord{
+			TransactionGetRecord: &services.TransactionGetRecordResponse{
+				Header: &services.ResponseHeader{
+					Cost:         0,
+					ResponseType: services.ResponseType_ANSWER_ONLY,
+				},
+				TransactionRecord: &services.TransactionRecord{
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_CONTRACT_REVERT_EXECUTED,
+					},
+					Body: &services.TransactionRecord_ContractCallResult{
+						ContractCallResult: &services.ContractFunctionResult{
+							ErrorMessage: "0x" + hex.EncodeToString(_encodeErrorString(reason)),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// _contractRevertResponses builds the mock flow for a transfer that reverts with reason.
+func _contractRevertResponses(reason string) [][]interface{} {
+	inner := []interface{}{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_CONTRACT_REVERT_EXECUTED,
+					},
+				},
+			},
+		},
+	}
+	// record query: cost query first, then the record carrying the revert
+	inner = append(inner, _costAnswerRecordResponse(), _contractRevertRecordResponse(reason))
+	return [][]interface{}{inner}
+}
+
+// _costAnswerRecordResponse is the COST_ANSWER reply for the record query's cost query.
+func _costAnswerRecordResponse() *services.Response {
+	return &services.Response{
+		Response: &services.Response_TransactionGetRecord{
+			TransactionGetRecord: &services.TransactionGetRecordResponse{
+				Header: &services.ResponseHeader{
+					Cost:         0,
+					ResponseType: services.ResponseType_COST_ANSWER,
+				},
+			},
+		},
+	}
+}
+
+func TestUnitTransactionRecordQueryContractRevertReturnsRecord(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewMockClientAndServer(_contractRevertResponses("insufficient balance"))
+	defer server.Close()
+
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	require.NoError(t, err)
+
+	record, err := tx.GetRecord(client)
+	var receiptErr ErrHederaReceiptStatus
+	require.ErrorAs(t, err, &receiptErr)
+	require.Equal(t, StatusContractRevertExecuted, receiptErr.Status)
+
+	// record is populated despite the error, so the revert reason is reachable
+	require.Equal(t, StatusContractRevertExecuted, record.Receipt.Status)
+	result, resErr := record.GetContractExecuteResult()
+	require.NoError(t, resErr)
+	require.True(t, strings.HasPrefix(result.ErrorMessage, "0x08c379a0"))
+	payload, decErr := hex.DecodeString(strings.TrimPrefix(result.ErrorMessage, "0x"))
+	require.NoError(t, decErr)
+	require.Contains(t, string(payload), "insufficient balance")
+}
+
+func TestUnitTransactionRecordQueryContractRevertValidateStatusFalse(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewMockClientAndServer(_contractRevertResponses("nope"))
+	defer server.Close()
+
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	require.NoError(t, err)
+
+	record, err := tx.SetValidateStatus(false).GetRecord(client)
+	require.NoError(t, err)
+	require.Equal(t, StatusContractRevertExecuted, record.Receipt.Status)
+	result, resErr := record.GetContractExecuteResult()
+	require.NoError(t, resErr)
+	require.True(t, strings.HasPrefix(result.ErrorMessage, "0x08c379a0"))
+	payload, decErr := hex.DecodeString(strings.TrimPrefix(result.ErrorMessage, "0x"))
+	require.NoError(t, decErr)
+	require.Contains(t, string(payload), "nope")
+}
+
+// validateStatus=false must not swallow a retry-exhaustion error.
+func TestUnitTransactionRecordQueryRetryExhaustedValidateStatusFalse(t *testing.T) {
+	t.Parallel()
+
+	busyRecordResponse := &services.Response{
+		Response: &services.Response_TransactionGetRecord{
+			TransactionGetRecord: &services.TransactionGetRecordResponse{
+				Header: &services.ResponseHeader{
+					NodeTransactionPrecheckCode: services.ResponseCodeEnum_BUSY,
+					ResponseType:                services.ResponseType_ANSWER_ONLY,
+				},
+			},
+		},
+	}
+	inner := []interface{}{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_CONTRACT_REVERT_EXECUTED,
+					},
+				},
+			},
+		},
+		_costAnswerRecordResponse(),
+		busyRecordResponse,
+		busyRecordResponse,
+	}
+
+	client, server := NewMockClientAndServer([][]interface{}{inner})
+	defer server.Close()
+
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	require.NoError(t, err)
+
+	client.SetMaxAttempts(2)
+	_, err = tx.SetValidateStatus(false).GetRecord(client)
+	require.Error(t, err)
+}
+
+// The populated-record-on-failure behavior is generic, not contract-specific.
+func TestUnitTransactionRecordQueryNonContractFailureReturnsRecord(t *testing.T) {
+	t.Parallel()
+
+	failedRecord := &services.Response{
+		Response: &services.Response_TransactionGetRecord{
+			TransactionGetRecord: &services.TransactionGetRecordResponse{
+				Header: &services.ResponseHeader{
+					Cost:         0,
+					ResponseType: services.ResponseType_ANSWER_ONLY,
+				},
+				TransactionRecord: &services.TransactionRecord{
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_INSUFFICIENT_ACCOUNT_BALANCE,
+					},
+				},
+			},
+		},
+	}
+	inner := []interface{}{
+		&services.TransactionResponse{
+			NodeTransactionPrecheckCode: services.ResponseCodeEnum_OK,
+		},
+		&services.Response{
+			Response: &services.Response_TransactionGetReceipt{
+				TransactionGetReceipt: &services.TransactionGetReceiptResponse{
+					Header: &services.ResponseHeader{
+						Cost:         0,
+						ResponseType: services.ResponseType_ANSWER_ONLY,
+					},
+					Receipt: &services.TransactionReceipt{
+						Status: services.ResponseCodeEnum_INSUFFICIENT_ACCOUNT_BALANCE,
+					},
+				},
+			},
+		},
+		_costAnswerRecordResponse(),
+		failedRecord,
+	}
+
+	client, server := NewMockClientAndServer([][]interface{}{inner})
+	defer server.Close()
+
+	tx, err := NewTransferTransaction().
+		SetNodeAccountIDs([]AccountID{{Account: 3}}).
+		AddHbarTransfer(AccountID{Account: 2}, HbarFromTinybar(-1)).
+		AddHbarTransfer(AccountID{Account: 3}, HbarFromTinybar(1)).
+		Execute(client)
+	require.NoError(t, err)
+
+	record, err := tx.GetRecord(client)
+	var receiptErr ErrHederaReceiptStatus
+	require.ErrorAs(t, err, &receiptErr)
+	require.Equal(t, StatusInsufficientAccountBalance, receiptErr.Status)
+
+	require.Equal(t, StatusInsufficientAccountBalance, record.Receipt.Status)
+	require.Nil(t, record.CallResult)
 }
 
 func TestUnitTransactionRecordQueryMarshalJSON(t *testing.T) {

--- a/sdk/transaction_response.go
+++ b/sdk/transaction_response.go
@@ -113,6 +113,7 @@ func (response *TransactionResponse) GetRecord(client *Client) (TransactionRecor
 	return NewTransactionRecordQuery().
 		SetTransactionID(response.TransactionID).
 		SetNodeAccountIDs(nodeAccountIDs).
+		SetValidateStatus(response.ValidateStatus).
 		Execute(client)
 }
 


### PR DESCRIPTION
**Description**:
Return the populated transaction record on a non-SUCCESS status instead of discarding it, so contract/Ethereum revert reasons (carried in the record's ContractFunctionResult.ErrorMessage) are reachable.

  * Build the record on terminal non-SUCCESS statuses in TransactionRecordQuery.shouldRetry instead of discarding it
  * Return the populated record alongside the status error from Execute, mirroring TransactionResponse.GetReceipt
  * Add SetValidateStatus/GetValidateStatus (default true) to opt out of the status error and read failed outcomes
  * Thread response.ValidateStatus through TransactionResponse.GetRecord
  * Add unit coverage for revert, validate-status opt-out, retry-exhaustion, and a non-contract failure
  * Add e2e coverage decoding Error(string) and a custom Solidity error via GetRecord and a direct TransactionRecordQuery

**Related issue(s)**:

Fixes #1734

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
