### PR TITLE
fix(sdk): correct panic message in TokenSupplyType.String() and add unit test

### DIFF
--- a/sdk/token_supply_type.go
+++ b/sdk/token_supply_type.go
@@ -20,5 +20,5 @@ func (tokenSupplyType TokenSupplyType) String() string {
 		return "TOKEN_SUPPLY_TYPE_FINITE"
 	}
 
-	panic(fmt.Sprintf("unreachable: TokenType.String() switch statement is non-exhaustive. Status: %v", uint32(tokenSupplyType)))
+	panic(fmt.Sprintf("unreachable: TokenSupplyType.String() switch statement is non-exhaustive. Status: %v", uint32(tokenSupplyType)))
 }

--- a/sdk/token_supply_type_unit_test.go
+++ b/sdk/token_supply_type_unit_test.go
@@ -1,0 +1,27 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitTokenSupplyTypeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		supplyType TokenSupplyType
+		expected   string
+	}{
+		{TokenSupplyTypeInfinite, "TOKEN_SUPPLY_TYPE_INFINITE"},
+		{TokenSupplyTypeFinite, "TOKEN_SUPPLY_TYPE_FINITE"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.supplyType.String())
+	}
+}


### PR DESCRIPTION
TokenSupplyType.String() panic message says TokenType.String() — copy-paste from token_type.go. Corrected to reference TokenSupplyType.

Table-driven test asserts the string mapping for both INFINITE and FINITE values.