### PR TITLE
chore: updated panic message for the TokenSupplyType

### DIFF
--- a/sdk/token_supply_type.go
+++ b/sdk/token_supply_type.go
@@ -20,5 +20,5 @@ func (tokenSupplyType TokenSupplyType) String() string {
 		return "TOKEN_SUPPLY_TYPE_FINITE"
 	}
 
-	panic(fmt.Sprintf("unreachable: TokenType.String() switch statement is non-exhaustive. Status: %v", uint32(tokenSupplyType)))
+	panic(fmt.Sprintf("unreachable: TokenSupplyType.String() switch statement is non-exhaustive. Status: %v", uint32(tokenSupplyType)))
 }

--- a/sdk/token_supply_type_unit_test.go
+++ b/sdk/token_supply_type_unit_test.go
@@ -1,0 +1,41 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnitTokenSupplyTypeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tst  TokenSupplyType
+		want string
+	}{
+		{name: "Infinite", tst: TokenSupplyTypeInfinite, want: "TOKEN_SUPPLY_TYPE_INFINITE"},
+		{name: "Finite", tst: TokenSupplyTypeFinite, want: "TOKEN_SUPPLY_TYPE_FINITE"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, test.tst.String(), "TokenSupplyType(%d).String()", test.tst)
+		})
+	}
+}
+
+func TestUnitTokenSupplyTypeStringPanic(t *testing.T) {
+	t.Parallel()
+
+	var unknownSupplyType TokenSupplyType = 100
+	assert.PanicsWithValue(
+		t,
+		"unreachable: TokenSupplyType.String() switch statement is non-exhaustive. Status: 100",
+		func() {
+			_ = unknownSupplyType.String()
+		},
+	)
+}


### PR DESCRIPTION
**Description**:
This PR update the message for the panic in TokenSupplyType.

**Changes Made:**
- Fix panic message in `token_supply_type.go`
- Added unit test for TokenSupplyType

**Related issue(s)**:

Fixes #1750

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
