### PR TITLE
feat: auto-chunk oversized FileUpdate contents via ExecuteAll

### DIFF
--- a/examples/file_update_chunked/main.go
+++ b/examples/file_update_chunked/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	hiero "github.com/hiero-ledger/hiero-sdk-go/v2/sdk"
+)
+
+func main() {
+	var client *hiero.Client
+	var err error
+
+	// Retrieving network type from environment variable HEDERA_NETWORK
+	client, err = hiero.ClientForName(os.Getenv("HEDERA_NETWORK"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error creating client", err))
+	}
+
+	// Retrieving operator ID from environment variable OPERATOR_ID
+	operatorAccountID, err := hiero.AccountIDFromString(os.Getenv("OPERATOR_ID"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to AccountID", err))
+	}
+
+	// Retrieving operator key from environment variable OPERATOR_KEY
+	operatorKey, err := hiero.PrivateKeyFromString(os.Getenv("OPERATOR_KEY"))
+	if err != nil {
+		panic(fmt.Sprintf("%v : error converting string to PrivateKey", err))
+	}
+
+	// Setting the client operator ID and key
+	client.SetOperator(operatorAccountID, operatorKey)
+
+	// Create a small file to start with
+	newFileResponse, err := hiero.NewFileCreateTransaction().
+		SetKeys(client.GetOperatorPublicKey()).
+		SetContents([]byte("Hello from hiero.")).
+		SetMemo("go file update chunked example").
+		SetMaxTransactionFee(hiero.NewHbar(2)).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error creating file", err))
+	}
+
+	receipt, err := newFileResponse.GetReceipt(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error retrieving file creation receipt", err))
+	}
+	fileID := *receipt.FileID
+
+	// Contents larger than the ~6 KiB single-transaction limit. ExecuteAll transparently overwrites
+	// the file with the first chunk and appends the remainder, so this one call replaces the whole
+	// file with content that could never fit in a single FileUpdateTransaction.
+	//
+	// Note: each chunk is a separate network transaction charged its own fee, and each is signed
+	// with the operator only. If the file needs additional keys, or you want explicit control of the
+	// FileID / per-chunk fees / error recovery, use the manual FileUpdate + FileAppend two-step.
+	bigContents := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 400)
+
+	responses, err := hiero.NewFileUpdateTransaction().
+		SetNodeAccountIDs([]hiero.AccountID{newFileResponse.NodeID}).
+		SetFileID(fileID).
+		SetContents([]byte(bigContents)).
+		SetMaxTransactionFee(hiero.NewHbar(5)).
+		ExecuteAll(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing chunked file update", err))
+	}
+
+	fmt.Printf("Chunked update ran as %d transactions (1 update + %d appends)\n", len(responses), len(responses)-1)
+
+	// Confirm the whole file was replaced
+	info, err := hiero.NewFileInfoQuery().
+		SetNodeAccountIDs([]hiero.AccountID{newFileResponse.NodeID}).
+		SetFileID(fileID).
+		Execute(client)
+	if err != nil {
+		panic(fmt.Sprintf("%v : error executing file info query", err))
+	}
+
+	fmt.Printf("Uploaded %d bytes; file size according to FileInfoQuery: %d\n", len(bigContents), info.Size)
+}

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -40,6 +40,10 @@ var errEvmAddressIsNotCorrectSize = errors.New("EVM address is not the correct s
 var errInvalidChunkSize = errors.New("chunk size must be greater than 0")
 var errPublicKeyHasNotSigned = errors.New("the public key has not signed this transaction")
 
+// FileUpdateTransaction auto-chunking (ExecuteAll) errors
+var errFileUpdateChunkingRequiresFileID = errors.New("FileUpdateTransaction requires a FileID to update contents larger than the chunk size")
+var errFileUpdateChunkingRequiresUnfrozen = errors.New("FileUpdateTransaction with contents larger than the chunk size must not be frozen before ExecuteAll")
+
 // Endpoint validation errors
 var errEndpointMustHaveAddressOrDomainName = errors.New("endpoint must have either address or domain name")
 var errEndpointCannotHaveBothAddressAndDomainName = errors.New("endpoint must have either address or domain name, but not both")

--- a/sdk/file_update_transaction.go
+++ b/sdk/file_update_transaction.go
@@ -24,6 +24,8 @@ type FileUpdateTransaction struct {
 	expirationTime *time.Time
 	contents       []byte
 	memo           string
+	maxChunks      uint64
+	chunkSize      int
 }
 
 // NewFileUpdateTransaction creates a FileUpdateTransaction which modifies the metadata and/or contents of a file.
@@ -33,7 +35,10 @@ type FileUpdateTransaction struct {
 // additional KeyList or ThresholdKey then M-of-M secondary KeyList or ThresholdKey signing
 // requirements must be meet
 func NewFileUpdateTransaction() *FileUpdateTransaction {
-	tx := &FileUpdateTransaction{}
+	tx := &FileUpdateTransaction{
+		maxChunks: 20,
+		chunkSize: 2048,
+	}
 	tx.Transaction = _NewTransaction(tx)
 
 	return tx
@@ -57,6 +62,8 @@ func _FileUpdateTransactionFromProtobuf(tx Transaction[*FileUpdateTransaction], 
 		expirationTime: expiration,
 		contents:       pb.GetFileUpdate().GetContents(),
 		memo:           pb.GetFileUpdate().GetMemo().Value,
+		maxChunks:      20,
+		chunkSize:      2048,
 	}
 
 	tx.childTransaction = &fileUpdateTransaction
@@ -130,6 +137,33 @@ func (tx *FileUpdateTransaction) GetContents() []byte {
 	return tx.contents
 }
 
+// SetMaxChunkSize sets the maximum size of each chunk used by ExecuteAll when the contents are
+// larger than a single transaction can hold. Defaults to 2048 bytes, matching FileAppendTransaction.
+func (tx *FileUpdateTransaction) SetMaxChunkSize(size int) *FileUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.chunkSize = size
+	return tx
+}
+
+// GetMaxChunkSize returns the maximum size of each chunk used by ExecuteAll.
+func (tx *FileUpdateTransaction) GetMaxChunkSize() int {
+	return tx.chunkSize
+}
+
+// SetMaxChunks sets the maximum number of chunks ExecuteAll is allowed to split the contents into.
+// Defaults to 20, matching FileAppendTransaction. ExecuteAll returns ErrMaxChunksExceeded if the
+// contents require more chunks than this.
+func (tx *FileUpdateTransaction) SetMaxChunks(size uint64) *FileUpdateTransaction {
+	tx._RequireNotFrozen()
+	tx.maxChunks = size
+	return tx
+}
+
+// GetMaxChunks returns the maximum number of chunks ExecuteAll is allowed to split the contents into.
+func (tx *FileUpdateTransaction) GetMaxChunks() uint64 {
+	return tx.maxChunks
+}
+
 // SetFileMemo Sets the new memo to be associated with the file (UTF-8 encoding max 100 bytes)
 func (tx *FileUpdateTransaction) SetFileMemo(memo string) *FileUpdateTransaction {
 	tx._RequireNotFrozen()
@@ -147,6 +181,100 @@ func (tx *FileUpdateTransaction) GeFileMemo() string {
 
 func (tx *FileUpdateTransaction) GetFileMemo() string {
 	return tx.memo
+}
+
+// ExecuteAll updates the file, transparently splitting contents larger than a single transaction
+// can hold. When the contents fit in one chunk it behaves like Execute and returns a single-element
+// slice; otherwise the first chunk overwrites the file via the FileUpdate and the remainder is
+// appended with a FileAppendTransaction, so a file larger than the ~6 KiB single-transaction limit
+// can be updated in one call. The returned slice holds the FileUpdate response followed by one
+// response per append chunk.
+//
+// Each sub-transaction is charged its own fee and is signed with the operator only. If the file
+// requires additional keys, or you need explicit control of the FileID, per-transaction fees, error
+// recovery between chunks, or scheduling, use the manual FileUpdateTransaction +
+// FileAppendTransaction two-step instead. Execute keeps its single-transaction semantics and still
+// returns TRANSACTION_OVERSIZE for oversized contents.
+func (tx *FileUpdateTransaction) ExecuteAll(client *Client) ([]TransactionResponse, error) {
+	if client == nil || client.operator == nil {
+		return nil, errNoClientProvided
+	}
+	if tx.freezeError != nil {
+		return nil, tx.freezeError
+	}
+
+	chunkSize := tx.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = 2048
+	}
+
+	chunks := uint64((len(tx.contents) + chunkSize - 1) / chunkSize)
+	if chunks == 0 {
+		chunks = 1
+	}
+	if chunks > tx.maxChunks {
+		return nil, ErrMaxChunksExceeded{Chunks: chunks, MaxChunks: tx.maxChunks}
+	}
+
+	// Fits in a single transaction: behave exactly like Execute.
+	if chunks <= 1 {
+		resp, err := tx.Execute(client)
+		return []TransactionResponse{resp}, err
+	}
+
+	// Chunking rebuilds the bodies and appends by FileID, so the transaction must be unfrozen and
+	// carry a FileID.
+	if tx.IsFrozen() {
+		return nil, errFileUpdateChunkingRequiresUnfrozen
+	}
+	if tx.fileID == nil {
+		return nil, errFileUpdateChunkingRequiresFileID
+	}
+
+	fullContents := tx.contents
+	firstChunkEnd := min(chunkSize, len(fullContents))
+
+	// The first chunk overwrites the file's contents via the update itself; wait for its receipt
+	// before appending the rest to preserve ordering.
+	tx.SetContents(fullContents[:firstChunkEnd])
+	updateResponse, err := tx.Execute(client)
+	if err != nil {
+		return []TransactionResponse{updateResponse}, err
+	}
+	if _, err := updateResponse.SetValidateStatus(true).GetReceipt(client); err != nil {
+		return []TransactionResponse{updateResponse}, err
+	}
+
+	appendTx := NewFileAppendTransaction().
+		SetFileID(*tx.fileID).
+		SetContents(fullContents[firstChunkEnd:]).
+		SetMaxChunkSize(chunkSize).
+		SetMaxChunks(tx.maxChunks)
+	if nodeAccountIDs := tx.GetNodeAccountIDs(); len(nodeAccountIDs) > 0 {
+		appendTx.SetNodeAccountIDs(nodeAccountIDs)
+	}
+
+	appendResponses, err := appendTx.ExecuteAll(client)
+	responses := append([]TransactionResponse{updateResponse}, appendResponses...)
+	return responses, err
+}
+
+// Schedule creates a ScheduleCreateTransaction for this FileUpdateTransaction. Chunked contents
+// (more than one chunk) cannot be scheduled, mirroring FileAppendTransaction.Schedule.
+func (tx *FileUpdateTransaction) Schedule() (*ScheduleCreateTransaction, error) {
+	chunkSize := tx.chunkSize
+	if chunkSize <= 0 {
+		chunkSize = 2048
+	}
+	chunks := uint64((len(tx.contents) + chunkSize - 1) / chunkSize)
+	if chunks > 1 {
+		return &ScheduleCreateTransaction{}, ErrMaxChunksExceeded{
+			Chunks:    chunks,
+			MaxChunks: 1,
+		}
+	}
+
+	return tx.Transaction.Schedule()
 }
 
 // ----------- Overridden functions ----------------

--- a/sdk/file_update_transaction_e2e_test.go
+++ b/sdk/file_update_transaction_e2e_test.go
@@ -5,6 +5,8 @@ package hiero
 // SPDX-License-Identifier: Apache-2.0
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,5 +100,96 @@ func TestIntegrationFileUpdateTransactionNoFileID(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+}
+
+// FileUpdate content auto-chunking via ExecuteAll
+
+func TestIntegrationFileUpdateTransactionExecuteAllChunked(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	resp, err := NewFileCreateTransaction().
+		SetKeys(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetContents([]byte("initial")).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	fileID := *receipt.FileID
+
+	var builder bytes.Buffer
+	for i := 0; builder.Len() < 8192; i++ {
+		fmt.Fprintf(&builder, "%d ", i)
+	}
+	newContents := builder.Bytes()[:8192]
+
+	responses, err := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetContents(newContents).
+		ExecuteAll(env.Client)
+	require.NoError(t, err)
+	require.Len(t, responses, 4, "8 KiB / 2048 = 4 chunks (1 update + 3 appends)")
+
+	contents, err := NewFileContentsQuery().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+	require.Equal(t, newContents, contents)
+
+	// Cross-check the reported size independently of the contents query.
+	info, err := NewFileInfoQuery().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(newContents)), info.Size)
+}
+
+func TestIntegrationFileUpdateTransactionExecuteAllSingleChunk(t *testing.T) {
+	t.Parallel()
+	env := NewIntegrationTestEnv(t)
+	defer CloseIntegrationTestEnv(env, nil)
+
+	resp, err := NewFileCreateTransaction().
+		SetKeys(env.Client.GetOperatorPublicKey()).
+		SetNodeAccountIDs(env.NodeAccountIDs).
+		SetContents([]byte("initial")).
+		Execute(env.Client)
+	require.NoError(t, err)
+
+	receipt, err := resp.SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+	fileID := *receipt.FileID
+
+	newContents := []byte("small enough for one transaction")
+
+	responses, err := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		SetContents(newContents).
+		ExecuteAll(env.Client)
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+
+	_, err = responses[0].SetValidateStatus(true).GetReceipt(env.Client)
+	require.NoError(t, err)
+
+	contents, err := NewFileContentsQuery().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
+	require.NoError(t, err)
+	assert.Equal(t, newContents, contents)
+
+	_, err = NewFileDeleteTransaction().
+		SetFileID(fileID).
+		SetNodeAccountIDs([]AccountID{resp.NodeID}).
+		Execute(env.Client)
 	require.NoError(t, err)
 }

--- a/sdk/file_update_transaction_unit_test.go
+++ b/sdk/file_update_transaction_unit_test.go
@@ -319,3 +319,152 @@ func TestUnitFileUpdateTransactionFromToBytes(t *testing.T) {
 
 	assert.Equal(t, tx.buildProtoBody(), txFromBytes.(FileUpdateTransaction).buildProtoBody())
 }
+
+// FileUpdate content auto-chunking via ExecuteAll
+
+func TestUnitFileUpdateTransactionChunkDefaults(t *testing.T) {
+	t.Parallel()
+
+	tx := NewFileUpdateTransaction()
+
+	assert.Equal(t, uint64(20), tx.GetMaxChunks(), "default max chunks should match FileAppendTransaction")
+	assert.Equal(t, 2048, tx.GetMaxChunkSize(), "default chunk size should match FileAppendTransaction")
+}
+
+func TestUnitFileUpdateTransactionChunkSettersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tx := NewFileUpdateTransaction().
+		SetMaxChunks(7).
+		SetMaxChunkSize(512)
+
+	assert.Equal(t, uint64(7), tx.GetMaxChunks())
+	assert.Equal(t, 512, tx.GetMaxChunkSize())
+}
+
+func TestUnitFileUpdateTransactionExecuteAllChunkMath(t *testing.T) {
+	t.Parallel()
+
+	fileID := FileID{File: 3}
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	cases := []struct {
+		size   int
+		chunks uint64
+	}{
+		{size: 101, chunks: 2},
+		{size: 200, chunks: 2},
+		{size: 201, chunks: 3},
+		{size: 1000, chunks: 10},
+	}
+
+	for _, c := range cases {
+		tx := NewFileUpdateTransaction().
+			SetFileID(fileID).
+			SetContents(make([]byte, c.size)).
+			SetMaxChunkSize(100).
+			SetMaxChunks(1)
+
+		_, err := tx.ExecuteAll(client)
+
+		var chunkErr ErrMaxChunksExceeded
+		require.ErrorAs(t, err, &chunkErr, "size %d should exceed max chunks", c.size)
+		assert.Equal(t, c.chunks, chunkErr.Chunks, "wrong chunk count for size %d", c.size)
+		assert.Equal(t, uint64(1), chunkErr.MaxChunks)
+	}
+}
+
+func TestUnitFileUpdateTransactionChunkBoundary(t *testing.T) {
+	t.Parallel()
+
+	fileID := FileID{File: 3}
+
+	atBoundary := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetContents(make([]byte, 100)).
+		SetMaxChunkSize(100)
+	_, err := atBoundary.Schedule()
+	require.NoError(t, err, "exactly chunkSize must be a single chunk")
+
+	overBoundary := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetContents(make([]byte, 101)).
+		SetMaxChunkSize(100)
+	_, err = overBoundary.Schedule()
+	var chunkErr ErrMaxChunksExceeded
+	require.ErrorAs(t, err, &chunkErr, "chunkSize+1 must need two chunks")
+	assert.Equal(t, uint64(2), chunkErr.Chunks)
+}
+
+func TestUnitFileUpdateTransactionExecuteAllRequiresFileID(t *testing.T) {
+	t.Parallel()
+
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	// Multi-chunk content with no FileID: chunking cannot append without the file id.
+	tx := NewFileUpdateTransaction().
+		SetContents(make([]byte, 300)).
+		SetMaxChunkSize(100).
+		SetMaxChunks(20)
+
+	_, err = tx.ExecuteAll(client)
+	require.ErrorIs(t, err, errFileUpdateChunkingRequiresFileID)
+}
+
+func TestUnitFileUpdateTransactionExecuteAllRequiresUnfrozen(t *testing.T) {
+	t.Parallel()
+
+	fileID := FileID{File: 3}
+	client, err := _NewMockClient()
+	require.NoError(t, err)
+
+	tx := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetContents(make([]byte, 300)).
+		SetMaxChunkSize(100).
+		SetMaxChunks(20)
+
+	_, err = tx.FreezeWith(client)
+	require.NoError(t, err)
+
+	_, err = tx.ExecuteAll(client)
+	require.ErrorIs(t, err, errFileUpdateChunkingRequiresUnfrozen)
+}
+
+func TestUnitFileUpdateTransactionExecuteAllNilClient(t *testing.T) {
+	t.Parallel()
+
+	tx := NewFileUpdateTransaction().
+		SetFileID(FileID{File: 3}).
+		SetContents(make([]byte, 300))
+
+	_, err := tx.ExecuteAll(nil)
+	require.ErrorIs(t, err, errNoClientProvided)
+}
+
+func TestUnitFileUpdateTransactionScheduleChunkedRejected(t *testing.T) {
+	t.Parallel()
+
+	fileID := FileID{File: 3}
+
+	// A single chunk of contents can still be scheduled.
+	single := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetContents(make([]byte, 100)).
+		SetMaxChunkSize(100)
+	_, err := single.Schedule()
+	require.NoError(t, err)
+
+	// Contents spanning more than one chunk cannot be scheduled.
+	chunked := NewFileUpdateTransaction().
+		SetFileID(fileID).
+		SetContents(make([]byte, 101)).
+		SetMaxChunkSize(100)
+	_, err = chunked.Schedule()
+	var chunkErr ErrMaxChunksExceeded
+	require.ErrorAs(t, err, &chunkErr)
+	assert.Equal(t, uint64(2), chunkErr.Chunks)
+	assert.Equal(t, uint64(1), chunkErr.MaxChunks)
+}


### PR DESCRIPTION
**Description**:

Add opt-in auto-chunking to `FileUpdateTransaction`, mirroring `FileAppendTransaction`, so files larger than a single transaction can be updated without hand-writing the `FileUpdate` + `FileAppend` two-step. `SetContents` previously sent one transaction, so contents over the ~6 KiB single-transaction limit were rejected with `TRANSACTION_OVERSIZE`.

* Add `FileUpdateTransaction.ExecuteAll`, which overwrites the file with the first chunk and appends the remainder, so contents over the single-transaction limit can be updated in one call; it returns the `FileUpdate` response followed by one response per append chunk
* Add `SetMaxChunks`/`GetMaxChunks` and `SetMaxChunkSize`/`GetMaxChunkSize` (defaults 20 / 2048, matching `FileAppendTransaction`)
* Guard `Schedule()` so chunked contents (more than one chunk) return `ErrMaxChunksExceeded`, mirroring `FileAppendTransaction.Schedule`
* Add `errFileUpdateChunkingRequiresFileID` / `errFileUpdateChunkingRequiresUnfrozen` sentinels for the chunking preconditions
* Keep `Execute` single-transaction semantics unchanged (still returns `TRANSACTION_OVERSIZE` for oversized contents)
* Extend the existing `file_update_transaction_unit_test.go` / `_e2e_test.go` with chunking tests (chunk-count math, boundary, guards, scheduling; >6 KiB round-trip verified via `FileContentsQuery` and `FileInfoQuery`, plus a single-chunk case), and add an `examples/file_update_chunked` example

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
