### PR TITLE
feat: add pending airdrop record unit test

### DIFF
--- a/sdk/pending_airdrop_record_unit_test.go
+++ b/sdk/pending_airdrop_record_unit_test.go
@@ -1,0 +1,49 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitPendingAirdropRecordProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	accID, err := AccountIDFromString("0.0.123")
+	require.NoError(t, err)
+	tokenID, err := TokenIDFromString("0.0.456")
+	require.NoError(t, err)
+
+	original := PendingAirdropRecord{
+		pendingAirdropId:     PendingAirdropId{&accID, &accID, &tokenID, nil},
+		pendingAirdropAmount: 789,
+	}
+
+	roundTripped := _PendingAirdropRecordFromProtobuf(original._ToProtobuf())
+
+	assert.Equal(t, original, roundTripped)
+	assert.Equal(t, uint64(789), roundTripped.GetPendingAirdropAmount())
+	assert.Equal(t, original.GetPendingAirdropId(), roundTripped.GetPendingAirdropId())
+}
+
+func TestUnitPendingAirdropRecordString(t *testing.T) {
+	t.Parallel()
+
+	accID, err := AccountIDFromString("0.0.123")
+	require.NoError(t, err)
+	tokenID, err := TokenIDFromString("0.0.456")
+	require.NoError(t, err)
+
+	record := PendingAirdropRecord{
+		pendingAirdropId:     PendingAirdropId{&accID, &accID, &tokenID, nil},
+		pendingAirdropAmount: 789,
+	}
+
+	expected := "PendingAirdropRecord{PendingAirdropId: Sender: 0.0.123, Receiver: 0.0.123, TokenID: 0.0.456, NftID: nil, PendingAirdropAmount: 789}"
+	assert.Equal(t, expected, record.String())
+}


### PR DESCRIPTION
**Description**:

Add unit test coverage for `PendingAirdropRecord`, which previously had no dedicated test file.

* Add `sdk/pending_airdrop_record_unit_test.go`
* Add proto round-trip test covering the fungible token case
* Add `String()` output assertion

**Related issue(s)**:

Fixes #1749 

**Notes for reviewer**:

```
$ go test ./sdk -tags="unit" -v -run TestUnitPendingAirdropRecord -timeout 9999s
PASS
```


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
