### PR TITLE
chore: update solo version to 0.69.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ env:
     NODE_VERSION: "22"
     HIERO_VERSION: v0.73.0
     MIRROR_NODE_VERSION: v0.153.0
-    SOLO_VERSION: v0.69.0
+    SOLO_VERSION: v0.69.1
     HEDERA_NETWORK: localhost
 
 jobs:


### PR DESCRIPTION
## Summary
- Bumps the pinned Solo CLI version used in CI from `v0.69.0` to `v0.69.1` (`SOLO_VERSION` workflow-level env var in `build.yml`, referenced by all three jobs that deploy Solo).