### PR TITLE
fix: honor payment tx id if present

### DIFF
--- a/sdk/contract_info_query_unit_test.go
+++ b/sdk/contract_info_query_unit_test.go
@@ -113,7 +113,6 @@ func TestUnitContractInfoQueryMock(t *testing.T) {
 }
 
 func TestUnitContractInfoQueryGetTransactionIDMock(t *testing.T) {
-	t.Skip("Skipping test as it is currently broken with the addition of generating new payment transactions for queries")
 	t.Parallel()
 
 	transactionID := TransactionIDGenerate(AccountID{Account: 123})

--- a/sdk/query.go
+++ b/sdk/query.go
@@ -262,7 +262,14 @@ func (q *Query) generatePayments(client *Client, cost Hbar) (*services.Transacti
 	var tx *services.Transaction
 	var err error
 	nodeID := q.nodeAccountIDs._GetCurrent()
-	txnID := TransactionIDGenerate(client.operator.accountID)
+
+	var txnID TransactionID
+	if !q.paymentTransactionIDs._IsEmpty() {
+		txnID = q.paymentTransactionIDs._GetCurrent().(TransactionID)
+	} else {
+		txnID = TransactionIDGenerate(client.operator.accountID)
+	}
+
 	tx, err = _QueryMakePaymentTransaction(
 		txnID,
 		nodeID.(AccountID),


### PR DESCRIPTION
**Description:**

Honor SetPaymentTransactionID when generating query payments so an explicitly-set payment transaction ID is used instead of being silently replaced by a freshly generated one.

- Update Query.generatePayments to use the payment transaction ID set via SetPaymentTransactionID when present, falling back to auto-generation otherwise
- Re-enable the previously skipped TestUnitContractInfoQueryGetTransactionIDMock

**Related issue(s):**

Fixes #1782

**Notes for reviewer:**

The setter stored the ID in q.paymentTransactionIDs, but generatePayments always called TransactionIDGenerate(...) and never read it back, so the setter was a no-op across all query types. The fix reads the current ID from the slice when it is non-empty.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)