### PR TITLE
chore: align CODEOWNERS to shared SDK teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*                                               @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+*                                               @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 #########################
 #####  Core Files  ######
 #########################
@@ -7,26 +7,26 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers
-/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 # Legacy Maven project files
-**/pom.xml                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+**/pom.xml                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 # Gradle project files and inline plugins
-/gradle/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+/gradle/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 gradlew                                         @hiero-ledger/github-maintainers
 gradlew.bat                                     @hiero-ledger/github-maintainers
-**/build-logic/                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
-**/gradle.*                                     @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
-**/*.gradle.*                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+**/build-logic/                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+**/gradle.*                                     @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+**/*.gradle.*                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 # Codacy Tool Configurations
-/config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
-.remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers
+/config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+.remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-go-maintainers @hiero-ledger/hiero-sdk-go-committers @hiero-ledger/tsc
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers @hiero-ledger/tsc
 **/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/tsc


### PR DESCRIPTION
## What
Updates `.github/CODEOWNERS` to reference the shared SDK teams introduced by the team merge:
- `@hiero-ledger/hiero-sdk-go-maintainers` → `@hiero-ledger/hiero-sdk-maintainers`
- `@hiero-ledger/hiero-sdk-go-committers` → `@hiero-ledger/hiero-sdk-committers`

`@hiero-ledger/github-maintainers` and `@hiero-ledger/tsc` are intentionally left unchanged — they are not part of the SDK team merge.

## ⚠️ DO NOT MERGE YET
The shared teams `hiero-sdk-maintainers` / `hiero-sdk-committers` **do not exist yet**. Per the guide (§4) a CODEOWNERS team only takes effect once it exists and has write access in `governance/config.yaml`. This PR must land **together** with the governance PR that creates and grants those teams (§7) — merging it earlier would point `*` at a non-existent team and break code-owner enforcement.

Reference: https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/sdk-team-structure-and-codeowners.md
