### PR TITLE
fix: mirror node contract query

### DIFF
--- a/sdk/fee_estimate_query.go
+++ b/sdk/fee_estimate_query.go
@@ -3,13 +3,11 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/hiero-ledger/hiero-sdk-go/v2/proto/services"
 	"github.com/pkg/errors"
@@ -195,52 +193,21 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 		url = fmt.Sprintf("%s&high_volume_throttle=%d", url, q.highVolumeThrottle)
 	}
 
-	var lastErr error
-	var resp *http.Response
-
-	for attempt := uint64(0); attempt < q.maxAttempts; attempt++ {
-		resp, err = http.Post(url, "application/protobuf", bytes.NewBuffer(txBytes)) // #nosec
-		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
-			break
-		}
-
-		switch {
-		case err != nil:
-			lastErr = err
-		case resp != nil:
-			body, readErr := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if readErr == nil {
-				lastErr = fmt.Errorf("received non-200 response: %d, details: %s", resp.StatusCode, body)
-			} else {
-				lastErr = fmt.Errorf("received non-200 response: %d", resp.StatusCode)
-			}
-		default:
-			lastErr = fmt.Errorf("received nil response")
-		}
-
-		// Check if we should retry
-		if !q.shouldRetry(err, resp) {
-			return FeeEstimateResponse{}, errors.Wrap(lastErr, "failed to call fee estimate API")
-		}
-
-		// Exponential backoff capped at 8s; exp is clamped to avoid shift overflow.
-		exp := min(attempt, uint64(5))
-		delayMs := 250.0 * float64(uint64(1)<<exp)
-		if delayMs > 8000 {
-			delayMs = 8000
-		}
-
-		// Wait before retry
-		select {
-		case <-client.networkUpdateContext.Done():
-			return FeeEstimateResponse{}, client.networkUpdateContext.Err()
-		case <-time.After(time.Duration(delayMs) * time.Millisecond):
-		}
+	// Timeout 0 preserves the previous no-per-request-timeout behaviour.
+	resp, err := mirrorNodePostWithRetry(client, url, "application/protobuf", txBytes, q.maxAttempts, 0)
+	if err != nil {
+		return FeeEstimateResponse{}, errors.Wrapf(err, "failed to call fee estimate API after %d attempts", q.maxAttempts)
 	}
-
 	if resp == nil {
-		return FeeEstimateResponse{}, errors.Wrapf(lastErr, "failed to call fee estimate API after %d attempts", q.maxAttempts)
+		return FeeEstimateResponse{}, errors.Wrap(errors.New("received nil response"), "failed to call fee estimate API")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr == nil {
+			return FeeEstimateResponse{}, errors.Wrap(fmt.Errorf("received non-200 response: %d, details: %s", resp.StatusCode, body), "failed to call fee estimate API")
+		}
+		return FeeEstimateResponse{}, errors.Wrap(fmt.Errorf("received non-200 response: %d", resp.StatusCode), "failed to call fee estimate API")
 	}
 
 	defer resp.Body.Close()
@@ -256,24 +223,6 @@ func (q *FeeEstimateQuery) callGetFeeEstimate(client *Client, protoTx *services.
 	}
 
 	return response, nil
-}
-
-// shouldRetry determines if an error should be retried
-func (q *FeeEstimateQuery) shouldRetry(err error, resp *http.Response) bool {
-	if err == nil && resp != nil {
-		if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
-			return true
-		}
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-			return false
-		}
-	}
-
-	if err == nil {
-		return false
-	}
-
-	return true
 }
 
 // validateNetworkOnIDs validates network and IDs on the query

--- a/sdk/fee_estimate_query_mock_test.go
+++ b/sdk/fee_estimate_query_mock_test.go
@@ -231,6 +231,37 @@ func TestUnitFeeEstimateQuerySendsHighVolumeThrottle(t *testing.T) {
 		"highVolumeMultiplier should be >= 1 when throttle is non-zero")
 }
 
+func TestUnitFeeEstimateQueryReturnsErrorAfterTransportFailures(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		// Drop the connection on every attempt, surfacing as a transport error (EOF).
+		// After the retries are exhausted the query must return a wrapped error rather
+		// than a response.
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok, "test server must support connection hijacking")
+		conn, _, hijackErr := hj.Hijack()
+		require.NoError(t, hijackErr)
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain("localhost:8084", server.URL)
+	defer cleanup()
+
+	client := newMockClientForREST()
+
+	tx := NewTransferTransaction()
+
+	_, err := NewFeeEstimateQuery().
+		SetTransaction(tx).
+		SetMaxAttempts(2).
+		Execute(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to call fee estimate API after 2 attempts")
+	assert.Equal(t, 2, requestCount, "transport errors should be retried up to maxAttempts")
+}
+
 func TestUnitFeeEstimateQueryDoesNotRetryOn400(t *testing.T) {
 	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/fee_estimate_query_unit_test.go
+++ b/sdk/fee_estimate_query_unit_test.go
@@ -100,33 +100,31 @@ func TestUnitFeeEstimateQueryExecuteWithoutClient(t *testing.T) {
 func TestUnitFeeEstimateQueryShouldRetry(t *testing.T) {
 	t.Parallel()
 
-	query := NewFeeEstimateQuery()
-
-	require.False(t, query.shouldRetry(nil, nil))
+	require.False(t, mirrorNodeShouldRetry(nil, nil))
 
 	resp200 := &http.Response{StatusCode: http.StatusOK}
-	require.False(t, query.shouldRetry(nil, resp200))
+	require.False(t, mirrorNodeShouldRetry(nil, resp200))
 
 	resp500 := &http.Response{StatusCode: http.StatusInternalServerError}
-	require.True(t, query.shouldRetry(nil, resp500))
+	require.True(t, mirrorNodeShouldRetry(nil, resp500))
 
 	resp503 := &http.Response{StatusCode: http.StatusServiceUnavailable}
-	require.True(t, query.shouldRetry(nil, resp503))
+	require.True(t, mirrorNodeShouldRetry(nil, resp503))
 
 	resp429 := &http.Response{StatusCode: http.StatusTooManyRequests}
-	require.True(t, query.shouldRetry(nil, resp429))
+	require.True(t, mirrorNodeShouldRetry(nil, resp429))
 
 	resp400 := &http.Response{StatusCode: http.StatusBadRequest}
-	require.False(t, query.shouldRetry(nil, resp400))
+	require.False(t, mirrorNodeShouldRetry(nil, resp400))
 
 	resp404 := &http.Response{StatusCode: http.StatusNotFound}
-	require.False(t, query.shouldRetry(nil, resp404))
+	require.False(t, mirrorNodeShouldRetry(nil, resp404))
 
 	err := errors.New("connection refused")
-	require.True(t, query.shouldRetry(err, nil))
+	require.True(t, mirrorNodeShouldRetry(err, nil))
 
 	err = errors.New("timeout")
-	require.True(t, query.shouldRetry(err, nil))
+	require.True(t, mirrorNodeShouldRetry(err, nil))
 }
 
 func TestUnitFeeEstimateResponseFromREST(t *testing.T) {

--- a/sdk/mirror_node_contract_query.go
+++ b/sdk/mirror_node_contract_query.go
@@ -1,7 +1,6 @@
 package hiero
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -215,9 +214,12 @@ func (mirrorNodeContractQuery *mirrorNodeContractQuery) performContractCallToMir
 
 	mirrorUrl = fmt.Sprintf("%s/contracts/call", mirrorUrl)
 
-	resp, err := http.Post(mirrorUrl, "application/json", bytes.NewBuffer([]byte(jsonPayload))) // #nosec
+	resp, err := mirrorNodePostWithRetry(client, mirrorUrl, "application/json", []byte(jsonPayload), mirrorNodeDefaultMaxAttempts, mirrorNodeDefaultTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	if resp == nil {
+		return nil, errors.New("received nil response from Mirror Node")
 	}
 
 	defer resp.Body.Close()

--- a/sdk/mirror_node_contract_query_unit_test.go
+++ b/sdk/mirror_node_contract_query_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,6 +204,107 @@ func stringPtr(s string) *string {
 
 func int64Ptr(i int64) *int64 {
 	return &i
+}
+
+func TestUnitMirrorNodeContractQueryRetriesTransientErrors(t *testing.T) {
+	// Note: Not running in parallel since we modify global http.DefaultTransport
+	const domain = "retrytransient.example.com:443"
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Transient 5xx on the first two attempts, then succeed (issue #1752).
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{"result": "0x5208"}))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain(domain, server.URL)
+	defer cleanup()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetMirrorNetwork([]string{domain})
+
+	gas, err := NewMirrorNodeContractEstimateGasQuery().
+		SetContractEvmAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").
+		SetFunction("testFunction", NewContractFunctionParameters().AddString("test")).
+		Execute(client)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21000), gas)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts), "transient failures should be retried until success")
+}
+
+func TestUnitMirrorNodeContractQueryRetriesTransportErrors(t *testing.T) {
+	// Note: Not running in parallel since we modify global http.DefaultTransport
+	const domain = "retrytransport.example.com:443"
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drop the connection on the first two attempts, surfacing as a transport error
+		// (EOF) — the failure mode from issue #1752 — then succeed on the third.
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			hj, ok := w.(http.Hijacker)
+			require.True(t, ok, "test server must support connection hijacking")
+			conn, _, hijackErr := hj.Hijack()
+			require.NoError(t, hijackErr)
+			_ = conn.Close()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]interface{}{"result": "0x5208"}))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain(domain, server.URL)
+	defer cleanup()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetMirrorNetwork([]string{domain})
+
+	gas, err := NewMirrorNodeContractEstimateGasQuery().
+		SetContractEvmAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").
+		SetFunction("testFunction", NewContractFunctionParameters().AddString("test")).
+		Execute(client)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21000), gas)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts), "transport errors should be retried until success")
+}
+
+func TestUnitMirrorNodeContractQueryDoesNotRetryNon200(t *testing.T) {
+	// Note: Not running in parallel since we modify global http.DefaultTransport
+	const domain = "no4xxretry.example.com:443"
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// A 4xx (e.g. gas limit too low) is a genuine result, not a transient failure,
+		// so it must be returned without retrying.
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"_status":{"messages":[{"message":"gas limit too low"}]}}`))
+	}))
+	defer server.Close()
+
+	cleanup := SetupMockTransportForDomain(domain, server.URL)
+	defer cleanup()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+	client.SetLedgerID(*NewLedgerIDTestnet())
+	client.SetMirrorNetwork([]string{domain})
+
+	_, err = NewMirrorNodeContractEstimateGasQuery().
+		SetContractEvmAddress("0x742d35Cc6634C0532925a3b844Bc454e4438f44e").
+		SetFunction("testFunction", NewContractFunctionParameters().AddString("test")).
+		Execute(client)
+	require.ErrorContains(t, err, "received non-200 response from Mirror Node")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "non-200 responses must not be retried")
 }
 
 func TestUnitMirrorNodeContractQueryWithDifferentPorts(t *testing.T) {

--- a/sdk/mirror_node_rest_helpers.go
+++ b/sdk/mirror_node_rest_helpers.go
@@ -1,0 +1,93 @@
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"bytes"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// Attempts before giving up on transient transport failures.
+	mirrorNodeDefaultMaxAttempts = 3
+	// Per-request timeout for a mirror node call.
+	mirrorNodeDefaultTimeout = 30 * time.Second
+)
+
+// mirrorNodePostWithRetry POSTs to a mirror node REST/JSON-RPC endpoint, retrying transport
+// failures and 5xx/429 responses with exponential backoff. Genuine 4xx responses are the
+// intended result of the call and are not retried.
+//
+// It returns the raw result of the final attempt so callers can format their own error:
+//   - success: non-nil response, StatusCode 200, Body open;
+//   - non-retryable/exhausted non-200: response with Body open and a nil error;
+//   - transport failure: nil response and the transport error.
+//
+// The caller must close a non-nil Body. A timeout of 0 disables the per-request timeout.
+func mirrorNodePostWithRetry(client *Client, url, contentType string, body []byte, maxAttempts uint64, timeout time.Duration) (*http.Response, error) {
+	if maxAttempts == 0 {
+		return nil, errors.New("maxAttempts must be at least 1")
+	}
+
+	httpClient := &http.Client{Timeout: timeout}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := uint64(0); attempt < maxAttempts; attempt++ {
+		resp, err = httpClient.Post(url, contentType, bytes.NewBuffer(body)) // #nosec
+
+		// Success or a non-retryable outcome is terminal; return the raw result.
+		if (err == nil && resp != nil && resp.StatusCode == http.StatusOK) || !mirrorNodeShouldRetry(err, resp) {
+			return resp, err
+		}
+
+		// Retryable, but no point backing off after the last attempt.
+		if attempt == maxAttempts-1 {
+			return resp, err
+		}
+
+		// Discard the retryable response body before the next attempt.
+		if resp != nil {
+			resp.Body.Close()
+		}
+
+		// Exponential backoff capped at 8s; exp is clamped to avoid shift overflow.
+		exp := min(attempt, uint64(5))
+		delayMs := 250.0 * float64(uint64(1)<<exp)
+		if delayMs > 8000 {
+			delayMs = 8000
+		}
+
+		select {
+		case <-client.networkUpdateContext.Done():
+			return nil, client.networkUpdateContext.Err()
+		case <-time.After(time.Duration(delayMs) * time.Millisecond):
+		}
+	}
+
+	// Unreachable: the final iteration always returns.
+	return resp, err
+}
+
+// mirrorNodeShouldRetry reports whether a failed POST should be retried: transport errors
+// and 5xx/429 are transient; 4xx responses are genuine results the caller expects.
+func mirrorNodeShouldRetry(err error, resp *http.Response) bool {
+	if err == nil && resp != nil {
+		if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return false
+		}
+	}
+
+	if err == nil {
+		return false
+	}
+
+	return true
+}

--- a/sdk/mirror_node_rest_helpers_unit_test.go
+++ b/sdk/mirror_node_rest_helpers_unit_test.go
@@ -1,0 +1,124 @@
+//go:build all || unit
+
+package hiero
+
+// SPDX-License-Identifier: Apache-2.0
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitMirrorNodePostWithRetryRejectsZeroMaxAttempts(t *testing.T) {
+	// Note: Not running in parallel since sibling tests modify global http.DefaultTransport.
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	resp, err := mirrorNodePostWithRetry(client, "https://example.com", "application/json", []byte("{}"), 0, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maxAttempts must be at least 1")
+	assert.Nil(t, resp)
+}
+
+func TestUnitMirrorNodePostWithRetryReturnsLastResponseAfterExhaustion(t *testing.T) {
+	// Note: Not running in parallel since sibling tests modify global http.DefaultTransport.
+	const maxAttempts = uint64(2)
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// Always transient: the helper retries until attempts are exhausted, then
+		// returns the final (still non-200) response with a nil error so the caller
+		// can format its own error.
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	resp, err := mirrorNodePostWithRetry(client, server.URL, "application/json", []byte("{}"), maxAttempts, time.Second)
+	require.NoError(t, err, "an exhausted retryable response is returned without a transport error")
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, int32(maxAttempts), atomic.LoadInt32(&attempts), "every attempt should be used before giving up")
+}
+
+func TestUnitMirrorNodePostWithRetryRetriesOnTooManyRequests(t *testing.T) {
+	// Note: Not running in parallel since sibling tests modify global http.DefaultTransport.
+	const maxAttempts = uint64(2)
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// 429 is transient: the helper must retry it (unlike a genuine 4xx) and, once
+		// attempts are exhausted, return the final 429 response with a nil error.
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	resp, err := mirrorNodePostWithRetry(client, server.URL, "application/json", []byte("{}"), maxAttempts, time.Second)
+	require.NoError(t, err, "an exhausted retryable response is returned without a transport error")
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(maxAttempts), atomic.LoadInt32(&attempts), "429 should be retried up to maxAttempts")
+}
+
+func TestUnitMirrorNodePostWithRetryReturnsTransportErrorAfterExhaustion(t *testing.T) {
+	// Note: Not running in parallel since sibling tests modify global http.DefaultTransport.
+	const maxAttempts = uint64(2)
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// Drop the connection every time, surfacing as a transport error (EOF) on
+		// every attempt so the helper exhausts its retries and returns the error.
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok, "test server must support connection hijacking")
+		conn, _, hijackErr := hj.Hijack()
+		require.NoError(t, hijackErr)
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	resp, err := mirrorNodePostWithRetry(client, server.URL, "application/json", []byte("{}"), maxAttempts, time.Second)
+	require.Error(t, err, "a transport failure on every attempt is surfaced as an error")
+	assert.Nil(t, resp)
+	assert.Equal(t, int32(maxAttempts), atomic.LoadInt32(&attempts), "every attempt should be used before giving up")
+}
+
+func TestUnitMirrorNodePostWithRetryStopsOnNetworkUpdateCancellation(t *testing.T) {
+	// Note: Not running in parallel since sibling tests modify global http.DefaultTransport.
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	// Cancelling the network-update context aborts the backoff wait between attempts.
+	client.cancelNetworkUpdate()
+
+	resp, err := mirrorNodePostWithRetry(client, server.URL, "application/json", []byte("{}"), 3, time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.networkUpdateContext.Err())
+	assert.Nil(t, resp)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "backoff cancellation should stop before a second attempt")
+}


### PR DESCRIPTION
**Description:**

Fix flaky mirror-node contract-query e2e tests that intermittently failed with an EOF transport error when the local JSON-RPC relay dropped connections under load. performContractCallToMirrorNode used a bare http.Post with no timeout or retry, so a transient connection drop surfaced as an unhandled transport error instead of being retried or returning the intended HTTP result.

Add a shared mirror-node POST helper with bounded retries, backoff, and an explicit timeout, and route the contract query and fee-estimate query through it.

- Add mirrorNodePostWithRetry and mirrorNodeShouldRetry in sdk/mirror_node_rest_helpers.go — retries transport errors and 5xx/429 with exponential backoff (capped at 8s, default 3 attempts), uses an http.Client with an explicit timeout (30s default), and does not retry genuine 4xx responses
- Route performContractCallToMirrorNode through the helper and return a clear error on a nil response
- Refactor FeeEstimateQuery.callGetFeeEstimate to reuse the helper and remove its duplicated inline retry loop
- Remove the now-unused FeeEstimateQuery.shouldRetry wrapper and repoint its unit test at mirrorNodeShouldRetry
- Add unit tests covering transient 5xx retry, transport-error (EOF) retry, and no-retry on 4xx

**Related issue(s):**

Fixes #1752
Fixes #1753

**Notes for reviewer:**

Both issues share the same root cause (the bare http.Post in performContractCallToMirrorNode), so this single change closes both. 4xx responses are intentionally not retried, preserving the "received non-200 response from Mirror Node" assertion in TestMirrorNodeContractQueryFailWhenGasLimitIsLow (#1752), while transient EOF/5xx are now retried, fixing the TestUint8*/TestUint16* success-path flakiness (#1753).

**Checklist**

- [x] Unit tests
- [x]  Integration tests