### PR TITLE
fix: keep unchanged nodes and connections on address-book refresh

### DIFF
--- a/sdk/managed_network.go
+++ b/sdk/managed_network.go
@@ -75,10 +75,7 @@ func (mn *_ManagedNetwork) _SetNetwork(network map[string]_IManagedNode) error {
 	}
 
 	for key, value := range network {
-		_, keyOk := newNodeKeys[key]
-		_, valueOk := newNodeValues[value._GetAddress()]
-
-		if keyOk && valueOk {
+		if newNodeKeys[value._GetKey()] && newNodeValues[key] {
 			continue
 		}
 
@@ -284,7 +281,8 @@ func _GetNodesToRemove(network map[string]_IManagedNode, nodes []_IManagedNode) 
 	nodeIndices := []int{}
 
 	for i, v := range slices.Backward(nodes) {
-		if _, ok := network[v._GetKey()]; !ok {
+		incoming, ok := network[v._GetAddress()]
+		if !ok || incoming._GetKey() != v._GetKey() {
 			nodeIndices = append(nodeIndices, i)
 		}
 	}

--- a/sdk/network_unit_test.go
+++ b/sdk/network_unit_test.go
@@ -153,3 +153,85 @@ func TestUnitConcurrentNodeGetChannel(t *testing.T) {
 	network._ReadmitNodes()
 	require.Equal(t, len(nodes), len(network.healthyNodes))
 }
+
+// Re-applying an unchanged network must keep the existing nodes and their open
+// connections rather than closing and recreating them.
+
+func TestUnitNetworkRefreshRemovesNoNodesWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	network := _NewNetwork()
+	err := network.SetNetwork(newNetworkMockNodes())
+	require.NoError(t, err)
+
+	// Incoming address book identical to the installed nodes, keyed by address
+	// the same way _Network.SetNetwork builds it.
+	incoming := make(map[string]_IManagedNode, len(network.nodes))
+	for _, node := range network.nodes {
+		incoming[node._GetAddress()] = node
+	}
+
+	require.Empty(t, _GetNodesToRemove(incoming, network.nodes),
+		"an unchanged address book must not mark any node for removal")
+}
+
+func TestUnitNetworkRefreshPreservesNodeObjects(t *testing.T) {
+	t.Parallel()
+
+	nodes := newNetworkMockNodes()
+	network := _NewNetwork()
+	err := network.SetNetwork(nodes)
+	require.NoError(t, err)
+
+	before := nodesByAccount(&network)
+
+	// Re-apply the identical address book, as the scheduled network update does.
+	err = network.SetNetwork(nodes)
+	require.NoError(t, err)
+
+	after := nodesByAccount(&network)
+
+	require.Equal(t, len(before), len(after))
+	for account, node := range before {
+		require.Samef(t, node, after[account],
+			"node 0.0.%d was recreated by an unchanged refresh", account)
+	}
+}
+
+func TestUnitNetworkRefreshPreservesNodeConnections(t *testing.T) {
+	t.Parallel()
+
+	nodes := newNetworkMockNodes()
+	network := _NewNetwork()
+	err := network.SetNetwork(nodes)
+	require.NoError(t, err)
+
+	// Open a node's channel, standing in for an in-flight request holding a live
+	// connection. grpc.NewClient is lazy, so nothing is dialed.
+	account := AccountID{0, 0, 3, nil, nil, nil}
+	node, ok := network._GetNodeForAccountID(account)
+	require.True(t, ok)
+	_, err = node._GetChannel(NewLogger("", LoggerLevelError))
+	require.NoError(t, err)
+	require.NotNil(t, node.channel)
+
+	err = network.SetNetwork(nodes)
+	require.NoError(t, err)
+
+	refreshed, ok := network._GetNodeForAccountID(account)
+	require.True(t, ok)
+	require.Same(t, node, refreshed,
+		"unchanged refresh replaced the node and dropped its open connection")
+	require.NotNil(t, refreshed.channel,
+		"unchanged refresh closed the node's open connection")
+}
+
+func nodesByAccount(network *_Network) map[uint64]*_Node {
+	byAccount := make(map[uint64]*_Node, len(network.nodes))
+	for _, node := range network.nodes {
+		if n, ok := node.(*_Node); ok {
+			byAccount[n.accountID.Account] = n
+		}
+	}
+	return byAccount
+}


### PR DESCRIPTION
**Description**:

Fix the address-book refresh needlessly closing and recreating every consensus node's gRPC connection, even when the fetched address book is unchanged. The churn let in-flight requests race a connection close and fail pre-send with a non-retryable `Canceled` ("the client connection is closing").

* Match existing nodes against the incoming address book by address and confirm the key, so an unchanged refresh keeps the current nodes
* Skip re-adding nodes already present so their open connections are preserved and only removed or re-addressed nodes are closed
* Add unit tests covering node and connection reuse across an unchanged refresh, using real consensus nodes since the managed-network mocks set key == address

**Related issue(s)**:

Fixes #1762

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)